### PR TITLE
Fix multi-line template comment in visibility badge

### DIFF
--- a/wiki/assets/templates/cotton/visibility_badge.html
+++ b/wiki/assets/templates/cotton/visibility_badge.html
@@ -1,6 +1,8 @@
-{# Visibility badge — icon-only for non-public items.
+{% comment %}
+   Visibility badge — icon-only for non-public items.
    Usage: <c-visibility-badge visibility="internal" />
-   Accepts: "public", "internal", "private". Shows nothing for public. #}
+   Accepts: "public", "internal", "private". Shows nothing for public.
+{% endcomment %}
 {% if visibility == "internal" %}
 <span class="inline-flex items-center text-yellow-600 dark:text-yellow-400 align-middle cursor-help" title="FLP Staff" aria-label="FLP Staff">
   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">


### PR DESCRIPTION
## Fixes

Fixes visibility badge comment text leaking into rendered page titles.

## Summary

Django's `{# #}` comment syntax only works on single lines. The multi-line comment in the visibility badge cotton component was being rendered as raw text in page/directory titles. Switches to `{% comment %}{% endcomment %}` which handles multi-line content correctly.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`