### PR TITLE
Add beforeunload warning for unsaved editor changes

### DIFF
--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -264,6 +264,21 @@ var initMarkdownEditor = (function() {
       });
     }
 
+    // ── Warn before leaving with unsaved changes ────────────
+    var initialContent = editor.value();
+    window.addEventListener('beforeunload', function(e) {
+      if (editor.value() !== initialContent) {
+        e.preventDefault();
+      }
+    });
+    // Disable the warning when the form is actually submitted
+    var form = document.getElementById('markdown-editor').closest('form');
+    if (form) {
+      form.addEventListener('submit', function() {
+        initialContent = editor.value();
+      });
+    }
+
     return editor;
   };
 })();


### PR DESCRIPTION
## Fixes
N/A — feature request

## Summary
Adds a browser `beforeunload` warning when a user tries to navigate away from a page with unsaved markdown editor changes. Compares current editor content against the initial value loaded on page open. Disables the warning on form submit so saving doesn't trigger a false positive. Applies to all edit forms (pages, directories, proposals) since they all use `initMarkdownEditor`.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-cronjob-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)