### PR TITLE
Require directory edit for pinning; AJAX toggle

### DIFF
--- a/wiki/assets/static-global/js/alpine-components.js
+++ b/wiki/assets/static-global/js/alpine-components.js
@@ -91,6 +91,35 @@ document.addEventListener('alpine:init', () => {
     },
   }))
 
+  // Pin toggle — POST via fetch, swap icon without page reload
+  Alpine.data('pinToggle', () => ({
+    pinned: false,
+    url: '',
+    init() {
+      this.pinned = this.$el.getAttribute('data-pinned') === 'true'
+      this.url = this.$el.getAttribute('data-url')
+    },
+    toggle() {
+      var self = this
+      var hxHeaders = document.body.getAttribute('hx-headers')
+      var csrfToken = hxHeaders ? JSON.parse(hxHeaders)['X-CSRFToken'] : ''
+      fetch(self.url, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': csrfToken,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      }).then(function(resp) {
+        return resp.json()
+      }).then(function(data) {
+        self.pinned = data.is_pinned
+      })
+    },
+    get title() {
+      return this.pinned ? 'Unpin' : 'Pin'
+    },
+  }))
+
   // Search tips toggle
   Alpine.data('searchTips', () => ({
     open: false,

--- a/wiki/directories/templates/directories/detail.html
+++ b/wiki/directories/templates/directories/detail.html
@@ -151,15 +151,30 @@
   </div>
   <div class="grid gap-2">
     {% for page in pages %}
-    <div class="card flex items-center gap-3 py-3.5 px-5 hover:shadow-card-hover hover:border-primary-300 dark:hover:border-primary-600 transition-all">
-      {% if page.is_pinned %}
-      <svg class="w-5 h-5 text-primary-400 dark:text-primary-500 flex-shrink-0" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
-      </svg>
+    <div class="card flex items-center gap-3 py-3.5 px-5 hover:shadow-card-hover hover:border-primary-300 dark:hover:border-primary-600 transition-all"
+         {% if can_edit %}x-data="pinToggle" data-pinned="{% if page.is_pinned %}true{% else %}false{% endif %}" data-url="{% url 'page_toggle_pin' path=page.content_path %}"{% endif %}>
+      {# Pin icon (shown for pinned pages) / Document icon (shown for unpinned) #}
+      {% if can_edit %}
+      <template x-if="pinned">
+        <svg class="w-5 h-5 text-primary-400 dark:text-primary-500 flex-shrink-0" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
+        </svg>
+      </template>
+      <template x-if="!pinned">
+        <svg class="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+        </svg>
+      </template>
       {% else %}
-      <svg class="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-      </svg>
+        {% if page.is_pinned %}
+        <svg class="w-5 h-5 text-primary-400 dark:text-primary-500 flex-shrink-0" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
+        </svg>
+        {% else %}
+        <svg class="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+        </svg>
+        {% endif %}
       {% endif %}
       <a href="{{ page.get_absolute_url }}" class="flex-1 min-w-0 no-underline">
         <span class="font-medium text-gray-900 dark:text-gray-100">{{ page.title }}</span>
@@ -169,20 +184,11 @@
         </span>
       </a>
       {% if can_edit %}
-      <form method="post" action="{% url 'page_toggle_pin' path=page.content_path %}" class="flex-shrink-0">
-        {% csrf_token %}
-        <button type="submit" class="text-gray-400 hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400 p-1" title="{% if page.is_pinned %}Unpin{% else %}Pin{% endif %}">
-          {% if page.is_pinned %}
-          <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
-          </svg>
-          {% else %}
-          <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
-          </svg>
-          {% endif %}
-        </button>
-      </form>
+      <button type="button" @click="toggle" class="text-gray-400 hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400 p-1 flex-shrink-0" x-bind:title="title">
+        <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
+        </svg>
+      </button>
       {% endif %}
     </div>
     {% endfor %}

--- a/wiki/directories/tests.py
+++ b/wiki/directories/tests.py
@@ -515,24 +515,29 @@ class TestPinnedPages:
         content = r.content.decode()
         assert content.index("Old Pinned") < content.index("New Unpinned")
 
-    def test_toggle_pin_requires_edit_permission(
+    def test_toggle_pin_requires_directory_edit_permission(
         self, client, other_user, page
     ):
+        """Page editors without directory edit permission cannot pin."""
         client.force_login(other_user)
         r = client.post(f"/c/{page.slug}/pin/")
         assert r.status_code == 404
 
-    def test_toggle_pin_works(self, client, owner_user, page):
+    def test_toggle_pin_works(self, client, owner_user, root_directory, page):
+        page.directory = root_directory
+        page.save(update_fields=["directory"])
         client.force_login(owner_user)
         assert not page.is_pinned
         r = client.post(f"/c/{page.slug}/pin/")
-        assert r.status_code == 302
+        assert r.status_code == 200
+        assert r.json()["is_pinned"] is True
         page.refresh_from_db()
         assert page.is_pinned
 
         # Toggle off
         r = client.post(f"/c/{page.slug}/pin/")
-        assert r.status_code == 302
+        assert r.status_code == 200
+        assert r.json()["is_pinned"] is False
         page.refresh_from_db()
         assert not page.is_pinned
 

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -1361,22 +1361,22 @@ def recent_changes(request, username=None):
 @require_POST
 @login_required
 def toggle_pin(request, path):
-    """Toggle the is_pinned flag on a page."""
+    """Toggle the is_pinned flag on a page (requires directory edit)."""
     slug = _parse_page_path(path)
-    page = get_object_or_404(Page, slug=slug)
+    page = get_object_or_404(
+        Page.objects.select_related("directory"), slug=slug
+    )
 
-    if not can_edit_page(request.user, page):
+    directory = page.directory
+    if not directory:
+        directory = Directory.objects.filter(path="").first()
+    if not directory or not can_edit_directory(request.user, directory):
         raise Http404
 
     page.is_pinned = not page.is_pinned
     page.save(update_fields=["is_pinned"])
 
-    action = "pinned" if page.is_pinned else "unpinned"
-    messages.success(request, f'Page "{page.title}" {action}.')
-
-    if page.directory:
-        return redirect(page.directory.get_absolute_url())
-    return redirect(reverse("root"))
+    return JsonResponse({"is_pinned": page.is_pinned})
 
 
 def page_raw_markdown(request, path):


### PR DESCRIPTION
## Fixes

Follow-up to #43 — addresses two issues with the pin feature.

## Summary

1. **Permission change**: Pin/unpin now requires `can_edit_directory` instead of `can_edit_page`. Only users who can edit the directory can pin pages within it.

2. **No page reload**: Pin toggle now uses `fetch()` via an Alpine.js `pinToggle` component instead of a form POST. Clicking the pin icon toggles state without reloading the page. The leading icon (thumbtack vs document) updates reactively via `x-if` templates.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No migration or deployment needed — this is a behavior/UI fix only.