### PR TITLE
Fix noisy postgres healthcheck log spam

### DIFF
--- a/docker/wiki/docker-compose.yml
+++ b/docker/wiki/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_PASSWORD: "postgres"
       POSTGRES_DB: "wiki"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Fixes
No issue — quality of life fix for local dev.

## Summary
The `pg_isready` healthcheck in docker-compose.yml was running without `-U postgres`, so it defaulted to the container's OS user (`root`). Since there's no `root` PostgreSQL role, this produced `FATAL: role "root" does not exist` every 5 seconds in the postgres logs, making them unusable for debugging.

Fix: add `-U postgres` to match the configured `POSTGRES_USER`.

## Deployment

**This PR should:**

- [X] `skip-deploy` (skips everything below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)