### PR TITLE
Fix: can_edit_page/can_edit_directory bypass directory visibility gate

### DIFF
--- a/wiki/directories/views.py
+++ b/wiki/directories/views.py
@@ -316,6 +316,9 @@ def directory_edit(request, path):
     """Edit a directory's title and description."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
 
+    if not can_view_directory(request.user, directory):
+        raise Http404
+
     if not can_edit_directory(request.user, directory):
         messages.error(
             request,
@@ -399,13 +402,16 @@ def directory_create(request, path=""):
             path="", defaults={"title": "Home"}
         )
 
-    # Check edit permission on parent directory
-    if parent.path and not can_edit_directory(request.user, parent):
-        messages.error(
-            request,
-            "You don't have permission to create directories here.",
-        )
-        return redirect(parent.get_absolute_url())
+    # Check permissions on parent directory
+    if parent.path:
+        if not can_view_directory(request.user, parent):
+            raise Http404
+        if not can_edit_directory(request.user, parent):
+            messages.error(
+                request,
+                "You don't have permission to create directories here.",
+            )
+            return redirect(parent.get_absolute_url())
 
     breadcrumbs = parent.get_breadcrumbs()
     breadcrumbs.append(("New Subdirectory", ""))
@@ -454,6 +460,9 @@ def _get_permissions_url(directory):
 
 def _directory_permissions_inner(request, directory):
     """Shared logic for managing directory permissions."""
+    if not can_view_directory(request.user, directory):
+        raise Http404
+
     if not can_edit_directory(request.user, directory):
         messages.error(
             request,
@@ -572,6 +581,9 @@ def directory_move(request, path):
     """Move a directory to a new parent."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
 
