### PR TITLE
Add TEST_DB_NAME for parallel test isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,16 @@ docker exec wiki-django python -m pytest wiki/pages/tests.py::TestClassName -v
 docker exec wiki-django python -m pytest wiki/pages/tests.py::TestClassName::test_method -v
 ```
 
+### Parallel Test Runs
+
+To run tests in multiple terminals simultaneously, give each a unique test database name via `TEST_DB_NAME`. Use `$$` (the host shell's PID) to automatically get a unique suffix per terminal:
+
+```bash
+docker exec -e TEST_DB_NAME=test_wiki_$$ wiki-django python -m pytest wiki/pages/ -v
+```
+
+This works because each terminal has a stable, unique shell PID. Without `TEST_DB_NAME`, concurrent runs will collide on the default `test_wiki` database.
+
 ### Testing Guidelines
 
 - Use pytest with Django's test client (not unittest-style TestCase)

--- a/wiki/settings/django.py
+++ b/wiki/settings/django.py
@@ -32,6 +32,9 @@ DATABASES = {
         "OPTIONS": {
             "sslmode": env("DB_SSL_MODE", default="require"),
         },
+        "TEST": {
+            "NAME": env("TEST_DB_NAME", default="test_wiki"),
+        },
     },
 }
 


### PR DESCRIPTION
## Fixes

No issue — developer experience improvement.

## Summary

Adds a `TEST_DB_NAME` env var to `DATABASES["default"]["TEST"]` so each pytest process can target its own test database, enabling parallel test runs across multiple terminals. Uses `$$` (host shell PID) for automatic per-terminal uniqueness:

```bash
docker exec -e TEST_DB_NAME=test_wiki_$$ wiki-django python -m pytest wiki/pages/ -v
```

Also documents the pattern in CLAUDE.md.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)