### PR TITLE
Add lead paragraph styling and link history from page footer

### DIFF
--- a/wiki/assets/tailwind/input.css
+++ b/wiki/assets/tailwind/input.css
@@ -195,6 +195,11 @@
   .wiki-content p {
     @apply my-3;
   }
+  .wiki-content > p.lead:first-child {
+    @apply text-xl font-serif font-semibold leading-relaxed tracking-tight
+           text-gray-800 dark:text-gray-100
+           mt-0 mb-8;
+  }
   .wiki-content ul {
     @apply list-disc ml-6 my-3;
   }

--- a/wiki/assets/tailwind/tailwind.config.js
+++ b/wiki/assets/tailwind/tailwind.config.js
@@ -16,9 +16,6 @@ module.exports = {
       '../../**/diff_utils.py',
     ],
   },
-  safelist: [
-    'lead',
-  ],
   theme: {
     extend: {
       fontFamily: {

--- a/wiki/assets/tailwind/tailwind.config.js
+++ b/wiki/assets/tailwind/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = {
       '../../**/diff_utils.py',
     ],
   },
+  safelist: [
+    'lead',
+  ],
   theme: {
     extend: {
       fontFamily: {

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -162,6 +162,7 @@ ALLOWED_ATTRIBUTES = {
     "a": {"href", "title"},
     "img": {"src", "alt", "title"},
     "input": {"type", "checked", "disabled"},
+    "p": {"class"},
     "span": {"class"},
     "th": {"align"},
     "td": {"align"},

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -589,12 +589,12 @@ class TestLeadParagraph:
         result = render_markdown(md)
         assert '<p class="lead">This is the intro.</p>' in result
 
-    def test_disallowed_class_stripped(self):
+    def test_unknown_class_preserved_by_nh3(self):
         md = '<p class="evil">Text.</p>'
         result = render_markdown(md)
-        assert "evil" in result  # nh3 keeps unknown classes
+        assert "evil" in result
 
-    def test_lead_with_inline_markdown(self):
-        md = '<p class="lead">Text with **bold** and *italic*.</p>'
+    def test_lead_class_preserved_with_mixed_content(self):
+        md = '<p class="lead">Text with <strong>bold</strong> and <em>italic</em>.</p>'
         result = render_markdown(md)
         assert 'class="lead"' in result

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -579,3 +579,22 @@ class TestAddNofollowToNonPublicLinks:
         html = f'<a href="{url}">link</a>'
         result = _add_nofollow_to_non_public_links(html)
         assert 'rel="nofollow"' in result
+
+
+class TestLeadParagraph:
+    """Test that <p class="lead"> survives the sanitizer."""
+
+    def test_lead_class_preserved_through_render(self):
+        md = '<p class="lead">This is the intro.</p>\n\nBody text.'
+        result = render_markdown(md)
+        assert '<p class="lead">This is the intro.</p>' in result
+
+    def test_disallowed_class_stripped(self):
+        md = '<p class="evil">Text.</p>'
+        result = render_markdown(md)
+        assert "evil" in result  # nh3 keeps unknown classes
+
+    def test_lead_with_inline_markdown(self):
+        md = '<p class="lead">Text with **bold** and *italic*.</p>'
+        result = render_markdown(md)
+        assert 'class="lead"' in result

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -280,6 +280,24 @@ Here's what they look like:
 [Outline button](https://example.com){button-outline}
 [Danger button](https://example.com){button-danger}
 
+### Lead paragraph
+
+You can style the opening paragraph of a page as a **lead** — a
+larger, bolder introduction that sets the tone before the body
+content begins. Wrap it in a `<p>` tag with the `lead` class as
+the very first thing in the page content:
+
+```html
+<p class="lead">
+This is the opening summary of the page. It appears larger
+and bolder than the rest of the content.
+</p>
+```
+
+The lead styling only applies when it is the first element on the
+page. A `<p class="lead">` placed anywhere else will render as a
+normal paragraph.
+
 ### Code blocks
 
 Use triple backticks with an optional language name for syntax

--- a/wiki/pages/templates/pages/detail.html
+++ b/wiki/pages/templates/pages/detail.html
@@ -112,7 +112,11 @@
     <div class="page-meta">
       <div class="flex items-center justify-between">
         <span>{{ page.view_count }} view{{ page.view_count|pluralize }}</span>
+        {% if user.is_authenticated %}
+        <a href="{% url 'page_history' path=page.content_path %}" class="hover:underline">Last updated {{ page.updated_at|timesince }} ago</a>
+        {% else %}
         <span>Last updated {{ page.updated_at|timesince }} ago</span>
+        {% endif %}
       </div>
       {% if people %}
       <div class="mt-3 flex items-center gap-1.5 flex-wrap">


### PR DESCRIPTION
## Fixes

N/A — new feature

## Summary

Two small improvements:

1. **Lead paragraph styling**: Authors can wrap the opening paragraph of a page in `<p class="lead">...</p>` for larger, bolder introductory text (like a newspaper lede). The styling only applies when it's the first element on the page (enforced via CSS `:first-child`). The `class` attribute on `<p>` tags is now allowed through the nh3 sanitizer, the `lead` class is safelisted in Tailwind config, and the feature is documented in the markdown syntax help page.

2. **History link in page footer**: The "Last updated X ago" text in the page metadata footer is now a link to the page history for authenticated users (history requires login, so anonymous users still see plain text).

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)