### PR TITLE
Auto-recover daemon from DB connection loss

### DIFF
--- a/wiki/pages/management/commands/run_daemon.py
+++ b/wiki/pages/management/commands/run_daemon.py
@@ -8,6 +8,7 @@ import logging
 import signal
 import time
 
+from django import db
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
@@ -74,6 +75,9 @@ class Command(BaseCommand):
             self.stdout.write(f"Finished {name}.")
         except Exception:
             logger.exception("Error running task %s", name)
+            # Discard broken DB connections (e.g. after a postgres
+            # restart) so the next iteration gets a fresh one.
+            db.close_old_connections()
 
     def _handle_signal(self, signum, frame):
         self.stdout.write(f"Received signal {signum}, shutting down...")


### PR DESCRIPTION
## Fixes
No issue — follow-up to #32 (healthcheck fix exposed this).

## Summary
When postgres restarts, the daemon's DB connection goes stale and every subsequent task fails with `OperationalError: the connection is closed`. The existing `except Exception` handler logged the error but didn't discard the broken connection, so the daemon stayed broken until manually restarted.

Adds `db.close_old_connections()` in the error handler so Django discards the stale connection and the next task iteration gets a fresh one automatically.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)