### PR TITLE
Fix CSP blocking static assets from S3 storage domain

### DIFF
--- a/wiki/settings/project/security.py
+++ b/wiki/settings/project/security.py
@@ -75,6 +75,9 @@ else:
 
     s3 = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["default-src"].append(s3)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["script-src"].append(s3)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["style-src"].append(s3)
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"].append(s3)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["font-src"].append(s3)
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["connect-src"].append(s3)
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = True


### PR DESCRIPTION
## Fixes

Fixes Content-Security-Policy errors blocking JS, CSS, and fonts served from `storage.wiki.free.law`.

## Summary

When `script-src`, `style-src`, and `font-src` are explicitly declared in CSP, browsers do **not** fall back to `default-src`. The S3 storage domain was added to `default-src`, `img-src`, and `connect-src` in the production block, but `script-src`, `style-src`, and `font-src` were left as `'self'` only — so the browser blocked all scripts, stylesheets, and fonts loaded from S3.

Added the S3 domain to `script-src`, `style-src`, and `font-src`.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`