+    if not can_view_directory(request.user, directory):
+        raise Http404
+
     if not can_edit_directory(request.user, directory):
         messages.error(
             request,
@@ -649,6 +661,9 @@ def _update_descendant_paths(directory):
 def directory_delete(request, path):
     """Delete a directory (must be empty)."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
+
+    if not can_view_directory(request.user, directory):
+        raise Http404
 
     if not can_edit_directory(request.user, directory):
         messages.error(
@@ -764,6 +779,9 @@ def directory_inherit_meta(request):
 
 def _directory_apply_permissions_inner(request, directory):
     """Shared logic for applying directory permissions to children."""
+    if not can_view_directory(request.user, directory):
+        raise Http404
+
     if not can_edit_directory(request.user, directory):
         messages.error(
             request,
@@ -1018,6 +1036,9 @@ def directory_diff_root(request, v1, v2):
 
 def _directory_revert_inner(request, directory, rev_num):
     """Shared logic for directory revert view."""
+    if not can_view_directory(request.user, directory):
+        raise Http404
+
     if not can_edit_directory(request.user, directory):
         messages.error(
             request,

--- a/wiki/lib/permissions.py
+++ b/wiki/lib/permissions.py
@@ -232,8 +232,15 @@ def viewable_pages_q(user):
 
 
 def can_edit_page(user, page):
-    """Check if user can edit a page."""
+    """Check if user can edit a page.
+
+    Editing requires view access first — a user who cannot see a page
+    must not be able to edit it, regardless of editability settings.
+    """
     if not user.is_authenticated:
+        return False
+
+    if not can_view_page(user, page):
         return False
 
     effective_editability, _ = resolve_effective_value(page, "editability")
@@ -276,8 +283,15 @@ def can_edit_page(user, page):
 
 
 def can_edit_directory(user, directory):
-    """Check if user can edit a directory."""
+    """Check if user can edit a directory.
+
+    Editing requires view access first — a user who cannot see a
+    directory must not be able to edit it, regardless of editability.
+    """
     if not user.is_authenticated:
+        return False
+
+    if not can_view_directory(user, directory):
         return False
 
     effective_editability, _ = resolve_effective_value(
@@ -400,4 +414,11 @@ def editable_page_ids(user):
             )
         )
 
-    return ids
+    # Enforce view access: a user cannot edit pages they cannot see
+    # (e.g. pages in private directories with internal editability).
+    viewable_q = viewable_pages_q(user)
+    return ids & set(
+        Page.objects.filter(viewable_q, id__in=ids).values_list(
+            "id", flat=True
+        )
+    )

--- a/wiki/lib/tests.py
+++ b/wiki/lib/tests.py
@@ -2,9 +2,10 @@
 
 import time_machine
 from django.contrib.auth.models import AnonymousUser
+from django.urls import reverse
 from django.utils import timezone
 
-from wiki.directories.models import DirectoryPermission
+from wiki.directories.models import Directory, DirectoryPermission
 from wiki.lib.edit_lock import (
     acquire_lock_for_directory,
     acquire_lock_for_page,
@@ -18,7 +19,9 @@ from wiki.lib.models import EditLock
 from wiki.lib.permissions import (
     can_edit_directory,
     can_edit_page,
+    can_view_directory,
     can_view_page,
+    editable_page_ids,
     is_system_owner,
 )
 from wiki.pages.models import Page, PagePermission
@@ -223,6 +226,273 @@ class TestCanEditDirectory:
         if hasattr(other_user, "_group_ids_cache"):
             del other_user._group_ids_cache
         assert can_edit_directory(other_user, sub_directory)
+
+
+class TestVisibilityGatesEditAccess:
+    """Verify that view access is enforced before edit access.
+
+    The core security invariant: a user who cannot VIEW a page or
+    directory must NEVER be able to edit it, even if the editability
+    setting would otherwise allow it (e.g. editability="internal" on
+    a private directory).
+    """
+
+    def test_private_dir_internal_edit_denies_non_viewer_page(
+        self, user, other_user, private_directory
+    ):
+        """Page in a private dir with editability=internal: non-viewer
+        must not be able to edit."""
+        private_directory.editability = "internal"
+        private_directory.save()
+
+        page = Page.objects.create(
+            title="Secret Roadmap",
+            slug="secret-roadmap",
+            content="Confidential plans.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+
+        # other_user is authenticated but has no access to private dir
+        assert not can_view_page(other_user, page)
+        assert not can_edit_page(other_user, page)
+
+    def test_private_dir_internal_edit_allows_authorized_viewer(
+        self, user, other_user, private_directory
+    ):
+        """Page in a private dir with editability=internal: user with
+        view permission should be able to edit."""
+        private_directory.editability = "internal"
+        private_directory.save()
+
+        page = Page.objects.create(
+            title="Visible Roadmap",
+            slug="visible-roadmap",
+            content="Plans for those with access.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        DirectoryPermission.objects.create(
+            directory=private_directory,
+            user=other_user,
+            permission_type=DirectoryPermission.PermissionType.VIEW,
+        )
+
+        assert can_view_page(other_user, page)
+        assert can_edit_page(other_user, page)
+
+    def test_private_dir_internal_edit_denies_non_viewer_directory(
+        self, user, other_user, root_directory
+    ):
+        """Private dir with editability=internal: non-viewer must not
+        be able to edit the directory itself."""
+        private_dir = Directory.objects.create(
+            path="classified",
+            title="Classified",
+            parent=root_directory,
+            owner=user,
+            created_by=user,
+            visibility="private",
+            editability="internal",
+        )
+
+        assert not can_view_directory(other_user, private_dir)
+        assert not can_edit_directory(other_user, private_dir)
+
+    def test_private_dir_internal_edit_allows_authorized_viewer_directory(
+        self, user, other_user, root_directory
+    ):
+        """Private dir with editability=internal: user with view
+        permission should be able to edit the directory."""
+        private_dir = Directory.objects.create(
+            path="team-dir",
+            title="Team Dir",
+            parent=root_directory,
+            owner=user,
+            created_by=user,
+            visibility="private",
+            editability="internal",
+        )
+        DirectoryPermission.objects.create(
+            directory=private_dir,
+            user=other_user,
+            permission_type=DirectoryPermission.PermissionType.VIEW,
+        )
+
+        assert can_view_directory(other_user, private_dir)
+        assert can_edit_directory(other_user, private_dir)
+
+    def test_private_page_internal_edit_denies_non_viewer(
+        self, user, other_user
+    ):
+        """A directly private page with editability=internal: non-viewer
+        must not be able to edit."""
+        page = Page.objects.create(
+            title="Private Internal",
+            slug="private-internal",
+            content="Secret.",
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="private",
+            editability="internal",
+        )
+
+        assert not can_view_page(other_user, page)
+        assert not can_edit_page(other_user, page)
+
+    def test_editable_page_ids_excludes_non_viewable(
+        self, user, other_user, private_directory
+    ):
+        """editable_page_ids must not include pages the user cannot view."""
+        private_directory.editability = "internal"
+        private_directory.save()
+
+        page = Page.objects.create(
+            title="Hidden Page",
+            slug="hidden-page",
+            content="Cannot see this.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+
+        ids = editable_page_ids(other_user)
+        assert page.id not in ids
+
+
+class TestVisibilityGatesEditViews:
+    """Verify that edit/move/permissions/revert views return 404 for
+    users who cannot view the page or directory, even when editability
+    would otherwise grant access."""
+
+    def test_page_edit_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Page",
+            slug="secret-page-edit",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        client.force_login(other_user)
+        url = reverse("page_edit", kwargs={"path": page.content_path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_page_move_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Move",
+            slug="secret-page-move",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        client.force_login(other_user)
+        url = reverse("page_move", kwargs={"path": page.content_path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_page_permissions_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Perms",
+            slug="secret-page-perms",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        client.force_login(other_user)
+        url = reverse("page_permissions", kwargs={"path": page.content_path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_directory_edit_returns_404_for_non_viewer(
+        self, client, user, other_user, root_directory
+    ):
+        private_dir = Directory.objects.create(
+            path="secret-dir-edit",
+            title="Secret Dir",
+            parent=root_directory,
+            owner=user,
+            created_by=user,
+            visibility="private",
+            editability="internal",
+        )
+        client.force_login(other_user)
+        url = reverse("directory_edit", kwargs={"path": private_dir.path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_directory_delete_returns_404_for_non_viewer(
+        self, client, user, other_user, root_directory
+    ):
+        private_dir = Directory.objects.create(
+            path="secret-dir-del",
+            title="Secret Dir Del",
+            parent=root_directory,
+            owner=user,
+            created_by=user,
+            visibility="private",
+            editability="internal",
+        )
+        client.force_login(other_user)
+        url = reverse("directory_delete", kwargs={"path": private_dir.path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_directory_permissions_returns_404_for_non_viewer(
+        self, client, user, other_user, root_directory
+    ):
+        private_dir = Directory.objects.create(
+            path="secret-dir-perms",
+            title="Secret Dir Perms",
+            parent=root_directory,
+            owner=user,
+            created_by=user,
+            visibility="private",
+            editability="internal",
+        )
+        client.force_login(other_user)
+        url = reverse(
+            "directory_permissions",
+            kwargs={"path": private_dir.path},
+        )
+        response = client.get(url)
+        assert response.status_code == 404
 
 
 # ── Edit Lock Helpers ─────────────────────────────────────

--- a/wiki/lib/tests.py
+++ b/wiki/lib/tests.py
@@ -24,7 +24,8 @@ from wiki.lib.permissions import (
     editable_page_ids,
     is_system_owner,
 )
-from wiki.pages.models import Page, PagePermission
+from wiki.pages.models import Page, PagePermission, PageRevision
+from wiki.proposals.models import ChangeProposal
 from wiki.users.models import SystemConfig
 
 
@@ -492,6 +493,170 @@ class TestVisibilityGatesEditViews:
             kwargs={"path": private_dir.path},
         )
         response = client.get(url)
+        assert response.status_code == 404
+
+    def test_page_delete_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Delete",
+            slug="secret-page-del",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        client.force_login(other_user)
+        url = reverse("page_delete", kwargs={"path": page.content_path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_page_revert_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Revert",
+            slug="secret-page-rev",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        PageRevision.objects.create(
+            page=page,
+            title=page.title,
+            content=page.content,
+            change_message="v1",
+            revision_number=1,
+            created_by=user,
+        )
+        client.force_login(other_user)
+        url = reverse(
+            "page_revert",
+            kwargs={"path": page.content_path, "rev_num": 1},
+        )
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_proposal_list_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Proposals",
+            slug="secret-page-prop",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        client.force_login(other_user)
+        url = reverse("proposal_list", kwargs={"path": page.content_path})
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_proposal_review_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Review",
+            slug="secret-page-review",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        proposal = ChangeProposal.objects.create(
+            page=page,
+            proposed_title=page.title,
+            proposed_content="New content",
+            change_message="test",
+        )
+        client.force_login(other_user)
+        url = reverse(
+            "proposal_review",
+            kwargs={"path": page.content_path, "pk": proposal.pk},
+        )
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_proposal_accept_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Accept",
+            slug="secret-page-accept",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        proposal = ChangeProposal.objects.create(
+            page=page,
+            proposed_title=page.title,
+            proposed_content="New content",
+            change_message="test",
+        )
+        client.force_login(other_user)
+        url = reverse(
+            "proposal_accept",
+            kwargs={"path": page.content_path, "pk": proposal.pk},
+        )
+        response = client.post(url)
+        assert response.status_code == 404
+
+    def test_proposal_deny_returns_404_for_non_viewer(
+        self, client, user, other_user, private_directory
+    ):
+        private_directory.editability = "internal"
+        private_directory.save()
+        page = Page.objects.create(
+            title="Secret Deny",
+            slug="secret-page-deny",
+            content="Hidden.",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility="inherit",
+            editability="inherit",
+        )
+        proposal = ChangeProposal.objects.create(
+            page=page,
+            proposed_title=page.title,
+            proposed_content="New content",
+            change_message="test",
+        )
+        client.force_login(other_user)
+        url = reverse(
+            "proposal_deny",
+            kwargs={"path": page.content_path, "pk": proposal.pk},
+        )
+        response = client.post(url)
         assert response.status_code == 404
 
 

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -526,17 +526,16 @@ def page_create(request, path=""):
     if path:
         directory = get_object_or_404(Directory, path=path.strip("/"))
 
-    # Check edit permission on target directory
-    if (
-        directory
-        and directory.path
-        and not can_edit_directory(request.user, directory)
-    ):
-        messages.error(
-            request,
-            "You don't have permission to create pages here.",
-        )
-        return redirect(directory.get_absolute_url())
+    # Check permissions on target directory
+    if directory and directory.path:
+        if not can_view_directory(request.user, directory):
+            raise Http404
+        if not can_edit_directory(request.user, directory):
+            messages.error(
+                request,
+                "You don't have permission to create pages here.",
+            )
+            return redirect(directory.get_absolute_url())
 
     # Build breadcrumbs for the target directory
     breadcrumbs = [("Home", reverse("root"))]
@@ -617,6 +616,9 @@ def page_edit(request, path):
     """Edit an existing page."""
     slug = _parse_page_path(path)
     page = get_object_or_404(Page, slug=slug)
+
+    if not can_view_page(request.user, page):
+        raise Http404
 
     if not can_edit_page(request.user, page):
         messages.error(request, "You don't have permission to edit this page.")
@@ -735,6 +737,9 @@ def page_move(request, path):
     slug = _parse_page_path(path)
     page = get_object_or_404(Page, slug=slug)
 
+    if not can_view_page(request.user, page):
+        raise Http404
+
     if not can_edit_page(request.user, page):
         messages.error(request, "You don't have permission to move this page.")
         return redirect(page.get_absolute_url())
@@ -837,6 +842,9 @@ def page_permissions(request, path):
     """Manage permissions for a page."""
     slug = _parse_page_path(path)
     page = get_object_or_404(Page, slug=slug)
+
+    if not can_view_page(request.user, page):
+        raise Http404
 
     if not can_edit_page(request.user, page):
         messages.error(
@@ -1022,6 +1030,9 @@ def page_revert(request, path, rev_num):
     """Revert a page to a previous revision (creates a new revision)."""
     slug = _parse_page_path(path)
     page = get_object_or_404(Page, slug=slug)
+
+    if not can_view_page(request.user, page):
+        raise Http404
 
     if not can_edit_page(request.user, page):
         messages.error(request, "You don't have permission to edit this page.")

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -790,6 +790,9 @@ def page_delete(request, path):
     slug = _parse_page_path(path)
     page = get_object_or_404(Page, slug=slug)
 
+    if not can_view_page(request.user, page):
+        raise Http404
+
     if page.owner != request.user and not is_system_owner(request.user):
         messages.error(
             request, "You don't have permission to delete this page."

--- a/wiki/proposals/views.py
+++ b/wiki/proposals/views.py
@@ -85,6 +85,9 @@ def proposal_list(request, path):
     """List proposals and comments for a page (for editors/owners)."""
     page = get_page_from_path(path)
 
+    if not can_view_page(request.user, page):
+        raise Http404
+
     if not can_edit_page(request.user, page):
         messages.error(
             request,
@@ -124,6 +127,9 @@ def proposal_review(request, path, pk):
     """Review a single proposal with diff view."""
     page = get_page_from_path(path)
 
+    if not can_view_page(request.user, page):
+        raise Http404
+
     if not can_edit_page(request.user, page):
         messages.error(
             request,
@@ -151,6 +157,9 @@ def proposal_review(request, path, pk):
 def proposal_accept(request, path, pk):
     """Accept a proposal, applying changes to the page."""
     page = get_page_from_path(path)
+
+    if not can_view_page(request.user, page):
+        raise Http404
 
     if not can_edit_page(request.user, page):
         messages.error(
@@ -209,6 +218,9 @@ def proposal_accept(request, path, pk):
 def proposal_deny(request, path, pk):
     """Deny a proposal with an optional reason."""
     page = get_page_from_path(path)
+
+    if not can_view_page(request.user, page):
+        raise Http404
 
     if not can_edit_page(request.user, page):
         messages.error(request, "You don't have permission to deny proposals.")


### PR DESCRIPTION
## Fixes

Security fix: `can_edit_page()` and `can_edit_directory()` did not enforce view access before granting edit access. A page in a private directory with `editability="internal"` was editable by any authenticated user — even those who should not know the page exists.

## Summary

**The bug:** `can_edit_page()` checked editability but never called `can_view_page()`. When a private directory had `editability="internal"`, any authenticated user could access edit/move/permissions/revert views, leaking private content and allowing unauthorized modifications. The same issue applied symmetrically to `can_edit_directory()`.

**The fix (3 commits):**

1. **Core permission fix** — `can_edit_page()` now gates on `can_view_page()` and `can_edit_directory()` gates on `can_view_directory()`. Also `editable_page_ids()` (used by the review queue) now intersects with `viewable_pages_q()`.

2. **View-level defense-in-depth** — All views that use `can_edit_*` now raise `Http404` for non-viewers (hiding existence), while users who CAN view but cannot edit still get the friendly error message + redirect. Affected views across pages, directories, and proposals apps.

3. **12 new tests** — Unit tests for the permission functions and integration tests via Django test client confirming 404 responses for non-viewers on edit/move/permissions/delete endpoints.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No special deployment steps required — no migrations, just code changes.