### PR TITLE
Add Plausible analytics

### DIFF
--- a/wiki/assets/templates/base.html
+++ b/wiki/assets/templates/base.html
@@ -50,6 +50,7 @@
   <script src="{% static 'js/alpine-components.js' %}" defer></script>
   <script src="{% static 'js/alpine.min.js' %}" defer></script>
   <script src="{% static 'js/htmx.min.js' %}"></script>
+  <script defer data-domain="wiki.free.law" src="https://plausible.io/js/plausible.js"></script>
   {% block footer_scripts %}{% endblock %}
 </body>
 </html>

--- a/wiki/settings/project/security.py
+++ b/wiki/settings/project/security.py
@@ -26,7 +26,7 @@ CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [SELF],
         # Uses @alpinejs/csp build — no unsafe-eval needed.
-        "script-src": [SELF],
+        "script-src": [SELF, "https://plausible.io/"],
         # Needed for style="" HTML attributes in templates.
         "style-src": [SELF, "'unsafe-inline'"],
         "img-src": [
@@ -35,7 +35,7 @@ CONTENT_SECURITY_POLICY = {
             "data:",
         ],
         "font-src": [SELF],
-        "connect-src": [SELF],
+        "connect-src": [SELF, "https://plausible.io/"],
         "frame-src": ["'none'"],
         "object-src": ["'none'"],
         "base-uri": [SELF],


### PR DESCRIPTION
## Fixes

N/A — new feature.

## Summary

Adds Plausible analytics to the wiki, loading the script on every page. Updates the Content Security Policy to allow `plausible.io` for `script-src` and `connect-src`.

Mirrors how CourtListener does it, but without the 1-in-10 sampling since the wiki has far less traffic.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

1. Standard deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)