### PR TITLE
Fix visibility badge inheritance and directory title-casing

### DIFF
--- a/wiki/assets/static-global/js/page-form.js
+++ b/wiki/assets/static-global/js/page-form.js
@@ -21,12 +21,14 @@
   var locationChips = document.getElementById('location-chips');
   var dirDropdown = document.getElementById('dir-dropdown');
   var dirPathInput = document.getElementById('directory-path-input');
+  var dirTitlesInput = document.getElementById('directory-titles-input');
 
   var segments = config.dirSegments;
   var searchTimeout = null;
 
   function renderChips() {
     locationChips.innerHTML = '';
+    var titles = {};
     segments.forEach(function(seg) {
       var chip = document.createElement('span');
       chip.className = 'inline-flex items-center gap-1 px-2 py-0.5 rounded bg-primary-100 dark:bg-primary-900 text-primary-800 dark:text-primary-200 text-sm';
@@ -36,8 +38,12 @@
       sep.className = 'text-gray-400 text-sm select-none';
       sep.textContent = '/';
       locationChips.appendChild(sep);
+      if (seg.isNew) {
+        titles[seg.path] = seg.title;
+      }
     });
     dirPathInput.value = segments.length > 0 ? segments[segments.length - 1].path : '';
+    dirTitlesInput.value = JSON.stringify(titles);
   }
 
   function currentParentPath() {

--- a/wiki/pages/templates/pages/detail.html
+++ b/wiki/pages/templates/pages/detail.html
@@ -53,7 +53,7 @@
   {# Main content #}
   <article class="flex-1 min-w-0">
     <div class="flex flex-col justify-between gap-3 mb-6">
-      <h1>{{ page.title|inline_code }} <c-visibility-badge visibility="{{ page.visibility }}" /></h1>
+      <h1>{{ page.title|inline_code }} <c-visibility-badge visibility="{{ effective_visibility }}" /></h1>
       <div class="flex items-center gap-2 flex-shrink-0">
         {% if can_edit %}
           <a href="{% url 'page_edit' path=page.content_path %}" class="btn-outline text-sm">Edit</a>

--- a/wiki/pages/templates/pages/form.html
+++ b/wiki/pages/templates/pages/form.html
@@ -25,6 +25,7 @@
       <label class="block text-sm font-medium mb-1">Location</label>
       <input type="hidden" name="directory_path" id="directory-path-input"
              value="{% if editing and page.directory %}{{ page.directory.path }}{% elif directory %}{{ directory.path }}{% endif %}">
+      <input type="hidden" name="directory_titles" id="directory-titles-input" value="{}">
       <div class="relative">
         <div id="location-picker" class="input-text w-full flex items-center flex-wrap gap-1 min-h-[2.5rem] cursor-text px-2 py-1">
           <span class="text-gray-400 dark:text-gray-500 text-sm select-none">/</span>

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -117,15 +117,23 @@ def _process_mentions_and_grants(page, request):
         )
 
 
-def _resolve_or_create_directory(dir_path, user):
+def _resolve_or_create_directory(dir_path, user, title_overrides=None):
     """Resolve a directory path, creating missing segments as needed.
 
     New directories inherit visibility, editability, and permission
     grants from their parent directory.
+
+    ``title_overrides`` is an optional dict mapping full segment paths
+    to display titles (e.g. {"eng/api": "API"}).  When a new directory
+    is created and its path appears in the mapping, the provided title
+    is used instead of deriving one from the slug.
     """
     directory = Directory.objects.filter(path=dir_path).first()
     if directory:
         return directory
+
+    if title_overrides is None:
+        title_overrides = {}
 
     # Build each segment of the path, creating as needed
     segments = dir_path.strip("/").split("/")
@@ -136,10 +144,13 @@ def _resolve_or_create_directory(dir_path, user):
 
     for segment in segments:
         current_path = f"{current_path}/{segment}" if current_path else segment
+        title = title_overrides.get(
+            current_path, segment.replace("-", " ").title()
+        )
         directory, created = Directory.objects.get_or_create(
             path=current_path,
             defaults={
-                "title": segment.replace("-", " ").title(),
+                "title": title,
                 "parent": parent,
                 "owner": user,
                 "created_by": user,
@@ -162,6 +173,24 @@ def _resolve_or_create_directory(dir_path, user):
         parent = directory
 
     return directory
+
+
+def _parse_directory_titles(post_data):
+    """Parse the directory_titles JSON from POST data.
+
+    Returns a dict mapping directory paths to user-provided titles
+    for newly created directories, e.g. {"eng/api": "API"}.
+    """
+    raw = post_data.get("directory_titles", "").strip()
+    if not raw:
+        return {}
+    try:
+        titles = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(titles, dict):
+        return {}
+    return {k: v for k, v in titles.items() if isinstance(v, str) and v}
 
 
 def resolve_path(request, path):
@@ -386,6 +415,7 @@ def _render_page_detail(request, page):
             "breadcrumbs_json": breadcrumbs_json,
             "article_json": article_json,
             "canonical_url": canonical_url,
+            "effective_visibility": eff_visibility,
         },
     )
 
@@ -427,8 +457,9 @@ def page_create(request, path=""):
         # Use directory from location picker if provided
         dir_path = request.POST.get("directory_path", "").strip()
         if dir_path:
+            title_overrides = _parse_directory_titles(request.POST)
             page.directory = _resolve_or_create_directory(
-                dir_path, request.user
+                dir_path, request.user, title_overrides
             )
         else:
             page.directory = directory
@@ -520,8 +551,9 @@ def page_edit(request, path):
         # Handle directory change from location picker
         dir_path = request.POST.get("directory_path", "").strip()
         if dir_path:
+            title_overrides = _parse_directory_titles(request.POST)
             page.directory = _resolve_or_create_directory(
-                dir_path, request.user
+                dir_path, request.user, title_overrides
             )
         else:
             page.directory = None


### PR DESCRIPTION
## Fixes

This fixes two page detail/edit UX issues.

## Summary

1. **Visibility badge shows resolved inheritance** — The page detail view was passing `page.visibility` to the visibility badge component. For pages set to "inherit", this showed no badge even when the effective visibility was internal or private. Now passes `effective_visibility` (resolved through the directory inheritance chain).

2. **Directory creation preserves user-typed names** — When creating a directory via the location picker (e.g. typing "API"), the name was slugified to "api" for the path, but then `.title()` was used to derive the display title, producing "Api". The location picker now sends the original user-typed titles as JSON in a hidden field, and the backend uses them when creating new directories.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)