### PR TITLE
Make 404 sign-in prompt more prominent for anonymous users

### DIFF
--- a/wiki/assets/templates/404.html
+++ b/wiki/assets/templates/404.html
@@ -5,17 +5,27 @@
 {% block content %}
 <div class="text-center py-20">
   <p class="text-8xl font-serif font-bold text-gray-200 dark:text-gray-700 leading-none">404</p>
+  {% if user.is_authenticated %}
   <h1 class="mt-4 text-2xl">Page Not Found</h1>
   <p class="mt-2 text-gray-500 dark:text-gray-400 max-w-md mx-auto">
     The page you're looking for doesn't exist or has been moved.
   </p>
-  {% if not user.is_authenticated %}
-  <p class="mt-4 text-gray-500 dark:text-gray-400 max-w-md mx-auto">
-    If you believe this page exists, you may need to
-    <a href="{% url 'login' %}?next={{ request.path }}" class="text-primary-600 dark:text-primary-400 underline">sign in</a>
-    to view it.
-  </p>
-  {% endif %}
   <a href="{% url 'root' %}" class="btn-primary mt-8 inline-flex">Go Home</a>
+  {% else %}
+  <h1 class="mt-4 text-2xl">Page Not Found <span class="text-lg text-gray-400 dark:text-gray-500">(or is it?)</span></h1>
+  <p class="mt-2 text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+    You're not signed in, so some of the wiki is invisible to you right now.
+    There's a good chance this page exists and is just waiting behind the login screen.
+  </p>
+  <p class="mt-4 text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+    If you're FLP staff, sign in with your email &mdash; no password needed.
+  </p>
+  <a href="{% url 'login' %}?next={{ request.path }}" class="btn-primary mt-6 inline-flex text-lg px-8 py-3">
+    Sign In to Find Out
+  </a>
+  <a href="{% url 'root' %}" class="mt-4 inline-block text-sm text-gray-400 dark:text-gray-500 underline">
+    or go home
+  </a>
+  {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Fixes

N/A — UX improvement for anonymous users hitting 404 pages.

## Summary

Logged-out users seeing the 404 page now get a much more prominent sign-in prompt instead of a subtle hint. The page explains that some wiki content is behind auth, calls out that FLP staff can sign in with just their email, and provides a large "Sign In to Find Out" button that redirects back to the original page after login. Authenticated users see the standard 404 message unchanged.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`


🤖 Generated with [Claude Code](https://claude.com/claude-code)