### PR TITLE
Fix S3 signed URLs for private file uploads

### DIFF
--- a/wiki/lib/storage.py
+++ b/wiki/lib/storage.py
@@ -9,6 +9,9 @@ class PrivateS3Storage(S3Boto3Storage):
     """S3 storage for private file uploads (wiki page attachments)."""
 
     default_acl = "private"
+    custom_domain = (
+        None  # Override global AWS_S3_CUSTOM_DOMAIN so urls are signed
+    )
     querystring_auth = True
     querystring_expire = 300  # 5-minute signed URLs
 

--- a/wiki/settings/project/security.py
+++ b/wiki/settings/project/security.py
@@ -71,7 +71,10 @@ else:
 
     # SECURITY: In production, allow S3 domain for file serving
     # and force HTTPS for all resources.
-    from ..third_party.aws import AWS_S3_CUSTOM_DOMAIN
+    from ..third_party.aws import (
+        AWS_PRIVATE_STORAGE_BUCKET_NAME,
+        AWS_S3_CUSTOM_DOMAIN,
+    )
 
     s3 = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["default-src"].append(s3)
@@ -80,4 +83,10 @@ else:
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"].append(s3)
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["font-src"].append(s3)
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["connect-src"].append(s3)
+
+    # Private bucket hosts user-uploaded images (served via signed URLs)
+    s3_private = f"https://{AWS_PRIVATE_STORAGE_BUCKET_NAME}.s3.amazonaws.com/"
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"].append(s3_private)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["connect-src"].append(s3_private)
+
     CONTENT_SECURITY_POLICY["DIRECTIVES"]["upgrade-insecure-requests"] = True


### PR DESCRIPTION
## Fixes

Fixes uploaded images returning 403 errors because URLs were unsigned.

## Summary

`PrivateS3Storage` inherited the global `AWS_S3_CUSTOM_DOMAIN` setting (`storage.wiki.free.law`), which caused django-storages to skip URL signing — it uses the custom domain directly instead of generating presigned URLs via the S3 API. Since the bucket is private, these unsigned URLs return 403.

The fix sets `custom_domain = None` on `PrivateS3Storage` so django-storages falls back to boto3 presigned URL generation, which is what `querystring_auth = True` was intended to enable.

Also adds the private bucket's `*.s3.amazonaws.com` domain to CSP `img-src` and `connect-src` so browsers accept the signed URL redirects.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`


🤖 Generated with [Claude Code](https://claude.com/claude-code)