### PR TITLE
Add CourtListener API docs import script and export files

### DIFF
--- a/wiki-exports/LINK_MAP.md
+++ b/wiki-exports/LINK_MAP.md
@@ -1,0 +1,52 @@
+# Link mapping: CourtListener URL → Local file → Wiki path
+
+## Pages being exported
+
+| CourtListener URL | Local file | Wiki path |
+|---|---|---|
+| /help/api/rest/ | rest-api.md | /c/courtlistener/help/api/rest/v4/overview/ |
+| /help/api/rest/v4/ | rest-api.md | /c/courtlistener/help/api/rest/v4/overview/ |
+| /help/api/rest/v3/ | rest-api-v3.md | /c/courtlistener/help/api/rest/v3/overview/ |
+| /help/api/rest/v2/ | rest-api-v2.md | /c/courtlistener/help/api/rest/v2/overview/ |
+| /help/api/rest/v1/ | rest-api-v1.md | /c/courtlistener/help/api/rest/v1/overview/ |
+| /help/api/rest/v4/case-law/ | case-law-api.md | /c/courtlistener/help/api/rest/v4/case-law/ |
+| /help/api/rest/v3/case-law/ | case-law-api.md | /c/courtlistener/help/api/rest/v4/case-law/ |
+| /help/api/rest/v4/citations/ | citation-api.md | /c/courtlistener/help/api/rest/v4/citations/ |
+| /help/api/rest/v4/citation-lookup/ | citation-lookup-api.md | /c/courtlistener/help/api/rest/v4/citation-lookup/ |
+| /help/api/rest/v3/citation-lookup/ | citation-lookup-api.md | /c/courtlistener/help/api/rest/v4/citation-lookup/ |
+| /help/api/rest/v4/pacer/ | pacer-api.md | /c/courtlistener/help/api/rest/v4/pacer-data/ |
+| /help/api/rest/v3/pacer/ | pacer-api.md | /c/courtlistener/help/api/rest/v4/pacer-data/ |
+| /help/api/rest/v4/recap/ | recap-api.md | /c/courtlistener/help/api/rest/v4/recap/ |
+| /help/api/rest/v3/recap/ | recap-api.md | /c/courtlistener/help/api/rest/v4/recap/ |
+| /help/api/rest/v4/judges/ | judge-api.md | /c/courtlistener/help/api/rest/v4/judges/ |
+| /help/api/rest/v3/judges/ | judge-api.md | /c/courtlistener/help/api/rest/v4/judges/ |
+| /help/api/rest/v4/oral-arguments/ | oral-argument-api.md | /c/courtlistener/help/api/rest/v4/oral-arguments/ |
+| /help/api/rest/v3/oral-arguments/ | oral-argument-api.md | /c/courtlistener/help/api/rest/v4/oral-arguments/ |
+| /help/api/rest/v4/visualizations/ | visualizations-api.md | /c/courtlistener/help/api/rest/v4/visualizations/ |
+| /help/api/rest/v3/visualizations/ | visualizations-api.md | /c/courtlistener/help/api/rest/v4/visualizations/ |
+| /help/api/rest/v4/financial-disclosures/ | financial-disclosure-api.md | /c/courtlistener/help/api/rest/v4/financial-disclosures/ |
+| /help/api/rest/v3/financial-disclosures/ | financial-disclosure-api.md | /c/courtlistener/help/api/rest/v4/financial-disclosures/ |
+| /help/api/rest/v4/search/ | search-api.md | /c/courtlistener/help/api/rest/v4/search/ |
+| /help/api/rest/v3/search/ | search-api-v3.md | /c/courtlistener/help/api/rest/v3/search/ |
+| /help/api/rest/v4/alerts/ | alert-api.md | /c/courtlistener/help/api/rest/v4/alerts/ |
+| /help/api/rest/v3/alerts/ | alert-api.md | /c/courtlistener/help/api/rest/v4/alerts/ |
+| /help/api/rest/v4/tags/ | tag-api.md | /c/courtlistener/help/api/rest/v4/tags/ |
+| /help/api/rest/v4/fields/ | field-help.md | /c/courtlistener/help/api/rest/v4/field-help/ |
+| /help/api/rest/v3/fields/ | field-help.md | /c/courtlistener/help/api/rest/v4/field-help/ |
+| /help/api/rest/changes/ | rest-change-log.md | /c/courtlistener/help/api/rest/change-log/ |
+| /help/api/webhooks/getting-started/ | webhooks-getting-started.md | /c/courtlistener/help/api/webhooks/getting-started/ |
+| /help/api/webhooks/ | webhooks.md | /c/courtlistener/help/api/webhooks/about/ |
+| /help/api/rest/v4/migration-guide/ | migration-guide.md | /c/courtlistener/help/api/rest/v4/migration-guide/ |
+
+## Pages NOT being exported (keep as absolute CL URLs)
+
+- /help/api/ → https://www.courtlistener.com/help/api/
+- /help/api/bulk-data/ → https://www.courtlistener.com/help/api/bulk-data/
+- /help/api/replication/ → https://www.courtlistener.com/help/api/replication/
+- /help/api/jurisdictions/ → https://www.courtlistener.com/help/api/jurisdictions/
+- /help/coverage/* → https://www.courtlistener.com/help/coverage/...
+- /help/alerts/ → https://www.courtlistener.com/help/alerts/
+- /help/mcp/ → https://www.courtlistener.com/help/mcp/
+- /contact/ → https://www.courtlistener.com/contact/
+- /terms/ → https://www.courtlistener.com/terms/
+- /api/rest/v4/ (the API root itself) → https://www.courtlistener.com/api/rest/v4/

--- a/wiki-exports/README.md
+++ b/wiki-exports/README.md
@@ -1,0 +1,148 @@
+# Wiki Import Instructions
+
+These files are exports of CourtListener's API help pages (from `/help/api/*`) being moved to the Free Law Project Wiki at wiki.free.law as part of [issue #7130](https://github.com/freelawproject/courtlistener/issues/7130). Each `.md` file (except this one and `LINK_MAP.md`) is a single wiki page.
+
+
+## Front Matter Fields
+
+Every exported file has YAML front matter between `---` delimiters. Here is what each field means and how to configure it during import:
+
+- **`title`** — The page title. Display this as the page heading. Do not add an H1 (`#`) in the page content; the title serves that purpose.
+
+- **`description`** — The Open Graph description for the page. Set this in the wiki page's OG description field.
+
+- **`redirect_from`** — The old CourtListener URL path (e.g., `/help/api/rest/v4/`). After import, CourtListener should return a **302 redirect** from this path to the new wiki URL. Every exported page has this field.
+
+- **`wiki_path`** — The target path on the wiki where this page should be created (e.g., `/c/courtlistener/help/api/rest/v4/`). Use this to determine the page's location in the wiki hierarchy.
+
+- **`data_source`** — (Only on some pages) A URL pointing to a JSON API that provides dynamic data for the page. Set this in the wiki page's **Data Source** settings. Currently the only value used is `https://www.courtlistener.com/api/rest/v4/wiki-data/`.
+
+- **`data_source_cache`** — (Only on some pages) Cache duration in seconds for the data source response. Set this in the wiki page's **Data Source** settings alongside the URL. Currently all pages use `86400` (24 hours).
+
+- **`search_engines: false`** — (Only on legacy version pages, e.g., v1/v2/v3 API docs) Set the wiki page setting "Include in search engines?" to **No**.
+
+- **`ai_assistants: false`** — (Only on legacy version pages) Set the wiki page setting "Share with AI assistants?" to **No**.
+
+
+## Data Connector Placeholders
+
+Some pages use `[[ key ]]` syntax to pull live data from the CourtListener API. These placeholders are rendered at display time by the wiki's data connector feature, not at import time.
+
+The data source URL is `https://www.courtlistener.com/api/rest/v4/wiki-data/` and should be configured in the wiki page's Data Source settings (along with the cache duration), not embedded in the markdown content.
+
+Available placeholder keys and the pages that use them:
+
+| Key | Description | Used in |
+|---|---|---|
+| `court_count` | Number of jurisdictions in CourtListener | `rest-api.md`, `rest-api-v3.md` |
+| `citation_count` | Total citations in the database | `citation-lookup-api.md` |
+| `citation_lookup.throttle_count` | Citation lookup throttle limit | `citation-lookup-api.md` |
+| `citation_lookup.throttle_period` | Citation lookup throttle time window | `citation-lookup-api.md` |
+| `citation_lookup.max_per_request` | Max citations per single request | `citation-lookup-api.md` |
+
+
+## Inter-page Links
+
+Links between exported pages use **local file references** such as `rest-api.md`, `case-law-api.md#cluster-endpoint`, or `field-help.md#downloads`. The import script should resolve these to the correct wiki paths using the `wiki_path` front matter field from the target file (or via `LINK_MAP.md`).
+
+Links to `https://www.courtlistener.com/...` are **intentionally absolute** — they point to pages that remain on CourtListener (e.g., coverage pages, bulk data, replication, the contact form, the API browser, jurisdiction list). Do not rewrite these.
+
+See `LINK_MAP.md` for the complete mapping of CourtListener URLs to local files and wiki paths.
+
+
+## Images
+
+Image URLs pointing to `https://www.courtlistener.com/static/...` should be:
+
+1. Downloaded from CourtListener
+2. Uploaded to the wiki as media/attachments
+3. Rewritten in the markdown to point to the wiki-hosted copy
+
+Preserve the alt text from each image's markdown syntax.
+
+Images appear in these files:
+- `rest-api.md` — Data model diagrams (people model, search model, complete model) and Creative Commons badge
+- `webhooks-getting-started.md` — Screenshots of the webhook panel, adding endpoints, disabled endpoints, and test modals
+- `webhooks.md` — Screenshot of re-enabling a webhook endpoint
+
+
+## Lead Paragraphs
+
+Some pages have a `<p class="lead">...</p>` tag wrapping their first paragraph. The wiki renders this as a visually prominent introductory paragraph. Keep this HTML as-is during import.
+
+
+## Button Links
+
+Some pages use the syntax `[text](url){button}` to render a link as a styled button. Keep this syntax as-is during import — the wiki rendering engine handles it.
+
+Files using button links: `rest-api.md`, `alert-api.md`, `migration-guide.md`, `webhooks.md`, `recap-api.md`, `tag-api.md`.
+
+
+## Special Files
+
+Two files in this directory are **not** wiki pages and should not be imported:
+
+- **`LINK_MAP.md`** — A reference table mapping CourtListener URL paths to local filenames and wiki paths. Use this during import to resolve links and set up redirects, but do not create a wiki page for it.
+
+- **`README.md`** — This file. Import instructions only.
+
+
+## Legacy Versions
+
+Four files contain older API version documentation:
+
+- `rest-api-v3.md` → `/c/courtlistener/help/api/rest/v3/`
+- `rest-api-v2.md` → `/c/courtlistener/help/api/rest/v2/`
+- `rest-api-v1.md` → `/c/courtlistener/help/api/rest/v1/`
+- `search-api-v3.md` → `/c/courtlistener/help/api/rest/v3/search/`
+
+These have `search_engines: false` and `ai_assistants: false` in their front matter. Import them as wiki pages but configure the page settings to:
+
+- Exclude from search engine indexing (no sitemap entry)
+- Exclude from AI assistant sharing (no llms.txt entry)
+
+These pages exist for historical reference only so that old links continue to work.
+
+
+## Page Hierarchy
+
+Pages should be created at the wiki paths specified in each file's `wiki_path` front matter field:
+
+```
+/c/courtlistener/help/api/rest/v4/overview/               ← rest-api.md
+/c/courtlistener/help/api/rest/v4/case-law/               ← case-law-api.md
+/c/courtlistener/help/api/rest/v4/pacer-data/             ← pacer-api.md
+/c/courtlistener/help/api/rest/v4/recap/                  ← recap-api.md
+/c/courtlistener/help/api/rest/v4/search/                 ← search-api.md
+/c/courtlistener/help/api/rest/v4/judges/                 ← judge-api.md
+/c/courtlistener/help/api/rest/v4/financial-disclosures/  ← financial-disclosure-api.md
+/c/courtlistener/help/api/rest/v4/oral-arguments/         ← oral-argument-api.md
+/c/courtlistener/help/api/rest/v4/citation-lookup/        ← citation-lookup-api.md
+/c/courtlistener/help/api/rest/v4/citations/              ← citation-api.md
+/c/courtlistener/help/api/rest/v4/alerts/                 ← alert-api.md
+/c/courtlistener/help/api/rest/v4/tags/                   ← tag-api.md
+/c/courtlistener/help/api/rest/v4/visualizations/         ← visualizations-api.md
+/c/courtlistener/help/api/rest/v4/field-help/             ← field-help.md
+/c/courtlistener/help/api/rest/v4/migration-guide/        ← migration-guide.md
+/c/courtlistener/help/api/rest/change-log/                ← rest-change-log.md
+/c/courtlistener/help/api/webhooks/about/                 ← webhooks.md
+/c/courtlistener/help/api/webhooks/getting-started/       ← webhooks-getting-started.md
+/c/courtlistener/help/api/rest/v1/overview/               ← rest-api-v1.md (legacy)
+/c/courtlistener/help/api/rest/v2/overview/               ← rest-api-v2.md (legacy)
+/c/courtlistener/help/api/rest/v3/overview/               ← rest-api-v3.md (legacy)
+/c/courtlistener/help/api/rest/v3/search/                 ← search-api-v3.md (legacy)
+```
+
+
+## Post-import Checklist
+
+- [ ] **Data placeholders**: Verify all `[[ ]]` placeholders render with live values from the wiki-data API (check `rest-api.md` and `citation-lookup-api.md`)
+- [ ] **Inter-page links**: Click through every local file reference link and confirm it resolves to the correct wiki page
+- [ ] **Anchor links**: Verify fragment links (e.g., `rest-api.md#field-selection`, `case-law-api.md#cluster-endpoint`) resolve to the correct heading
+- [ ] **Images**: Confirm all images display correctly, especially the data model diagrams and webhook screenshots
+- [ ] **Button links**: Verify `{button}` syntax renders as styled buttons
+- [ ] **302 redirects**: Set up redirects in CourtListener for every `redirect_from` path pointing to the corresponding wiki URL. Multiple CourtListener paths may redirect to the same wiki page (e.g., both `/help/api/rest/v4/case-law/` and `/help/api/rest/v3/case-law/` redirect to the same wiki page)
+- [ ] **Legacy page settings**: Confirm pages with `search_engines: false` and `ai_assistants: false` are excluded from the wiki sitemap and llms.txt
+- [ ] **Page titles**: Confirm no page has a duplicate H1 — the `title` front matter field is the sole heading
+- [ ] **External links**: Spot-check that absolute `https://www.courtlistener.com/...` links still point to live pages on CourtListener
+- [ ] **Data source settings**: Confirm the data source URL and cache duration are configured in the wiki page settings for pages that have `data_source` and `data_source_cache` front matter

--- a/wiki-exports/alert-api.md
+++ b/wiki-exports/alert-api.md
@@ -1,0 +1,190 @@
+---
+title: "Legal Alert APIs"
+description: "Use these APIs to automatically track search queries and cases. Alerts can be sent to your inbox or server."
+redirect_from: "/help/api/rest/v4/alerts/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/alerts/"
+---
+
+<p class="lead">Use these APIs to create, modify, list, and delete search and docket alerts in our system.</p>
+
+Once configured, alerts can notify you by email or with a [webhook event sent to your server][webhooks].
+
+This page focuses on the alerts API itself. To learn more about alerts generally, read the alert documentation.
+
+[Learn About Alerts](https://www.courtlistener.com/help/alerts/){button}
+
+[webhooks]: webhooks.md
+
+## Search Alerts
+`/api/rest/v4/alerts/`
+
+Search Alerts update you when there is new information in our search engine.
+
+This system scales to support thousands or even millions of alerts, allowing organizations to stay updated about numerous topics. This is a powerful system when used with [webhooks][webhooks].
+
+Search alerts have three required fields and one optional field:
+
+- **`name`** — A human-friendly name for the alert.
+- **`query`** — Search parameters you get from the front end, as a string.
+- **`rate`** — How frequently you want to receive email updates. Webhook events are always sent in real time. This field accepts the following values:
+  - `rt` — Real time
+  - `dly` — Daily
+  - `wly` — Weekly
+  - `mly` — Monthly
+- **`alert_type`** — This is a required field for RECAP Search Alerts, but it is ignored for other types. When used with RECAP Search alerts, this field specifies whether you want alerts for each new case matching the query or for both new cases and new filings. For notifications on cases only, use the `d` type (short for "dockets"). For notifications on both cases and filings, use the `r` type (meaning all of RECAP).
+
+To learn more about this API, make an HTTP `OPTIONS` request:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/alerts/"
+```
+
+### Example Usage
+
+Let's say we want to know about case law involving Apple Inc. On the front end, we search for "Apple Inc" (in quotes) and [get query parameters](/?q=%22Apple%20Inc%22&type=o) like:
+
+```
+q=%22Apple%20Inc%22&type=o
+```
+
+We can create that as an alert with an HTTP `POST` request:
+
+```
+curl -X POST \
+  --data 'name=Apple' \
+  --data 'query=q=%22Apple%20Inc%22&type=o' \
+  --data 'rate=rt' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/alerts/"
+```
+
+The response:
+
+```json
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v4/alerts/4839/",
+  "id": 4839,
+  "date_created": "2024-05-02T15:29:32.048912-07:00",
+  "date_modified": "2024-05-02T15:29:32.048929-07:00",
+  "date_last_hit": null,
+  "name": "Apple",
+  "query": "q=\"Apple Inc\"",
+  "rate": "rt",
+  "alert_type": "o",
+  "secret_key": "ybSBXwtDcMKI2SxPZDCEx02DSSUF7EEvx1CjOk4f"
+}
+```
+
+Search Alerts can be modified with HTTP `PATCH` requests. For example, to change the rate to `dly`:
+
+```
+curl -X PATCH \
+  --data 'rate=dly' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/alerts/4839/"
+```
+
+Search Alerts can be deleted with HTTP `DELETE` requests:
+
+```
+curl -X DELETE \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/alerts/4839/"
+```
+
+To list your alerts, send an HTTP `GET` request with no filters:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/alerts/"
+```
+
+## Docket Alerts
+`/api/rest/v4/docket-alerts/`
+
+Docket Alerts keep you updated about cases by sending notifications by email or webhook whenever there is new information in our system. Use this API to create, modify, list, and delete Docket Alerts.
+
+Docket Alerts are always sent as soon as an update is available. See [the help page on Docket Alerts][alerts-help] to learn more about how we get updates.
+
+Docket Alerts have two fields you can set:
+
+- **`docket`** — Required: The docket you want to subscribe to or unsubscribe from.
+
+- **`alert_type`** — Whether to subscribe or unsubscribe from the docket.
+
+  This field is part of [@recap.email][recap-email]'s auto-subscribe feature. If you are not using @recap.email or have auto-subscribe disabled, you can ignore this field.
+
+  If you are using @recap.email and have auto-subscribe enabled [in your profile][recap-email-profile], Docket Alerts will be automatically created for you as CourtListener receives notifications about cases. To permanently unsubscribe from a case for which you are receiving notifications from PACER, create an "Unsubscription" for the case.
+
+To learn more about this API, make an HTTP `OPTIONS` request:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/"
+```
+
+[alerts-help]: https://www.courtlistener.com/help/alerts/
+[recap-email]: https://www.courtlistener.com/help/recap/email/
+[recap-email-profile]: https://www.courtlistener.com/profile/recap-email/
+
+### Example Usage
+
+To create a Docket Alert, send a POST request with the `docket` ID you wish to subscribe to.
+
+This example subscribes to docket number 1:
+
+```
+curl -X POST \
+  --data 'docket=1' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/"
+```
+
+The response:
+
+```json
+{
+  "id": 133013,
+  "date_created": "2024-05-02T16:35:58.562617-07:00",
+  "date_modified": "2024-05-02T16:35:58.562629-07:00",
+  "date_last_hit": null,
+  "secret_key": "Xv6sg4xkarzyWdzABi84AyjzV3CslJs9Ldippq3s",
+  "alert_type": 1,
+  "docket": 1
+}
+```
+
+To unsubscribe from a docket, you can either delete the alert with an HTTP `DELETE` request:
+
+```
+curl -X DELETE \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/133013/"
+```
+
+Or, if you are using @recap.email and have auto-subscribe enabled, you can send an HTTP `PATCH` request to change it from a subscription (`alert_type=1`) to an unsubscription (`alert_type=0`):
+
+```
+curl -X PATCH \
+  --data 'alert_type=0' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/133013/"
+```
+
+To list your Docket Alerts, send an HTTP `GET` request with no filters:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/"
+```
+
+### Help with Relative Dates Queries
+
+Use relative dates in your queries to keep your searches and alerts dynamically up to date.
+
+[Learn More](https://www.courtlistener.com/help/relative-dates/){button}

--- a/wiki-exports/case-law-api.md
+++ b/wiki-exports/case-law-api.md
@@ -1,0 +1,346 @@
+---
+title: "Case Law APIs"
+description: "Use these APIs to gather data from our massive collection of case law."
+redirect_from: "/help/api/rest/v4/case-law/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/case-law/"
+---
+
+<p class="lead">Use these APIs to access our huge and growing database of case law.</p>
+
+To learn more about this collection, including the cases it has and how we get new data each day, see [Case Law Coverage][case-law-coverage].
+
+This data is organized into a number of objects. An overview of these objects is described in this section, and greater detail is provided for each, below.
+
+The four most important objects in this data set are courts, dockets, clusters, and opinions. Together, these hold most of the information from a single case:
+
+- `Court` objects hold information about thousands of courts in this country, including their name, abbreviation, founding date, and more. Every docket is joined to a court to indicate where the case was filed.
+
+- `Docket` objects hold metadata about the case like the date it was initiated or terminated, the docket number, and more. Every cluster is joined to a docket.
+
+- `Cluster` objects group together opinions when a panel hears a case and there is more than one decision, such as a dissent, concurrence, etc. Clusters are an abstraction we created. Every opinion is joined to a cluster.
+
+- `Opinion` objects contain the text of the decision and the metadata related to the individual panel member that wrote it.
+
+Putting this all together, dockets are filed in particular courts and contain clusters of opinions.
+
+If you are looking for a particular piece of metadata, you will find it at the lowest object from the list above where it would not be repeated in the database.
+
+For example, you *could* make the docket number a field of the opinion object. This would be fine until you had more than one opinion in a cluster, or more than one cluster joined to a docket. When that happened, you would wind up repeating the docket number value in each opinion object. Instead, if you make it a field of the docket object, you only have to save it to one place: The docket that binds together the clusters and opinions.
+
+Another example is the opinion text. You *could* make it a field of the cluster, say, but, again, that wouldn't work, since it wouldn't be clear which opinion the text was a part of in a case with a dissent, concurrence, and majority opinion.
+
+There are two other objects in the case law database:
+
+- **Citation** objects link together which opinion objects cite each other. For more information, see the [Citation help page][citation-api].
+- **Parenthetical** objects are extracted from the opinion text when a decision explains a citation it relies on as authority. These are not yet available in an API (see [parentheticals issue on GitHub][parentheticals-issue]), but are available as bulk data.
+
+[case-law-coverage]: https://www.courtlistener.com/help/coverage/opinions/
+[citation-api]: citation-api.md
+[parentheticals-issue]: https://github.com/freelawproject/courtlistener/issues/4082
+
+## The APIs
+
+### Dockets
+`/api/rest/v4/dockets/`
+
+`Docket` objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+
+In our case law database, dockets sit above `Opinion Clusters`. In our oral argument database, they sit above `Audio` objects.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/"
+```
+
+To look up a particular docket, use its ID:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/4214664/"
+```
+
+The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+
+```json
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v4/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/v4/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/v4/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/v4/tag/1316/"
+  ],
+  "panel": []
+}
+```
+
+The name of a docket can change in response to the outside world, but the names of clusters do not change. Therefore, we have `case_name` fields on both the docket and the cluster.
+
+For example, a suit filed against the EPA administrator might be captioned *Petroleum Co. v. Regan*. That would go into the case name fields of the docket and any decisions that were issued. But if the administrator resigns before the case is resolved, the docket would get a new case name, *Petroleum Co. v. New Administrator*, while the case name fields on the clusters would not change.
+
+For more information, see the [advanced help on case names][case-names-help].
+
+[case-names-help]: field-help.md#case-names
+
+### Clusters
+`/api/rest/v4/clusters/`
+
+This is a major API that provides the millions of `Opinion Clusters` that are available on CourtListener.
+
+As with all other APIs, you can look up the field descriptions, filtering, ordering, and rendering options by making an `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/clusters/"
+```
+
+A few notes:
+
+- The `id` field of the cluster is used in case law URLs on CourtListener.
+
+- The `sub_opinions` field provides a list of the opinions that are linked to each cluster.
+
+- The `citations` field will contain a list of parallel citations for the cluster. See the [citation API][citation-api] for details.
+
+- There are several fields with judge information, such as `judges`, `panel`, `non_participating_judges`, etc. Some of these fields contain strings and others are linked to records in our [judge API][judge-api]. When we are able to normalize a judge's name into a record in the judge database, we do so. If not, we store their name in a string field for later normalization.
+
+[judge-api]: judge-api.md
+
+### Opinions
+`/api/rest/v4/opinions/`
+
+This API contains the text and other metadata about specific decisions.
+
+As with all other APIs, you can look up the field descriptions, filtering, ordering, and rendering options by making an `OPTIONS` request:
+
+> [!WARNING]
+> **Listen Up:** When retrieving opinion text, prefer the `html_with_citations` field instead of `plain_text`. The `html_with_citations` field contains the raw text of the decision, and is the most reliable field for most purposes.
+>
+> Opinion URLs on the CourtListener website contain a `cluster_id`, not an `opinion_id`. If you want to look up a case using that ID, query the Cluster API. See [Finding a Case by URL](#finding-a-case-by-url), below.
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions/"
+```
+
+A few notes:
+
+- The `type` field indicates whether the item is a concurrence, lead opinion, dissent, etc. The values provided for this field are proceeded by numbers so that if they are sorted, they will also be sorted from highest priority to lowest. The most common type of opinion is a "Combined Opinion" this is what we label any opinion that either cannot be identified as a specific type, or that contains more than one type.
+
+- The `download_url` field contains the original location where we scraped the decision. Many courts do not maintain [Cool URIs][cool-uris], so this field is often unreliable.
+
+- The `local_path` field contains the path to the binary file for the decision, if we have one. To use it, see the [advanced help on file download fields][file-downloads-help].
+
+- The `opinions_cited` field has a list of other opinions cited by the one you are reviewing.
+
+- The `ordering_key` field indicates the order of opinions within a cluster. This field is only populated for opinions ingested from Harvard or Columbia sources.
+
+- In general, the best field for the text of a decision is `html_with_citations`, in which each citation has been identified and linked. This is the field that is used in the CourtListener website.
+
+    The following fields are used to generate `html_with_citations`, but are not usually recommended:
+
+    - `html_columbia` will be populated if we got the content from the Columbia collaboration.
+    - `html_lawbox` will be populated if we got the content from the Lawbox donation.
+    - `xml_harvard` will be populated if the source was Harvard's Caselaw Access Project. This field has a lot of data but is not always perfect due to being created by OCR.
+    - `html_anon_2020` will be populated if we got the content from our anonymous source in 2020.
+    - `html` will be populated if we got the opinion from a court's website as a Word Perfect or HTML document, or if we got the opinion from Resource.org, which provided HTML documents.
+    - `plain_text` will be populated if we got the opinion from a court's website as a PDF or Microsoft Word document.
+
+    Whichever field you choose, please use [Field Selection][field-selection] to omit unnecessary fields. This will make your system faster and ease the load on ours.
+
+[cool-uris]: https://www.w3.org/Provider/Style/URI.html
+[file-downloads-help]: field-help.md#file-download-fields
+[field-selection]: rest-api.md#field-selection
+
+### Courts
+`/api/rest/v4/courts/`
+
+This API contains data about the courts we have in our database, and is joined into nearly every other API so that you can know where an event happened, a judge worked, etc.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+You can generally cache this API. It does not change often.
+
+## API Examples
+
+### Filtering to Opinions in a Court
+
+Opinions are joined to clusters, which join to dockets, and finally to courts. Therefore, one way to get opinions in a specific court is to use a filter like `cluster__docket__court=XYZ` (note the use of double underscores):
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions/?cluster__docket__court=scotus"
+```
+
+That returns:
+
+```json
+{
+  "next": "https://www.courtlistener.com/api/rest/v4/opinions/?cluster__docket__court=scotus&cursor=cD0xMDUxNjI5NA%3D%3D",
+  "previous": null,
+  "results": [
+      {
+          "resource_uri": "https://www.courtlistener.com/api/rest/v4/opinions/9973155/",
+          "id": 9973155,
+    ...
+```
+
+Such an approach is fine if all you want is the opinion object, but often you'll want the docket and the cluster too.
+
+In that case, start by getting the dockets with a filter like `court=XYZ`, then use the IDs in those dockets to get clusters and opinions.
+
+For example, this gets the dockets from SCOTUS:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/?court=scotus"
+```
+
+The first result contains a `clusters` key like:
+
+```json
+"clusters": [
+    "https://www.courtlistener.com/api/rest/v4/clusters/9502621/"
+],
+```
+
+So we can simply get that URL:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/clusters/9502621/"
+```
+
+That returns a cluster, which has the following keys:
+
+```json
+"docket": "https://www.courtlistener.com/api/rest/v4/dockets/68533094/",
+"sub_opinions": [
+    "https://www.courtlistener.com/api/rest/v4/opinions/9969234/"
+],
+```
+
+Finally, GET the links in the `sub_opinions` field to have the complete object:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions/9969234/"
+```
+
+### Filtering by Docket Number
+
+If you know a docket number, you can use it to look up a docket, cluster, or opinion:
+
+A docket by docket number:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/?docket_number=23A994"
+```
+
+A cluster by docket number:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/clusters/?docket__docket_number=23A994"
+```
+
+An opinion by docket number:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions/?cluster__docket__docket_number=23A994"
+```
+
+Docket numbers are not unique, so you'll want to add a court filter too:
+
+- For dockets, add: `&court=scotus`
+- For clusters, add: `&docket__court=scotus`
+- For opinions, add: `&cluster__docket__court=scotus`
+
+You may also find the [search API][search-api] helpful, since it will do fuzzy docket searches.
+
+### Making a Custom Case Law Corpus
+
+A common need by empirical researchers is a collection of case law about a particular topic. To build such a corpus, use the [search API][search-api] to identify cases and use these APIs to download them.
+
+[search-api]: search-api.md
+
+### Finding a Case by URL
+
+If you know the URL of a case, you can find it in the cluster API. For example, *Obergefell v. Hodges* has this URL, with cluster ID `2812209`:
+
+```
+https://www.courtlistener.com/opinion/2812209/obergefell-v-hodges/
+```
+
+This case can be found in the cluster API using that same ID:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/clusters/2812209/"
+```
+
+Opinion IDs do not reliably match cluster IDs.

--- a/wiki-exports/citation-api.md
+++ b/wiki-exports/citation-api.md
@@ -1,0 +1,138 @@
+---
+title: "Legal Citation APIs"
+description: "Use these APIs to understand the citation graph in the CourtListener case law database."
+redirect_from: "/help/api/rest/v4/citations/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/citations/"
+---
+
+<p class="lead">Use these APIs to analyze and query the network of citations between legal cases.</p>
+
+These APIs are powered by [Eyecite][eyecite], our tool for identifying citations in legal text. Using that tool, we have identified millions of citations between legal decisions, which you can query using these APIs.
+
+These citations power our visualizations, tables of authorities, citation search, and more.
+
+To look up specific citations, see our [citation lookup and verification API][citation-lookup-api].
+
+[eyecite]: https://free.law/open-source-tools#eyecite
+[citation-lookup-api]: citation-lookup-api.md
+
+## Opinions Cited/Citing API
+`/api/rest/v4/opinions-cited/`
+
+This endpoint provides an interface into the citation graph that CourtListener provides between opinions in [our case law database][case-law-api].
+
+You can look up the field descriptions, filtering, ordering, and rendering options by making an `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions-cited/"
+```
+
+That query will return the following filter options:
+
+```json
+{
+  "id": {
+    "type": "NumberRangeFilter",
+    "lookup_types": [
+      "exact",
+      "gte",
+      "gt",
+      "lte",
+      "lt",
+      "range"
+    ]
+  },
+  "citing_opinion": {
+    "type": "RelatedFilter",
+    "lookup_types": "See available filters for 'Opinions'"
+  },
+  "cited_opinion": {
+    "type": "RelatedFilter",
+    "lookup_types": "See available filters for 'Opinions'"
+  }
+}
+```
+
+To understand `RelatedFilters`, see our [filtering documentation][filtering].
+
+These filters allow you to filter to the opinions that an opinion cites (its "Authorities" or backward citations) or the later opinions that cite it (forward citations).
+
+For example, opinion `2812209` is the decision in *Obergefell v. Hodges*. To see what it cites:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions-cited/?citing_opinion=2812209"
+```
+
+Which returns (in part):
+
+```json
+{
+  "count": 75,
+  "next": "https://www.courtlistener.com/api/rest/v4/opinions-cited/?citing_opinion=2812209&cursor=cD0xMjA5NjAyMg%3D%3D",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v4/opinions-cited/167909003/",
+      "id": 167909003,
+      "citing_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/2812209/",
+      "cited_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/96405/",
+      "depth": 1
+    },
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v4/opinions-cited/167909002/",
+      "id": 167909002,
+      "citing_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/2812209/",
+      "cited_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/2264443/",
+      "depth": 1
+    },
+...
+```
+
+To go the other direction, and see what cites *Obergefell*, use the `cited_opinion` parameter instead:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/opinions-cited/?cited_opinion=2812209"
+```
+
+That returns (in part):
+
+```json
+{
+  "count": 403,
+  "next": "https://www.courtlistener.com/api/rest/v4/opinions-cited/?cited_opinion=2812209&page=2",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v4/opinions-cited/213931728/",
+      "id": 213931728,
+      "citing_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/10008139/",
+      "cited_opinion": "https://www.courtlistener.com/api/rest/v4/opinions/2812209/",
+      "depth": 4
+    },
+...
+```
+
+Note that:
+
+- The `depth` field indicates how many times the cited opinion is referenced by the citing opinion. In the example above opinion `10008139` references *Obergefell* (`2812209`) four times. This may indicate that *Obergefell* is an important authority for `10008139`.
+
+- Opinions are often published in more than one book or online resource. Therefore, many opinions have more than one citation to them. These are called "parallel citations." We do not have every parallel citation for every decision. This can impact the accuracy of the graph.
+
+- Frequently, we backfill citations, adding a new citation to an older case. When we do this, we do not always re-run our citation linking utility. This means that any later cases that referred to the newly-added citation may not be linked to it for some time.
+
+## Bulk Data
+
+The citation graph is exported once a month as part of our [bulk data system][bulk-data-citations].
+
+If you want to analyze the citation network, that is often the best place to begin.
+
+[case-law-api]: case-law-api.md
+[filtering]: rest-api.md#filtering
+[bulk-data-citations]: https://www.courtlistener.com/help/api/bulk-data/#citation-data

--- a/wiki-exports/citation-lookup-api.md
+++ b/wiki-exports/citation-lookup-api.md
@@ -1,0 +1,288 @@
+---
+title: "Citation Lookup and Verification API"
+description: "Trained on over 50 million citations going back centuries, our citation lookup API can translate a citation you have to a link on our site, or it can serve as a guardrail to help identify and prevent hallucinated citations."
+redirect_from: "/help/api/rest/v4/citation-lookup/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/citation-lookup/"
+data_source: "https://www.courtlistener.com/api/rest/v4/wiki-data/"
+data_source_cache: 86400
+---
+
+## Overview
+`/api/rest/v4/citation-lookup/`
+
+<p class="lead">Use this API to look up citations in CourtListener's database of [[ citation_count ]] citations.</p>
+
+This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
+
+This API uses [Eyecite][eyecite], a tool we developed with [Harvard Library Innovation Lab][lil] to parse legal citations. To develop Eyecite, we analyzed more than 50 million citations going back more than two centuries. We believe we have identified every reporter abbreviation in American case law and that there is no case law citation that Eyecite cannot properly parse and interpret.
+
+This API uses the same authentication and serialization methods as the rest of the CourtListener APIs. It does not support filtering, pagination, ordering, or field selection.
+
+[eyecite]: https://free.law/open-source-tools#eyecite
+[lil]: https://lil.law.harvard.edu/
+
+## Usage
+
+The simplest way to query this API is to send it a blob of text. If the text does not have any citations, it will simply return an empty JSON array:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=Put some text here'
+```
+
+Returns:
+
+```json
+[]
+```
+
+If the text contains valid citations, it will return a list of the citations, analyzing each. This example contains a single citation that is found:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=Obergefell v. Hodges (576 U.S. 644) established the right to marriage among same-sex couples'
+```
+
+Which would return:
+
+```json
+[
+  {
+    "citation": "576 U.S. 644",
+    "normalized_citations": [
+      "576 U.S. 644"
+    ],
+    "start_index": 22,
+    "end_index": 34,
+    "status": 200,
+    "error_message": "",
+    "clusters": [...one large cluster object here...]
+  }
+]
+```
+
+If you have the volume, reporter, and page for a citation, you can look it up as follows:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'volume=576' \
+  --data 'reporter=U.S.' \
+  --data 'page=644'
+```
+
+That returns the same response as above.
+
+## Field Definitions
+
+The fields returned by this API are:
+
+- `citation` — The citation you looked up. If you supplied the volume, reporter, and page, they will appear here as a single space-separated string.
+
+- `normalized_citations` — Normalized versions of your citation if it contains a typo or if it is not the canonical (standard) abbreviation for a reporter. If the citation queried is ambiguous, more than one item can appear in this field. See examples below.
+
+- `start_index` & `end_index` — These fields indicate the start and end positions where a citation is found in the text queried.
+
+- `status` — indicates the outcome of a citation lookup. Its values correspond to HTTP status codes and can have one of five values:
+
+    - `200 (OK)` — We found a citation, it was valid, and we were able to look it up in CourtListener.
+    - `404 (Not Found)` — We found a citation, it was valid, but we were unable to look it up in CourtListener.
+    - `400 (Bad Request)` — We found something that looks like a citation, but the reporter in the citation wasn't in our system (e.g., "33 Umbrella 422" looks like a citation, but is not valid).
+    - `300 (Multiple Choices)` — We found a valid citation, it was valid, but it matched more than one item in CourtListener.
+    - `429 (Too Many Requests)` — This API will only lookup [[ citation_lookup.max_per_request ]] citations in a single request. Any citations after that point will have this status. They will be identified but will not be looked up. (See throttles below)
+
+- `error_message` — This field will contain additional details about any problems the lookup encounters.
+
+- `clusters` — This is a list of the CourtListener [cluster objects][cluster-endpoint] that match the citation in your query. This key will contain multiple values when a citation matches more than one legal decision. This can happen when a citation is ambiguous or when multiple decisions are on a single page in a printed book (and thus share the same citation).
+
+[cluster-endpoint]: case-law-api.md#clusters
+
+## Limitations & Throttles
+
+This API has four limitations on how much it can be used:
+
+1. The performance of this API is affected by the number of citations it has to look up. Therefore, it is throttled to [[ citation_lookup.throttle_count ]] valid citations per [[ citation_lookup.throttle_period ]]. If you are below this throttle, you will be able to send a request to the API. If a request pushes you beyond this throttle, further requests will be denied. When your request is denied, the API will respond with a 429 HTTP code and a JSON object. The JSON object will contain a `wait_util` key that uses an ISO-8601 datetime to indicate when you will be able to make your next request.
+
+2. The API will look up at most [[ citation_lookup.max_per_request ]] citations in any single request. Any citations past that point will be parsed, but not matched to the CourtListener database. The `status` key of such citations will be 429, indicating "Too many citations requested." See examples below for details.
+
+3. Text lookup requests to this API can only contain 64,000 characters at a time. Requests with more than this amount will be blocked for security. This is about 50 pages of legal content.
+
+4. To prevent denial of service attacks that do not contain any citations, this API has the same request throttle rates as the other CourtListener APIs. This way, even requests that do not contain citations can be throttled. (Most users will never encounter this throttle.)
+
+A few other limitations to be aware of include:
+
+1. This API does not look up statutes, law journals, id, or supra citations. If you wish to match such citations, please use Eyecite directly.
+
+2. This API will not attempt to match citations without volume numbers or page numbers (e.g. 22 U.S. ___).
+
+## API Examples
+
+### Basic, Valid Lookup
+
+The following is a basic lookup using the `text` parameter and a block of text:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=Obergefell v. Hodges (576 U.S. 644) established the right to marriage among same-sex couples'
+[
+  {
+    "citation": "576 U.S. 644",
+    "normalized_citations": [
+      "576 U.S. 644"
+    ],
+    "start_index": 22,
+    "end_index": 34,
+    "status": 200,
+    "error_message": "",
+    "clusters": [...one cluster here...]
+  }
+]
+```
+
+### Failed Lookup
+
+This query uses the volume-reporter-page triad, but fails because the citation does not exist:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'volume=1' \
+  --data 'reporter=U.S.' \
+  --data 'page=200'
+[
+  {
+    "citation": "1 U.S. 200",
+    "normalized_citations": [
+      "1 U.S. 200"
+    ],
+    "start_index": 0,
+    "end_index": 10,
+    "status": 404,
+    "error_message": "Citation not found: '1 U.S. 200'",
+    "clusters": []
+  }
+]
+```
+
+Note that:
+
+1. The `status` field is set to 404 indicating the citation was not found.
+
+2. The `start_index` is 0, and the `end_index` is the length of the citation including space separators.
+
+3. The `error_message` field provides details of the error.
+
+### Throttled Citations
+
+If your request contains more than [[ citation_lookup.max_per_request ]] citations, the 6th and subsequent citations will be returned with 429 `status` fields:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=Imagine a very long blob here, with 6 citations.'
+[
+  ...5 citations would appear here, then the 6th and subsequent citations would be...
+  {
+    "citation": "576 U.S. 644",
+    "normalized_citations": [
+      "576 U.S. 644"
+    ],
+    "start_index": 10002,
+    "end_index": 10013,
+    "status": 429,
+    "error_message": "Too many citations requested.",
+    "clusters": []
+  }
+]
+```
+
+Note that:
+
+1. All citations will be parsed and will provide normalized versions and index locations.
+
+2. Citations after the [[ citation_lookup.max_per_request ]]th will return a `status` of 429, indicating "Too many citations requested."
+
+3. A follow-up query that begins on the 6th `start_index` (in this case number 10002) will look up the next [[ citation_lookup.max_per_request ]] items.
+
+### Typoed/Non-Canonical Reporter Abbreviation
+
+If you query the non-canonical reporter abbreviation or if your reporter contains a known typo, we will provide the corrected citation in the `normalized_citations` key. The following example looks up a citation using "US" instead of the correct "U.S.":
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=576 US 644'
+[
+  {
+    "citation": "576 US 644",
+    "normalized_citations": [
+      "576 U.S. 644"
+    ],
+    "start_index": 1,
+    "end_index": 11,
+    "status": 200,
+    "error_message": "",
+    "clusters": [...one cluster here...]
+  }
+]
+```
+
+### Ambiguous Citation
+
+This lookup is for an ambiguous citation abbreviated as "H." This reporter abbreviation can refer to Handy's Ohio Reports, the Hawaii Reports, or Hill's New York Reports. Only two of those reporter series have cases at the queried volume and page number, so the API returns two possible matches for the citation:
+
+```
+curl -X POST "https://www.courtlistener.com/api/rest/v4/citation-lookup/" \
+  --header 'Authorization: Token <your-token-here>' \
+  --data 'text=1 H. 150'
+[
+  {
+    "citation": "1 H. 150",
+    "normalized_citations": [
+      "1 Handy 150",
+      "1 Haw. 150",
+      "1 Hill 150"
+    ],
+    "start_index": 0,
+    "end_index": 8,
+    "status": 300,
+    "clusters": [
+      {
+        ...
+        "citations": [{
+          "volume": 1,
+          "reporter": "Handy",
+          "page": "150",
+          "type": 2
+        }],
+       ...
+       "case_name": "Louis v. Steamboat Buckeye",
+       ...
+      },
+      {
+        ...
+        "citations": [{
+          "volume": 1,
+          "reporter": "Haw.",
+          "page": "150",
+          "type": 2
+        }],
+        ...
+        "case_name": "Fell v. Parke",
+        ...
+      }
+    ]
+  }
+]
+```
+
+Note that:
+
+1. The `normalized_citations` field returned three possible values for the ambiguous query.
+
+2. The `status` field returned a 300 code, indicating "Multiple Choices."
+
+3. There are two different objects returned in the `clusters` field.

--- a/wiki-exports/field-help.md
+++ b/wiki-exports/field-help.md
@@ -1,0 +1,77 @@
+---
+title: "Advanced Help for API Fields"
+description: "Learn more about specific fields in the CourtListener API."
+redirect_from: "/help/api/rest/v4/fields/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/field-help/"
+---
+
+<p class="lead">Some fields in the API can be complicated. This page goes into greater detail about this topic.</p>
+
+## Fields
+
+### Case Names
+
+Case names are a complicated topic, and there are a few common misconceptions about them:
+
+1. **Case names are not unique.** There's nothing stopping a court from using *Johnson v. State* every time a person named Johnson sues the State. Indeed, this is common.
+
+2. **Case names are not stable.** Many cases begin their lives by suing the governor or the attorney general. But these people change as a result of elections or appointments, and so the names of these cases often change too.
+
+3. **Case names don't always contain v.** Instead, many cases start with *In Re* or other abbreviations.
+
+We've done our best to normalize case names wherever we can, following Blue Book conventions. Some things we regularly do include:
+
+1. We normalize all the different ways people write "United States" (U.S.A., United States of America, U.S., etc.) All of these variations simply become "United States", as the Blue Book requires.
+
+2. We remove some abbreviations, like *Et al*.
+
+3. We replace any instance of vs. with v.
+
+4. We do our best to make the case names Title Case rather than UPPERCASE, as many courts publish them.
+
+The result of all this work is that we have pretty good case names.
+
+In the API, you'll see case names in a variety of places due to the fact that they can change over time. For example, there are `case_name` fields on the `Docket` object and also on the `Opinion Cluster` objects. In almost all instances, these values are the same but some cases have different values for the `Docket` than for an `Opinion Cluster`, so we keep this data in duplicate.
+
+Case names can also vary considerably in length, and we've identified three different types of case names:
+
+1. `case_name`: This is a typical case name that can be used in almost all references. An example might be *Roe v. Wade*.
+
+2. `case_name_short`: This is a shortened one or two word case name that can be used in legal writing after the standard case name has been provided by the author. An example of this might be simply *Roe* used, "As was stated in *Roe*..."
+
+3. `case_name_full`: This is the full list of plaintiffs and defendants in a case, sometimes going on for hundreds of words, and often including titles or other information. For example: *Roe Et Al v. Wade, District Attorney of Dallas County*.
+
+All cases have at least one of these values, many have two values, and some have all three. A `case_name_short` was generated algorithmically for every case possible, but about 40% of cases were too complicated for our program to process and so they were left blank. Editors have ensured that every Supreme Court case from 1945 to 2018 has a `case_name_short` value.
+
+`case_name` is available for the majority of cases, except those that were imported from Resource.org, which only provided `case_name_full` values. When that happened, there was no way for us to condense a `case_name_full`, so until an editor is available to review them, they will lack this value. All cases have either a `case_name` or a `case_name_full` value.
+
+Our advice is to use a `case_name` if it is available and to fall back on the `case_name_full` if it is not. If you are interested in sponsoring trained humans to improve this data, please [get in touch][contact].
+
+### The `absolute_url` Field
+
+The `absolute_url` field shows the URL where a resource can be seen live on the site. It is absolute in the sense that it should never change and will always be backwards compatible if changes are ever needed.
+
+In some cases you might start with a URL from CourtListener, and you might want to look up the item in the API. Generally, CourtListener URLs are designed to contain an ID that can be used in the API to look it up, following a pattern like:
+
+```
+/$type/$id/$name-of-the-case/
+```
+
+There are three sections:
+
+1. **$type**: This is the type of object that has been returned, for example, "docket" indicates that you have gotten a docket as your result.
+
+2. **$id**: This is a numeric ID for the document. This value increments as we add content to the system. Note that due to deletions and modifications the numeric IDs are not always sequential, but they will never be duplicated within a document type.
+
+3. **$name-of-the-case**: This is the "[slug][slug-wiki]" of the document, and generally mirrors its case name. This value can change if we clean up a case name, but provided it is not omitted completely, this part of the URL can be any value without affecting the page that is loaded.
+
+   Put another way, we load pages based on the `$id` and `$type`, not by the name of the case.
+
+### File Download Fields
+
+API responses will give you the URL path to a resource such as a PDF or MP3, but not the domain. These are often in a field named `local_path` or similar.
+
+To download a resource, create a full URL by concatenating the path from the API response with `https://storage.courtlistener.com/`.
+
+[contact]: https://www.courtlistener.com/contact/
+[slug-wiki]: https://en.wikipedia.org/wiki/Slug_%28publishing%29

--- a/wiki-exports/financial-disclosure-api.md
+++ b/wiki-exports/financial-disclosure-api.md
@@ -1,0 +1,261 @@
+---
+title: "Financial Disclosures API"
+description: "We collected millions of disclosure records from thousands of federal judges. Use these APIs to query and study this immense dataset."
+redirect_from: "/help/api/rest/v4/financial-disclosures/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/financial-disclosures/"
+---
+
+<p class="lead">Use these APIs to work with financial disclosure records of current and former federal judges.</p>
+
+This data was collected from senate records and information requests we sent to the federal judiciary. You can learn more about which disclosures are included and the limitations of these APIs on [our coverage page for financial disclosures][fd-coverage].
+
+Judicial officers and certain judicial employees in the United States are required to file financial disclosure reports by [Title I of the Ethics in Government Act of 1978][ethics-act]. The Act requires that designated federal officials publicly disclose their personal financial interests to ensure confidence in the integrity of the federal government by demonstrating that they are able to carry out their duties without compromising the public trust.
+
+These APIs were used by the Wall Street Journal in [their 17-part expose][wsj-expose] about the hidden conflicts of federal judges. That led to Congress passing the Courthouse Ethics and Transparency Act to put this information online. It was also used by ProPublica in [their Pulitzer prize winning reporting][propublica-thomas] about failures to disclose gifts and perks.
+
+This data is updated in partnership with organizations using it. Please [get in touch][contact] if you would like to work together to process and ingest the latest disclosure records.
+
+[fd-coverage]: https://www.courtlistener.com/help/coverage/financial-disclosures/
+[ethics-act]: https://www.law.cornell.edu/uscode/text/5/13103
+[wsj-expose]: https://www.wsj.com/articles/131-federal-judges-broke-the-law-by-hearing-cases-where-they-had-a-financial-interest-11632834421
+[propublica-thomas]: https://www.propublica.org/article/clarence-thomas-scotus-undisclosed-luxury-travel-gifts-crow
+[contact]: https://www.courtlistener.com/contact/
+
+## Available APIs
+
+The Ethics in Government Act details the types of information required, and prescribes the general format and procedures for the reports themselves.
+
+The APIs described below mirror the Act's language, with APIs corresponding to each required disclosure type.
+
+### Disclosures
+`/api/rest/v4/financial-disclosures/`
+
+This API contains information about the main document itself and is the link between the other financial disclosure endpoints and the judges in our system.
+
+### Investments
+`/api/rest/v4/investments/`
+
+This API lists the source and type of investment income held by a judge, including dividends, rents, interest, capital gains, or income from qualified or excepted trusts.
+
+### Positions
+`/api/rest/v4/disclosure-positions/`
+
+This API lists the positions held as an officer, director, trustee, general partner, proprietor, representative, executor, employee, or consultant of any corporation, company, firm, partnership, trust, or other business enterprise, any nonprofit organization, any labor organization, or any educational or other institution other than the United States.
+
+### Agreements
+`/api/rest/v4/agreements/`
+
+This API lists any agreements or arrangements of the filer in existence at any time during the reporting period.
+
+### Non-Investment Income
+`/api/rest/v4/non-investment-incomes/`
+
+This API lists the source, type, and the amount or value of earned or other non-investment income aggregating $200 or more from any one source that is received during the reporting period.
+
+### Non-Investment Income (Spouse)
+`/api/rest/v4/spouse-incomes/`
+
+This API lists the source and type earned of non-investment income from the spouse of the filer.
+
+### Reimbursements
+`/api/rest/v4/reimbursements/`
+
+This API lists the source identity and description (including travel locations, dates, and nature of expenses provided) of any travel-related reimbursements aggregating more than $415 in value that are received by the filer from one source during the reporting period.
+
+### Gifts
+`/api/rest/v4/gifts/`
+
+This API lists the source, a brief description, and the value of all gifts aggregating more than $415 in value that are received by the filer during the reporting period from any one source.
+
+### Debts
+`/api/rest/v4/debts/`
+
+All liabilities specified by that section that are owed during the period beginning on January 1 of the preceding calendar year and ending fewer than 31 days before the date on which the report is filed.
+
+## Fields
+
+### Understanding the Fields
+
+Like most of our APIs, field definitions can be obtained by sending an HTTP `OPTIONS` request to any of the APIs. For example, this request, piped through [`jq`][jq], shows you the fields of the Gifts API:
+
+```
+curl -X OPTIONS "https://www.courtlistener.com/api/rest/v4/gifts/" \
+    | jq '.actions.POST'
+
+{
+  "resource_uri": {
+    "type": "field",
+    "required": false,
+    "read_only": true,
+    "label": "Resource uri"
+  },
+  "id": {
+    "type": "field",
+    "required": false,
+    "read_only": true,
+    "label": "Id"
+  },
+  "date_created": {
+    "type": "datetime",
+    "required": false,
+    "read_only": true,
+    "label": "Date created",
+    "help_text": "The moment when the item was created."
+  },
+  "date_modified": {
+    "type": "datetime",
+    "required": false,
+    "read_only": true,
+    "label": "Date modified",
+    "help_text": "The last moment when the item was modified. A value in year 1750 indicates the value is unknown"
+  },
+  "source": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Source",
+    "help_text": "Source of the judicial gift. (ex. Alta Ski Area)."
+  },
+  "description": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Description",
+    "help_text": "Description of the gift (ex. Season Pass)."
+  },
+  "value": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Value",
+    "help_text": "Value of the judicial gift, (ex. $1,199.00)"
+  },
+  "redacted": {
+    "type": "boolean",
+    "required": false,
+    "read_only": false,
+    "label": "Redacted",
+    "help_text": "Does the gift row contain redaction(s)?"
+  },
+  "financial_disclosure": {
+    "type": "field",
+    "required": true,
+    "read_only": false,
+    "label": "Financial disclosure",
+    "help_text": "The financial disclosure associated with this gift."
+  }
+}
+```
+
+Note that each field has the following attributes:
+
+- **`type`**: Indicating the object type for the field.
+- **`required`**: Indicating whether the field can have null values. Note that string fields will be blank instead of null.
+- **`read_only`**: Indicates whether the field can be updated by users (this does not apply to read-only APIs like the financial disclosure APIs).
+- **`label`**: This is a human-readable form for the field's name.
+- **`help_text`**: This explains the meaning of the field.
+
+[jq]: https://github.com/jqlang/jq
+
+### Redactions
+
+For security reasons, filers can redact information on their disclosure forms. When a line in a disclosure contains a redaction, we will attempt to set the `redacted` field on that row to `True`. This is your hint that you may want to investigate that row more carefully.
+
+This field can be used as a filter. For example, here are all the investments with redacted information:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/investments/?redacted=True" \
+  --header 'Authorization: Token <your-token-here>'
+{
+  "next": "https://www.courtlistener.com/api/rest/v4/investments/?page=2&redacted=True&cursor=cD0xMjA5NjAyMg%3D%3D",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v4/investments/5385644/",
+      "id": 5385644,
+      "date_created": "2023-04-17T11:03:22.404170-07:00",
+      "date_modified": "2023-04-17T11:03:22.404185-07:00",
+      "page_number": 4,
+      "description": "Common Stock",
+      "redacted": true,
+      "income_during_reporting_period_code": "G",
+      "income_during_reporting_period_type": "Dividend",
+      "gross_value_code": "P2",
+      "gross_value_method": "T",
+      "transaction_during_reporting_period": "",
+      "transaction_date_raw": "",
+      "transaction_date": null,
+      "transaction_value_code": "",
+      "transaction_gain_code": "",
+      "transaction_partner": "",
+      "has_inferred_values": false,
+      "financial_disclosure": "https://www.courtlistener.com/api/rest/v4/financial-disclosures/34187/"
+    },
+    ...
+  ]
+}
+```
+
+### Value Codes
+
+Several APIs, including `Investments`, `Debts`, and `Gifts` use form-based value codes to indicate monetary ranges instead of exact values. For example, the letter "J" indicates a value of $1-15,000.
+
+Place an `OPTIONS` request to these endpoints to learn the values of those fields or look in a PDF filing to see the key.
+
+Regrettably, these fields have not been updated by the judiciary in many years, so the highest value code only goes up to $50,000,000. For some judges, this may not be enough to accurately reflect their wealth.
+
+### Inferred Values
+
+`Investment` objects contain the field `has_inferred_values`. This field indicates that we inferred information about an investment based on the layout of the data in the disclosure form.
+
+For example, an investment could have been bought in Q1, while a dividend was paid out in Q2 before being sold in Q4. Often, after the first entry of the investment, later rows in the table are mostly blank. In this instance, we infer the values.
+
+The table below gives a brief example where we would infer that the blank cell below the cell for `AAPL` also refers to `AAPL`:
+
+| Description | Date | Type |
+|---|---|---|
+| AAPL | 2020-01-01 | Bought |
+| -- | 2020-02-01 | Sold |
+
+In this (slightly contrived) example our database would have two rows in the `Investment` table. The first would be for the purchase of the `AAPL` stock, and the second would be for the sale of it.
+
+## API Examples
+
+You can query for investments by stock name, transaction dates and even gross values. For example, the following query is for financial disclosures with individual investments valued above $50,000,000.00. Note that this uses a value code as explained in the general notes above:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/investments/?gross_value_code=P4&fields=investments" \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+Additionally, you could pinpoint gifts of individual judges when combining the gift database with our judicial database. The following query returns all reported gifts by the late [Ruth Bader Ginsburg][rbg] (her ID is 1213):
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/financial-disclosures/?person=1213&fields=gifts" \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+In 2024, we presented these APIs at the NICAR conference and created [many more examples][nicar-examples] you can explore.
+
+[rbg]: https://www.courtlistener.com/person/1213/ruth-bader-ginsburg/
+[nicar-examples]: https://github.com/freelawproject/talks/tree/main/talks/2024/march/NICAR/cracking_the_courts_panel/examples
+
+### Learn More
+
+The following references may help you learn more about these forms:
+
+1. [The official policies guiding financial disclosures][guide-vol02d]
+2. [The reporting instructions given to judges and judicial employees][reporting-instructions]
+3. [A GAO report on disclosures][gao-report]
+4. [The Ethics in Government Act establishing disclosure rules][ethics-bill]
+
+[guide-vol02d]: https://www.uscourts.gov/sites/default/files/guide-vol02d.pdf
+[reporting-instructions]: https://www.uscourts.gov/administration-policies/judiciary-financial-disclosure-reports
+[gao-report]: https://www.gao.gov/assets/gao-18-406.pdf
+[ethics-bill]: https://www.govtrack.us/congress/bills/95/s555
+
+### Security
+
+Please report any security or privacy concerns to [security@free.law][security-email].
+
+[security-email]: mailto:security@free.law

--- a/wiki-exports/judge-api.md
+++ b/wiki-exports/judge-api.md
@@ -1,0 +1,134 @@
+---
+title: "Judge and Justice API"
+description: "Use these APIs to query and analyze thousands of federal and state judges, including their biographical information, political affiliations, education and employment histories, judgeships, and more."
+redirect_from: "/help/api/rest/v4/judges/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/judges/"
+---
+
+<p class="lead">Use these APIs to query and analyze thousands of federal and state court judges.</p>
+
+This data set is person-centric. All data links back to a particular person.
+
+To learn more about this data, see [our page about it on Free.law][judges-db].
+
+The available APIs include:
+
+- Judges and Appointers
+- Positions Held
+- Political Affiliations
+- Educational Histories
+- ABA Ratings
+- Retention Events
+- Sources
+
+Other types of data are linked to this API and have their own documentation, including:
+
+- [Financial Disclosures][financial-disclosures]
+- [PACER Filings][pacer-api]
+- [Case Law][case-law-api]
+- [Oral Argument Audio][oral-argument-api]
+
+In life, people can serve various roles in the justice system. Therefore, this is not strictly a database of judges, but rather a database of *people* and the positions they hold.
+
+For example, [William Taft][taft] served as president, where he appointed justices, but he was also a Supreme Court justice himself. Therefore, he has a single "person" record in the API, he has one position record for his role as president, and another position record for his role as a justice.
+
+There are a number of "granularity" fields for dates. These are used to indicate how granular a corresponding date is. For example, if we know the year somebody died but not the month or day, we would put `2010-01-01` as the date of death, and set the date of death granularity field to `%Y`.
+
+This approach means that you can still — mostly — filter and sort by these date fields, but with an awareness that the data may be incomplete.
+
+[judges-db]: https://free.law/datasets#judges-db
+[financial-disclosures]: financial-disclosure-api.md
+[pacer-api]: pacer-api.md
+[case-law-api]: case-law-api.md
+[oral-argument-api]: oral-argument-api.md
+[taft]: https://www.courtlistener.com/person/26/william-howard-taft/
+
+## The APIs
+
+### People (Judges and Appointers)
+`/api/rest/v4/people/`
+
+This API contains the central "person" object. As explained above, people can be judges, appointers, or both.
+
+This object holds the core metadata about the person, including their biographical data, positions held, educational history, ABA ratings, and political affiliations.
+
+A few notes:
+
+- Position objects can be quite large, so they are linked in the person object instead of nested within it.
+
+- If the `is_alias_of` field has a value, that means the record represents a nickname for the person referenced in the alias field. Alias records make it possible to find a judge by name, even if they sometimes go by Bob instead of Robert. In our database, this field is a [self-join][self-join].
+
+  In general, you will only want to work with judges where this field is null, indicating a record that represents a person, not an alias to a person.
+
+- The `race` and `gender` fields are not self-reported and should therefore be considered best guesses. We have done our best to gather these fields from reputable sources, but have also supplied values ourselves when it felt appropriate to do so. Some values may be incorrect.
+
+  To create choices for race, we used the U.S. census and added [MENA (it has since been added to the census)][mena].
+
+- The `has_photo` field indicates whether we have a photo for the judge in [our database of judge portraits][judge-portraits].
+
+- The `ftm_*` fields relate to state court judges, who raise money for elections. Use these fields to link judges to their IDs on [Follow The Money][ftm], where you can gather and analyze the details.
+
+  These fields have not been updated in many years, but we can do so as a service.
+
+[self-join]: https://en.wikipedia.org/wiki/Join_(SQL)#Self-join
+[mena]: https://en.wikipedia.org/wiki/Middle_East_and_North_Africa
+[judge-portraits]: https://free.law/datasets#judges-portraits
+[ftm]: https://www.followthemoney.org/
+
+### Positions
+`/api/rest/v4/positions/`
+
+Use this API to learn the positions held by a person, including their time as president, in private practice, as a judge, or in any number of other roles in society or the judiciary.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+To filter to positions for a particular person:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/positions/?person=20"
+```
+
+### Political Affiliations
+`/api/rest/v4/political-affiliations/`
+
+Use this API to learn the political affiliations of a person. Political affiliations are gathered from a number of sources such as ballots or appointments, and have start and end dates.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+### Educations and Schools
+`/api/rest/v4/educations/`
+
+Use this API to learn about the educational history of a person, including which schools they went to, when, and what degrees they received. Each education object can include a school object based on data from the Department of Education.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+To filter for judges educated at a particular school:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/people/?educations__school__name__contains=Rochester"
+```
+
+### ABA Ratings
+`/api/rest/v4/aba-ratings/`
+
+These are the American Bar Association ratings that are given to many judges, particularly those that are nominated to federal positions.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+### Retention Events
+`/api/rest/v4/retention-events/`
+
+These are the events that keep a judge in a position, such as a retention vote, or reappointment.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+### Sources
+`/api/rest/v4/sources/`
+
+This API keeps a list of sources that explain how we built this database.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.

--- a/wiki-exports/migration-guide.md
+++ b/wiki-exports/migration-guide.md
@@ -1,0 +1,321 @@
+---
+title: "V4 API Migration Guide"
+description: "Guide for migrating from v3 to v4 of the CourtListener REST API."
+redirect_from: "/help/api/rest/v4/migration-guide/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/migration-guide/"
+---
+
+After several years of planning and development, we have released v4 of our APIs.
+
+This upgrade responds to feedback we have received over the years and should be much better for our users — faster, more featureful, more scalable, and more accurate.
+
+Unfortunately, we couldn't make these new APIs completely backwards compatible, so this guide explains what's new.
+
+## Support
+
+Questions about this migration can be sent [to our GitHub Discussions forum][gh-discussions] or to our [contact form][contact].
+
+We prefer that questions be posted in the forum so they can help others. If you are a private organization posting to that forum, we will avoid sharing details about your organization.
+
+[Ask in GitHub Discussions](https://github.com/freelawproject/courtlistener/discussions){button} [Send us a Private Message](https://www.courtlistener.com/contact/){button}
+
+## Timeline for Changes
+
+v4 of the API is available now and is the default version for anybody creating new systems. Before its full release, a number of organizations beta tested it.
+
+All of our APIs except for our search API are powered by our database. We do not have plans at present to deprecate any of these APIs, but we'd like to remove them someday and urge you to migrate to v4 as soon as possible so we can do that.
+
+That said, the v3 Search API is currently powered by Solr while v4 is powered by ElasticSearch. In **nine weeks** we aim to switch v3 so it uses ElasticSearch too. This will change v3 in small backwards incompatible ways, but will allow us to continue supporting it even after turning off our Solr server.
+
+If you are a v3 Search API user, you will soon get an email from us to communicate and discuss timelines.
+
+## What If I Do Nothing?
+
+You might be fine. Most of the database and search APIs are only changing slightly, and v3 will be supported for some period of time. But you should read this guide to see if any changes are needed to your application.
+
+The remainder of this guide is in three sections:
+
+- New features you can expect
+- How to migrate database APIs
+- How to migrate search APIs
+
+We're very excited to be releasing v4 of our APIs. We hope you will review these changes so we can all have a smooth transition.
+
+## What New Features Can I Expect?
+
+### Cursor-Based Pagination
+
+Our database-powered APIs now support cursor-based pagination. This allows you to crawl very deeply in the API. In v3, any page past 100 was blocked.
+
+### ElasticSearch
+
+v4 of the Search API is powered by ElasticSearch instead of Solr. This is a huge upgrade to our API and search engine.
+
+Some improvements include:
+
+- In v4, all PACER cases are now searchable. In v3 you only got results if a case had a docket entry.
+- You can search for PACER filings based on what decisions they cite.
+- You can now search for exact words like "Deposit" and not get back results for things like "Deposition."
+- We've added about 800 legal acronyms like "IRS" to make sure those bring back results.
+- Better relevancy for edge cases:
+  - Small words like "of," "to," and "the" are now searchable.
+  - Camelcase words like "McDonalds" are more searchable.
+  - Highlighting is more consistent and can be disabled for better performance.
+- Emojis and Unicode characters are now searchable.
+- Docket number and other fielded searches are more robust.
+- Timezone handling is more consistent.
+- We've added a number of new searchable fields.
+
+For more details, please [see our blog][blog-recap-search].
+
+## Breaking Changes to v3 of the Search API
+
+We cannot continue running Solr forever, but we can do our best to support v3 of the API. To do this, on **November 25, 2024**, v3 of the Search API will be upgraded to use ElasticSearch. We expect this to support most uses, but it will cause some breaking changes, as outlined in this section.
+
+We recommend all users upgrade to v4 of the API, but if that is not possible, please review this section to learn about the upcoming changes to v3 of the search API.
+
+### RECAP (type=r)
+
+- The following fields will be removed from the v3 search API when `type=r`:
+  - attorney
+  - attorney_id
+  - firm
+  - firm_id
+  - party
+  - party_id
+  - docket_absolute_url
+
+- Fielded text queries that include party fields won't work, for instance:
+
+  `firm_id:1245 AND party:(United States)`
+
+- The `type=r` will use a cardinality aggregation to compute the result count, which will have an error of +/-6% if results are over 2000.
+
+### Opinions (type=o)
+
+- The following fields will be removed from the v3 search API when `type=o`:
+  - caseNameShort
+  - pagerank
+  - status_exact
+  - non_participating_judge_ids
+  - source
+- The `date_created` field will be added.
+- The `snippet` will change. In the Solr version, it includes content from all fields, while in ElasticSearch it will display only the Opinion text content.
+- The `type=o` will use a cardinality aggregation to compute the result count, which will have an error of +/-6% if results are over 2000 hits.
+
+### Oral Arguments (type=oa)
+
+- The `snippet` field currently stores a variety of fields. After the change, it will contain the audio transcription only.
+
+### People (type=p)
+
+- No breaking changes. v3 is already switched to ElasticSearch.
+
+## How Do I Migrate Database APIs to v4?
+
+### Result Count is Removed
+
+The total count of the results is no longer available in the response. Most users don't need this when using the API, and computing the count for each response slows down the API. If this value is important to your service, let us know so we can discuss adding a new API with this feature.
+
+### Invalid Cursor Error Code: 404
+
+A new type of error in the v4 API is **Invalid Cursor** with a 404 status code.
+
+This can happen when GET parameters are changed without getting a fresh cursor parameter. To prevent this error, do not change the GET parameters while maintaining an existing cursor parameter.
+
+## Enhancements in Search API v4
+
+### Search API Crawls Are No Longer Limited to 100 Pages
+
+- Deep pagination of search results is now possible.
+- Users cannot directly jump to a specific page. Look at and follow the `next` and `previous` parameters provided in each response. Navigation of the API is exclusively through those keys in each API response.
+
+### Result Sorting is More Consistent
+
+- When sorting the API results, we now add a tie-breaking field to all responses. This ensures that ordering is consistent even when the ordering key has identical values for multiple results.
+- If your sorting field has null values, those results will be sorted at the end of the query, regardless of whether you sort in ascending or descending order. For example if you sort by a date that is null for an opinion, that opinion will go at the end of the result set.
+
+### Highlighting is More Consistent
+
+- When enabled, highlighting will more consistently highlight the fields in the response.
+
+### Empty Fields Are Standardized
+
+- Empty fields are now more consistent in their response types, and follow the conventions provided by Django. This means that dates, date times, and integers return `null`, strings return an empty string, and lists return an empty array.
+
+## Backwards Incompatible Changes in Search API v4
+
+### High Query Counts Are Estimated
+
+- To enhance performance, query counts above 2,000 hits are approximate. For queries exceeding this threshold, counts can be off by as much as six percent. We recommend noting this in your interface by saying something like, "About 5,000 results," instead of presenting the value as exact.
+
+### Highlighting
+
+- To enhance performance, results are not highlighted by default. To enable highlighting, include `highlight=on` in your request.
+- When highlighting is disabled, the first 500 characters of `snippet` fields are returned for types `o`, `r`, and `rd`.
+
+### Nested Keys (Documents) for `type=o` and `type=p`
+
+- To enhance the structure of the API, sub-opinions are now nested within clusters in case law results (`type=o`), and `positions` are nested within judges in judge results (`type=p`).
+
+### `type=r` is Now For Dockets With Nested Documents
+
+- To align the API results with the front end results, `type=r` no longer returns a flat list of documents. Instead, it now returns a list of dockets with up to three matching documents nested within each docket's `recap_documents` key.
+- To return a flat list of documents, as in the past, try the new `type=rd` parameter. This can be useful for those upgrading from v3 to v4 of the search API.
+- If there are more than three matching documents, the `more_docs` field for the docket result will be true. As in the front end, you can get the remaining documents for a docket by placing a docket ID query like: `type=rd&q=(original query) AND docket_id:XYZ`
+- This response type includes two counts of the results: `count` is the number of dockets returned. `document_count` is the number of documents.
+
+### `type=rd` is a New Result Type For Documents
+
+- `type=rd` returns a flat list of PACER documents, and is similar to `type=r` in v3 of the API. Results for this type can be queried by any docket fields except the `party` and `attorney` fields.
+- The field differences between `r` in v3 and `rd` in v4 are that all the docket-level fields were removed:
+  - assignedTo
+  - assigned_to_id
+  - caseName
+  - cause
+  - court
+  - court_citation_string
+  - court_exact
+  - court_id
+  - dateArgued
+  - dateFiled
+  - dateTerminated
+  - docketNumber
+  - jurisdictionType
+  - juryDemand
+  - referredTo
+  - referred_to_id
+  - suitNature
+- `docket_id` is still available in the `rd` type so users can identify the docket and pull additional docket data from the docket API.
+- One field that changed is `entry_date_filed`. In `r` v3, it was a `datetime` field with PST midnight as the default time. Now, it's simply a date field.
+- The `timestamp` field has been moved to the new `meta` field, which also contains `date_created`.
+
+### `type=d` Still Returns Dockets
+
+- `type=d` returns dockets without nested documents. If all you need in the response is the docket information, this response type will be significantly faster. You can query document fields with this response type even though they will not be returned.
+
+### Removed Fields
+
+- The following fields have been removed from the case law search results (`type=o`):
+  - caseNameShort
+  - pagerank
+  - status_exact
+  - non_participating_judge_ids
+
+### Changed Field Values
+
+- For legibility, in the case law search results (`type=o`), some `type` field values have changed:
+  - 010combined -> combined-opinion
+  - 015unamimous -> unanimous-opinion
+  - 020lead -> lead-opinion
+  - 025plurality -> plurality-opinion
+  - 030concurrence -> concurrence-opinion
+  - 035concurrenceinpart -> in-part-opinion
+  - 040dissent -> dissent
+  - 050addendum -> addendum
+  - 060remittitur -> remittitur
+  - 070rehearing -> rehearing
+  - 080onthemerits -> on-the-merits
+  - 090onmotiontostrike -> on-motion-to-strike
+
+- Some of the values of the `status` field in the case law search results have changed:
+  - precedential -> published
+  - non-precedential -> unpublished
+  - errata -> errata
+  - separate opinion -> separate
+  - in-chambers -> in-chambers
+  - relating-to orders -> relating-to
+  - unknown status -> unknown
+
+- The `snippet` field in the case law search results previously included more than one opinion text field. It now only contains the best text field, based on the following priority and determined by availability:
+  - html_columbia
+  - html_lawbox
+  - xml_harvard
+  - html_anon_2020
+  - html
+  - plain_text
+
+### Dates and Times
+
+- All dates and times are in UTC instead of PST.
+- Date objects are now rendered as an ISO-8601 date instead of an ISO-8601 datetime.
+
+The following is a full list of date fields that are now date objects (rather than datetime objects, which they were in v3):
+
+- types `r` and `d`:
+  - dateArgued
+  - dateFiled
+  - dateTerminated
+
+- types `r` and `rd`:
+  - `entry_date_filed` (in type `r` is available in documents nested within the `recap_documents` key)
+
+- type `o`:
+  - dateArgued
+  - dateFiled
+  - dateReargued
+  - dateReargumentDenied
+
+- type `oa`:
+  - dateArgued
+  - dateReargued
+  - dateReargumentDenied
+
+- type `p`:
+  - dob
+  - dod
+  - The following fields are available within the nested `positions` key:
+    - date_confirmation
+    - date_elected
+    - date_hearing
+    - date_judicial_committee_action
+    - date_nominated
+    - date_recess_appointment
+    - date_referred_to_judicial_committee
+    - date_retirement
+    - date_start
+    - date_termination
+
+### No More Random Sorting
+
+- You can no longer sort the results randomly. This was only used by developers and was difficult to support.
+
+### Stemming and Synonyms
+
+- To provide better relevancy, stemming and synonyms are disabled on the `caseName` fields.
+- This is because broadening a query to include synonyms and other words with the same stem are not relevant when a user searches for a case by name. For example, when searching for a case name that includes the word "Howells" results for a search on the word "Howell" would not be relevant.
+- This change applies to both the `case_name` filter and the text query.
+
+### Changes to GET Parameters
+
+- When searching the case law status fields, the GET parameters have been changed as follows:
+  - stat_Precedential -> stat_Published
+  - stat_Non-Precedential -> stat_Unpublished
+  - stat_Errata -> stat_Errata
+  - stat_Separate Opinion -> stat_Separate
+  - stat_In-chambers -> stat_In-chambers
+  - stat_Relating-to orders -> stat_Relating-to
+  - stat_Unknown Status -> stat_Unknown
+
+### Bad Request Error Code: 400
+
+- The error can contain one of the following custom messages in the `detail` key, explaining the reason for the error:
+  - The query contains unbalanced parentheses.
+  - The query contains unbalanced quotes.
+  - The query contains an unrecognized proximity token.
+
+### Server Error Code: 500
+
+- Any other error, such as a connection error or a parsing error of the ElasticSearch query, will raise `Server Error` Code: `500`.
+- And the message in the detail key: `Internal Server Error. Please try again later or review your query.`
+
+### Not Found Error Code: 404
+
+- In the v4 Search API or other v4 database-based endpoints using cursor pagination, the following error can be raised: `Not Found Error` Code: `404`
+- Message in the `detail` key: `Invalid cursor`
+- This can happen if the cursor was modified manually or if the ordering key changed and doesn't match the ordering key in the cursor.
+- To avoid this problem, when changing the sorting key, restart your request by removing the cursor key from your request.
+
+[gh-discussions]: https://github.com/freelawproject/courtlistener/discussions
+[contact]: https://www.courtlistener.com/contact/
+[blog-recap-search]: https://free.law/2024/01/18/new-recap-archive-search-is-live/

--- a/wiki-exports/oral-argument-api.md
+++ b/wiki-exports/oral-argument-api.md
@@ -1,0 +1,117 @@
+---
+title: "Oral Argument Recordings APIs"
+description: "We have the biggest collection of oral argument audio in the world. Use these APIs to gather and analyze oral argument audio files from federal courts."
+redirect_from: "/help/api/rest/v4/oral-arguments/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/oral-arguments/"
+---
+
+<p class="lead">Use these APIs to gather and analyze the largest collection of oral argument recordings on the Internet.</p>
+
+## The APIs
+
+### Oral Argument Recordings
+`/api/rest/v4/audio/`
+
+Use this API to gather data about oral argument recordings. This API is linked to the docket API (below), which contains data about each case. It is also linked to the [judge API][judge-api], which has information about the judges in the case.
+
+The audio files we gather from court websites come in many formats. After we gather the files, we convert them into optimized MP3s that have a 22050Hz sample rate and 48k bitrate. After converting the files, we set the ID3 tags to better values that we scraped. Finally, we set the cover art for the MP3 to the seal of the court, and set the publisher album art to our logo.
+
+The original audio files can be downloaded from the court using the `download_url` field. If you prefer to download our enhanced version, that location is in the `local_path_mp3` field. To download the file, see our [help article on this topic][field-help].
+
+The `duration` field contains an estimated length of the audio file, in seconds. Because these MP3s are variable bitrate, this field is based on sampling the file and is not always accurate.
+
+As with all other APIs, you can look up the field descriptions, filtering, ordering, and rendering options by making an `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/audio/"
+```
+
+[judge-api]: judge-api.md
+[field-help]: field-help.md
+
+### Dockets
+`/api/rest/v4/dockets/`
+
+`Docket` objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+
+In our case law database, dockets sit above `Opinion Clusters`. In our oral argument database, they sit above `Audio` objects.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/"
+```
+
+To look up a particular docket, use its ID:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/4214664/"
+```
+
+The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+
+```json
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v4/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/v4/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/v4/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/v4/tag/1316/"
+  ],
+  "panel": []
+}
+```

--- a/wiki-exports/pacer-api.md
+++ b/wiki-exports/pacer-api.md
@@ -1,0 +1,376 @@
+---
+title: "PACER Data APIs"
+description: "Use these APIs to query parties, dockets, and filings in the RECAP Archive of PACER data. This is sourced from federal district, appellate, and bankruptcy courts."
+redirect_from: "/help/api/rest/v4/pacer/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/pacer-data/"
+---
+
+<p class="lead">Use these APIs to access almost half a billion items we have in our collection of PACER data.</p>
+
+To learn more about what's in the collection and how we gather PACER data each day, see [our coverage page on the topic.][recap-coverage]
+
+This data is organized into a number of objects. An overview of these objects is described in this section, and greater detail is provided for each, below.
+
+In any legal proceeding, there are roughly three things: Documents, people, and organizations. Documents are grouped together into docket entries, which are grouped together into dockets. People and organizations are examples of parties. Parties have attorneys who act on their behalf in particular ways, which we call the attorney's role in the case.
+
+Each of these relationships is interlinked and has metadata that describes it. Use these APIs to explore this data.
+
+[recap-coverage]: https://www.courtlistener.com/help/coverage/recap/
+
+## Dockets, Courts, Docket Entries, and Documents
+
+A docket is a list of docket entries and some metadata. Each docket entry is a collection of documents that is uploaded to the court by a party or their attorney at a given time.
+
+The endpoints described in this section explain these objects and how they can be accessed in our system.
+
+### Dockets
+`/api/rest/v4/dockets/`
+
+`Docket` objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+
+In our case law database, dockets sit above `Opinion Clusters`. In our oral argument database, they sit above `Audio` objects.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request:
+
+```
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "http://localhost:8000/api/rest/v4/dockets/"
+```
+
+To look up a particular docket, use its ID:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "http://localhost:8000/api/rest/v4/dockets/4214664/"
+```
+
+The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+
+```json
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v4/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/v4/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/v4/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/v4/tag/1316/"
+  ],
+  "panel": []
+}
+```
+
+Ideally, docket entries, parties, and attorneys would be nested within the docket object you request, but this is not possible because some dockets have a vast number of these objects. Listing so many values in a single response from the server is impractical. To access docket entries, parties, or attorneys for a specific docket, use the docket entry, party, or attorney endpoints and filter by docket ID.
+
+The court fields are references to our Court API, described below.
+
+### Courts
+`/api/rest/v4/courts/`
+
+This API contains data about the courts we have in our database, and is joined into nearly every other API so that you can know where an event happened, a judge worked, etc.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+You can generally cache this API. It does not change often.
+
+### Docket Entries
+`/api/rest/v4/docket-entries/`
+
+`Docket Entry` objects represent the rows on a PACER docket, and contain one or more nested documents. This follows the design on PACER, in which a single row on a docket represents a document with its associated attachments.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+To filter to the docket entries for a particular docket use the `docket` filter:
+
+### Documents
+`/api/rest/v4/recap-documents/`
+
+Each docket entry contains several documents, which we call `RECAP Document` objects.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+A few field-level notes:
+
+| Field | Notes |
+|---|---|
+| `plain_text` | This field contains the extracted text of the document. We use [Doctor][doctor] to complete this task. If needed, Doctor uses an optimized version of Tesseract to complete OCR. To see whether OCR was used, check the `ocr_status` field. If you don't need this content, omit it via [Field Selection][field-selection] to significantly reduce response times and payload size. |
+| `filepath_local` | This field contains the path to the binary file if we have it (`is_available=True`). To use this field, see the [help article on this topic][file-downloads-help]. The name of this field dates back to when all our files were locally stored on a single server. |
+
+This endpoint is only available to select users. Please [get in touch][contact] to access this API.
+
+[doctor]: https://free.law/open-source-tools#doctor
+[field-selection]: rest-api.md#field-selection
+[file-downloads-help]: field-help.md#file-download-fields
+
+### Parties
+`/api/rest/v4/parties/`
+
+The `Party` endpoint provides details about parties that have been involved in federal cases in PACER, and contains nested attorney information.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP `OPTIONS` request.
+
+This API can be filtered by docket ID to show all the parties for a particular case.
+
+> [!WARNING]
+> **Listen Up:** Filters applied to this endpoint only affect the top-level data, not the data nested records within it. Therefore, each party returned by this API will list all the attorneys that have represented them in any case, even if the parties themselves are filtered to a particular case.
+>
+> To filter the nested attorney data for each party, include the `filter_nested_results=True` parameter in your API request.
+
+For example, this query returns the parties for docket number `123`:
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/parties/?docket=123"
+```
+
+It returns something like:
+
+```json
+{
+  "next": "https://www.courtlistener.com/api/rest/v4/parties/?docket=123&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v4/parties/42/",
+      "id": 42,
+      "attorneys": [
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/v4/attorneys/1/",
+          "attorney_id": 1,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/v4/dockets/123/",
+          "docket_id": 123,
+          "role": 10
+        },
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/v4/attorneys/2/",
+          "attorney_id": 2,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/v4/dockets/456/",
+          "docket_id": 456,
+          "role": 2
+        }
+      ],
+      "party_types": [
+        {
+          "docket": "https://www.courtlistener.com/api/rest/v4/dockets/123/",
+          "docket_id": 123,
+          "name": "Plaintiff",
+          "date_terminated": null,
+          "extra_info": "",
+          "highest_offense_level_opening": "",
+          "highest_offense_level_terminated": "",
+          "criminal_counts": [],
+          "criminal_complaints": []
+        }
+      ],
+      "date_created": "2024-04-24T13:33:39.096780-07:00",
+      "date_modified": "2024-04-24T13:33:39.096790-07:00",
+      "name": "Samuel Jackson",
+      "extra_info": ""
+    },
+    ...
+  ]
+}
+```
+
+Note that:
+
+1. There are 35 parties in this case. (Only the first is shown in this example.)
+
+2. The first party (ID 42) has had two attorneys. The first attorney (ID 1) represented them with role 10 in case 123 (the one we filtered to). The second attorney (ID 2) represented party 42 with role 2 in case 456.
+
+3. The `party_types` field indicates the role the party has in the case (defendant, plaintiff, trustee, etc).
+
+4. In criminal cases, the `party_type` field may also include the highest offenses, criminal counts, and criminal complaints against the defendant.
+
+These endpoints are only available to select users. Please [get in touch][contact] to access these endpoints.
+
+### Attorneys
+`/api/rest/v4/attorneys/`
+
+Use this API to look up an attorney in our system.
+
+To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP OPTIONS request.
+
+Like docket entries and parties, attorneys can be filtered to a particular docket. For example:
+
+> [!WARNING]
+> **Listen Up:** Like the parties endpoint, filters applied to this endpoint only affect the top-level data. To filter the nested data for each attorney, include the `filter_nested_results=True` parameter in your API request URL.
+
+```
+curl -v \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/attorneys/?docket=4214664"
+```
+
+Returns:
+
+```json
+{
+  "next": "https://www.courtlistener.com/api/rest/v4/attorneys/?docket=4214664&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",
+  "previous": null,
+  "results": [
+    {
+        "resource_uri": "https://www.courtlistener.com/api/rest/v4/attorneys/9247906/",
+        "id": 9247906,
+        "parties_represented": [
+            {
+                "role": 10,
+                "docket": "https://www.courtlistener.com/api/rest/v4/dockets/4214664/",
+                "party": "https://www.courtlistener.com/api/rest/v4/parties/13730908/",
+                "date_action": null
+            }
+        ],
+        "date_created": "2024-04-24T13:33:39.109264-07:00",
+        "date_modified": "2024-05-07T21:32:12.465340-07:00",
+        "name": "ERIC ALAN ISAACSON",
+        "contact_raw": "6580 Avenida Mirola\nLa Jolla, CA 92037\n(858) 263-9581\nPRO SE\n",
+        "phone": "(858) 263-9581",
+        "fax": "",
+        "email": ""
+    },
+    ...
+  ]
+}
+```
+
+Similar to the party API above, when you filter attorneys to a particular docket, the nested `parties_represented` field is not filtered and can show other parties the attorney represented in other dockets.
+
+These endpoints are only available to select users. Please [get in touch][contact] to access these endpoints.
+
+### Originating Court Info
+`/api/rest/v4/originating-court-information/`
+
+`Originating Court Information` represents the information gathered at an appellate court about a case when it was in a lower court or administrative body.
+
+The information in this table is joined via a one-to-one relationship to the `Docket` object. Generally, this table is only completed for appellate cases that we acquire from PACER.
+
+Cross-walking from the upper court docket to the lower is possible using the `docket_number` and `appeal_from` fields.
+
+### Bankruptcy Information
+`/api/rest/v4/bankruptcy-information/`
+
+`Bankruptcy Information` represents metadata specific to PACER bankruptcy dockets, such as details about the bankruptcy case, including the chapter, trustee information, and key dates.
+
+The information in this table is joined via a one-to-one relationship to the `Docket` object. Generally, it is only populated for dockets acquired from bankruptcy courts via PACER, so it does not apply to other types of cases.
+
+### Integrated Database
+`/api/rest/v4/fjc-integrated-database/`
+
+`FJC Integrated Database` objects represent the information available in the [Federal Judicial Center's Integrated Database][fjc-idb], a regularly updated source of metadata about federal court cases. You can learn more about the IDB from the following sources:
+
+- [The FJC IDB Homepage][fjc-idb]
+- [Our datasheet on the IDB][idb-facts]
+- The various codebooks for [civil][codebook-civil], [criminal][codebook-criminal], [appellate][codebook-appellate], and [bankruptcy][codebook-bankruptcy] datasets.
+
+As always, you can find our interpretations of these fields by performing an `OPTIONS` request on this endpoint.
+
+**Note:** Pending further support, this endpoint should be considered *experimental* quality. It is not guaranteed to have all of the available data sets, may not have the latest quarterly data, and indeed may have bugs. If you encounter any bugs, please let us know. If you would like better guarantees about the quality of this endpoint, we are enthusiastic about finding partners to better support it.
+
+[fjc-idb]: https://www.fjc.gov/research/idb
+[idb-facts]: https://free.law/idb-facts/
+[codebook-civil]: https://www.fjc.gov/sites/default/files/idb/codebooks/Civil%20Codebook%201988%20Forward_0.pdf
+[codebook-criminal]: https://www.fjc.gov/sites/default/files/idb/codebooks/Criminal%20Code%20Book%201996%20Forward.pdf
+[codebook-appellate]: https://www.fjc.gov/sites/default/files/idb/codebooks/Appeals%20Codebook%202008%20Forward.pdf
+[codebook-bankruptcy]: https://www.fjc.gov/sites/default/files/idb/codebooks/Bankruptcy%20Codebook%202008%20Forward%20(Rev%20January%202018).pdf
+
+## Fast Document Lookup
+`/api/rest/v4/recap-query/`
+
+This API is used to check if documents with known IDs are available in our system.
+
+To use it, provide a court ID and a comma-separated list of `pacer_doc_id`'s:
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  'https://www.courtlistener.com/api/rest/v4/recap-query/?docket_entry__docket__court=dcd&pacer_doc_id__in=04505578698,04505578717'
+```
+
+This will return one entry for each document found, up to a maximum of 300 items:
+
+```json
+{
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "pacer_doc_id": "04505578717",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.2.0_54.pdf",
+      "id": 2974081
+    },
+    {
+      "pacer_doc_id": "04505578698",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.1.0_48.pdf",
+      "id": 2974077
+    }
+  ]
+}
+```
+
+CourtListener court IDs match the subdomains on PACER, except for the following mapping:
+
+| PACER Code | CL ID | Description |
+|---|---|---|
+| azb | arb | Arizona Bankruptcy Court |
+| cofc | uscfc | Court of Federal Claims |
+| neb | nebraskab | Nebraska Bankruptcy |
+| nysb-mega | nysb | Do not use 'mega' |
+
+> [!WARNING]
+> **Careful:** When placing queries, the fourth digit of a PACER document ID can be a zero or one. We always normalize it to zero, and you will need to do so in your queries.
+
+To query whether a case is in our system, use the `Docket` endpoint described above.
+
+This endpoint is only available to select users. Please [get in touch][contact] to access this API.
+
+[contact]: https://www.courtlistener.com/contact/

--- a/wiki-exports/recap-api.md
+++ b/wiki-exports/recap-api.md
@@ -1,0 +1,429 @@
+---
+title: "RECAP APIs for PACER Data"
+description: "Use these APIs to download content from PACER and share it in the RECAP Archive of federal court cases and filings."
+redirect_from: "/help/api/rest/v4/recap/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/recap/"
+---
+
+<p class="lead">Use these APIs to scrape PACER data and to upload data into CourtListener's database of federal court cases and filings.</p>
+
+Once data is gathered by these APIs, our [PACER APIs and data model][pacer-api] can be used to retrieve dockets, entries, parties, and attorneys from our system.
+
+The endpoints for RECAP are:
+
+- `/api/rest/v4/recap-fetch/` — Use this API to scrape PACER data, including dockets, PDFs, and more.
+- `/api/rest/v4/recap/` — Use this API to upload PACER data to CourtListener and to check on the progress of an upload.
+
+[pacer-api]: pacer-api.md
+
+## PACER Fetch
+`/api/rest/v4/recap-fetch/`
+
+Use this API to buy PACER content and add it to CourtListener so that it is available via our website, APIs, [webhooks][webhooks], and [replicated database][replication]. This is [a free API][free-api] to use, but it uses your PACER credentials to purchase and download PACER content. You'll still have to pay your PACER bill when it comes.
+
+Because downloading content from PACER takes time, this API is asynchronous. After you send an HTTP `POST`, it immediately responds with an ID for the request and places the request in a queue to be downloaded by our scrapers. Most requests are completed within seconds.
+
+As the request is processed, it will have a status code:
+
+| Code | Description |
+|---|---|
+| 1 | Awaiting processing in queue |
+| 2 | Item processed successfully |
+| 3 | Item encountered an error while processing |
+| 4 | Item is currently being processed |
+| 5 | Item failed processing, but will be retried |
+| 6 | Item failed validity tests during your POST |
+| 7 | There was insufficient metadata to complete the task |
+
+### Monitoring Your Request
+
+To monitor your request, poll the API for your request, or use our [Fetch Webhook][fetch-webhook] to get immediate updates without polling.
+
+We recommend using the webhook endpoint, since it reduces load on our servers.
+
+[fetch-webhook]: webhooks.md#recap-fetch-events
+
+### PACER Password Rotation Requirement
+
+As of 2025, the federal judiciary requires that **all PACER accounts change their passwords every 180 days.** Because the RECAP Fetch API uses your PACER credentials to log in and retrieve documents, this policy affects all Fetch API users.
+
+This means:
+
+- You'll need to **update your PACER password at least once every 180 days**.
+- If your password expires, the Fetch API will no longer be able to log in on your behalf until you update it.
+
+To use this API without downtime during password change events, we recommend using two PACER accounts, and rotating between them in your code.
+
+### Security of RECAP Fetch API
+
+A security maxim is to never share your password. This API requires that you violate this maxim. Why should you do so, and how do we handle your password securely?
+
+While we prefer not to have unhashed user passwords, PACER lacks any permissions-based or granular authentication system. This means that the only way we can act on your behalf is to have your credentials.
+
+Once we have your password, we work to rid ourselves of it as quickly as possible. We do not store it in our database or logs at any time. Instead, we use it to immediately log into the PACER system. That gives us cookies for your account, which we store in our in-memory database with a one hour expiration period. As soon as we have the cookies, we throw away your username and password.
+
+The result of this system is that we have your password until we have logged you in, and no longer. After that point, we only have a cache of your cookies for one hour.
+
+> [!WARNING]
+> **Listen Up!** This API gets content on your behalf using *your* access rights. This means that if you use this API to request a sealed item from PACER, we will go get it and add it to our system, just like you asked. **Do not do this**. If you do this accidentally, [please get in touch][contact] as soon as possible, so we can revert the error.
+
+If you have questions about our approach, please see [our vulnerability reporting policy and bug bounty program][vuln-policy], where you'll find details on contacting us.
+
+[webhooks]: webhooks.md
+[replication]: https://www.courtlistener.com/help/api/replication/
+[free-api]: https://free.law/2019/11/05/pacer-fetch-api
+[contact]: https://www.courtlistener.com/contact/
+[vuln-policy]: https://free.law/vulnerability-disclosure-policy/
+
+### Known Issues
+
+#### PACER login may fail with missing cookie error
+
+Some users have experienced the following error when using the RECAP Fetch API to log in to PACER:
+
+```
+PacerLoginException: Did not get NextGenCSO cookie when attempting PACER login.
+```
+
+This issue appears to be related to recent changes in PACER's password requirements and how it handles multi-factor authentication (MFA).
+
+If you encounter this error, temporarily disabling multi-factor authentication on your PACER account may resolve the issue and allow the RECAP Fetch to complete the login successfully.
+
+### API Examples
+
+#### Purchasing PDFs
+
+1. Set `request_type` field to `2`, which indicates PDFs.
+
+2. Set the `recap_document` field to the ID for the RECAP Document you wish to add to our system.
+
+   To identify the `recap_document` ID, look up the RECAP Document in [our PACER API][pacer-api] and provide the CourtListener ID for the item.
+
+An example of downloading a PDF by `recap_document` ID might be:
+
+```
+curl -X POST \
+  --data 'request_type=2' \
+  --data 'pacer_username=xxx' \
+  --data 'pacer_password=yyy' \
+  --data 'recap_document=112' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/recap-fetch/"
+```
+
+If you have a client code, you can provide it to the API with the `client_code` parameter.
+
+If we do not have the `pacer_doc_id` for a particular `recap_document`, we will not be able to download it. If that's the case, you'll get an error message asking you to download the docket, which will get us the `pacer_doc_id` we need. Once that is completed you can retry your PDF purchase.
+
+#### Scraping Attachment Pages
+
+Attachment pages are the pages that you see in PACER after you click to download a document if a docket entry has attachments. These pages are free in PACER. Fetching attachment pages is done same as PDFs, above, but with `request_type` set to `3`.
+
+#### Purchasing Dockets
+
+Buying docket information is done similarly, but has a few additional options:
+
+1. Provide the `request_type` of `1` for dockets.
+
+2. Indicate the docket you want by either a CourtListener `docket` ID, a `docket_number`-`court` pair or a `pacer_case_id`-`court` pair (for district court dockets only):
+
+   - `pacer_case_id` is the internal ID in the PACER system.
+   - `docket_number` is the visible docket number humans use to refer to the case.
+   - `court` is the CourtListener court ID.
+
+     CourtListener court IDs match the subdomains on PACER, except for the following mapping:
+
+     | PACER Code | CL ID | Description |
+     |---|---|---|
+     | azb | arb | Arizona Bankruptcy Court |
+     | cofc | uscfc | Court of Federal Claims |
+     | neb | nebraskab | Nebraska Bankruptcy |
+     | nysb-mega | nysb | Do not use 'mega' |
+
+3. As when buying dockets from PACER directly, you can choose to buy only some docket entries (available for district court dockets only), omit parties, do a date range query, etc. To see how to use these options map to the API, place an HTTP `OPTIONS` request.
+
+For example, this request identifies a case by docket number and court:
+
+```
+curl -X POST \
+  --data 'request_type=1' \
+  --data 'pacer_username=xxx' \
+  --data 'pacer_password=yyy' \
+  --data 'docket_number=5:16-cv-00432' \
+  --data 'court=okwd' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/recap-fetch/"
+```
+
+This is the same, but includes parties and counsel:
+
+```
+curl -X POST \
+  --data 'request_type=1' \
+  --data 'pacer_username=xxx' \
+  --data 'pacer_password=yyy' \
+  --data 'docket_number=5:16-cv-00432' \
+  --data 'court=okwd' \
+  --data 'show_parties_and_counsel=true' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/recap-fetch/"
+```
+
+Finally, this request updates an existing docket in CourtListener by its ID, but only gets the parties and counsel. Docket entries are excluded by requesting only ones from before 1980:
+
+```
+curl -X POST \
+  --data 'request_type=1' \
+  --data 'pacer_username=xxx' \
+  --data 'pacer_password=yyy' \
+  --data 'docket=5' \
+  --data 'show_parties_and_counsel=true' \
+  --data 'de_date_end=1980-01-01' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/recap-fetch/"
+```
+
+Sometimes, we get a PDF before we get a docket, making it impossible to know what case the PDF is associated with. We call these "orphan documents" because they do not have valid parent objects in our system.
+
+Later, when we receive new or updated docket information, we have an opportunity to fix this problem by checking our system for orphan documents. When this happens, the orphans will automatically be associated with the new docket information, and the case will have PDFs linked to it.
+
+## Pray and Pay API
+`/api/rest/v4/prayers/`
+
+Use the [Pray and Pay system][pray-and-pay] to monitor when PDFs are added to CourtListener. If a PACER document is not yet available in the RECAP Archive, you create a prayer for it via this API. Later, when another user purchases that document from PACER or the Fetch API, your prayer is "granted" and you are notified via webhook or email.
+
+This API enables you to programmatically create and manage prayers, making it ideal for:
+
+- **Automated monitoring** — Track when specific documents become available without manual checking.
+- **Bulk document requests** — Request multiple documents of interest efficiently.
+- **Workflow integration** — Integrate document availability notifications into your systems via [webhooks][pray-and-pay-webhooks].
+
+To learn more about the Pray and Pay system itself, including how to fulfill prayers and contribute documents, see the help documentation:
+
+[Pray and Pay Help](https://www.courtlistener.com/help/pray-and-pay/){button}
+
+### Creating Prayers
+
+To create a prayer, send an HTTP `POST` request with the `recap_document` ID of the document you want:
+
+```
+curl -X POST \
+  --data 'recap_document=112' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/prayers/"
+```
+
+The response will contain the created prayer:
+
+```json
+{
+  "id": 12345,
+  "date_created": "2025-01-15T10:30:00.123456-07:00",
+  "status": 1,
+  "recap_document": 112
+}
+```
+
+The `status` field indicates whether the prayer is waiting (1) or has been granted (2). Newly created prayers always have status 1.
+
+To identify the `recap_document` ID, look up the RECAP Document in [our PACER API][pacer-api] and provide the CourtListener ID for the item.
+
+### Listing Your Prayers
+
+To retrieve a list of your active (waiting) prayers, send an HTTP `GET` request:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/prayers/"
+```
+
+This returns only prayers with status 1 (WAITING). Once a prayer is granted (status 2), it will no longer appear in this list.
+
+### Deleting Prayers
+
+To delete a prayer before it is granted, send an HTTP `DELETE` request:
+
+```
+curl -X DELETE \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/prayers/12345/"
+```
+
+Note that prayers cannot be modified once created. The API does not support `PUT` or `PATCH` requests. If you need to change a prayer, delete it and create a new one.
+
+### Webhook Notifications
+
+When a prayer is granted and the document becomes available, you can be notified immediately via webhooks. This is the recommended way to monitor your prayers instead of polling the API.
+
+Webhook events are sent as soon as a document becomes available and include the prayer ID, document ID, and status information. To set up webhook notifications for granted prayers, see the webhook documentation:
+
+[Pray and Pay Webhooks](https://www.courtlistener.com/help/api/webhooks/#pray-and-pay){button}
+
+### Limitations and Future Plans
+
+The Pray and Pay API has the same limitations as the web interface:
+
+- Standard users can create a limited number of prayers per day (the same daily quota applies to both web and API usage).
+- Free Law Project members have a higher daily prayer limit.
+- Prayers cannot be modified once created; they can only be created or deleted.
+- Many documents may be unavailable for purchase on PACER (sealed filings, delayed transcripts, etc.). After you create a prayer, our system checks PACER availability. If unavailable, you'll receive an email notification.
+- Once a prayer is granted (the document becomes available), it cannot be deleted.
+
+In the future, we may allow higher prayer limits on a per-account basis for API users who need to monitor hundreds of documents programmatically. If your organization has this need, please [get in touch][contact] to discuss options.
+
+[pray-and-pay]: https://www.courtlistener.com/help/pray-and-pay/
+[pray-and-pay-webhooks]: webhooks.md#pray-and-pay-events
+
+## RECAP Upload API
+`/api/rest/v4/recap/`
+
+This API is used by the RECAP extension and a handful of special partners to upload PACER content to the RECAP Archive. This API is not available to the public. If you have a collection of PACER data you wish to donate to the RECAP Archive so it is permanently available to the public, please [get in touch][contact].
+
+We describe the process for completing these uploads below, and you can see examples of them in [CourtListener's automated test suite][recap-tests]. Uploads to these endpoints should be done using HTTP `POST` requests and multipart form data.
+
+When you make an upload, you create a `Processing Queue` object in the CourtListener system. This object will be returned in the HTTP response to your upload, so you will know its ID. This object will contain the fields you uploaded, and the following fields will be populated as the item is processed:
+
+| Field | Description |
+|---|---|
+| `status` | When you upload an item, it is placed into a queue until processing resources are available to merge it into the RECAP Archive. Use this field to determine where in that process your item is. To see the possible values, place an `OPTIONS` request to this endpoint. |
+| `error_message` | This field will provide you information about whether your upload was processed successfully or will explain any errors that occurred. (It's not strictly errors.) |
+| `docket` / `docket_entry` / `recap_document` | After an item is successfully processed, these fields will be populated with the IDs of the items that were created or updated. The `docket` field will be populated for dockets that were created or updated, and all three fields will be populated for uploaded PDFs. |
+
+### Global Parameters
+
+The following parameters apply to all uploads:
+
+- `upload_type` *(required)* — This field accepts integers representing object types in PACER. Send an HTTP `OPTIONS` request to this API to learn the possible values for this field.
+- `filepath_local` *(required)* — Use this field to upload the binary data you are submitting, whether it HTML of a docket or attachment menu or a PDF file.
+- `court` *(required)* — The CourtListener court id.
+
+  CourtListener court IDs match the subdomains on PACER, except for the following mapping:
+
+  | PACER Code | CL ID | Description |
+  |---|---|---|
+  | azb | arb | Arizona Bankruptcy Court |
+  | cofc | uscfc | Court of Federal Claims |
+  | neb | nebraskab | Nebraska Bankruptcy |
+  | nysb-mega | nysb | Do not use 'mega' |
+
+- `debug` *(optional)* — While you are developing, use this field to test your work. When it is set to `true`, your uploads will not make changes to the RECAP Archive, but you will create processing requests which will be processed in debug mode.
+
+### Uploading Dockets, History Reports, and Claims Registries
+
+These are fairly straightforward uploads. In addition to the required fields above, supply the `pacer_case_id` field.
+
+### Uploading PDFs
+
+To upload PDFs, include the `pacer_doc_id` and `document_number` fields. For documents originating from courts outside the new Appellate Case Management System (ACMS), the fourth digit of the `pacer_doc_id` must always be normalized to a zero before uploading (see below).
+
+If you are uploading an attachment, you must also provide the `attachment_number` field. Note that if you are not uploading an attachment, no `attachment_number` should be provided, otherwise the document will be marked as an attachment.
+
+Because some cases share documents, the `pacer_case_id` field should also be provided, though it's not a required field if it's unknown.
+
+`pacer_doc_id` is the number you see in URLs when purchasing documents on PACER and in the HTML when clicking document numbers on docket pages. For example, in the URL `ecf.flp.uscourts.gov/doc1/035021404350`, the `pacer_doc_id` is `035021404350`.
+
+`pacer_doc_id` numbers, excluding those associated with ACMS, all share a common structure: they embed three variables within their format.
+
+- The first three digits (in this case, `035`) are a code indicating the court.
+- The fourth digit is a zero or one, and is a boolean value that determines if URL should load an attachment page for the document or instead take you directly to the purchase page (we believe this digit is why the URL mentions `/doc1/`).
+
+  **Important:** When uploading to this endpoint, the fourth digit must always be normalized to a zero before uploading.
+- The remaining digits are the serial number of the document itself.
+
+When uploading documents from a court that uses ACMS, you'll notice the `pacer_doc_id` for attachments is identical across all records within the same entry. To ensure proper uploads, you must include the `acms_document_guid` for each document originating from this system.
+
+Locating the `acms_document_guid` requires an additional step as its value is stored within the browser's `sessionStorage` object, accessible on the download page. The following script, executed in your browser's console, will help you retrieve this value:
+
+```javascript
+let downloadData =
+  document.getElementsByClassName('text-center')[0].parentElement.__vue__._data;
+  console.log(downloadData.docketEntryDocuments[0].docketDocumentDetailsId);
+```
+
+PDF uploads will only succeed when they can be associated with a docket. If the RECAP Archive does not have a docket for the `pacer_doc_id` you uploaded, your upload will be re-queued and retried several times. If that fails, your PDF upload will be marked as an "orphan document." Later, when the docket is uploaded, your PDF will be automatically associated with it. Until then it's not visible in the system.
+
+### Uploading Document Zips
+
+From the attachment page in district court PACER websites, there is a button to get all the documents for a particular docket entry as a zip. Such zips can be uploaded using the same parameters as PDFs, using the `upload_type` of `10`.
+
+### Uploading Attachment Pages
+
+These are the HTML pages that you will see that list the attachments for a docket entry. The only required field for this upload type is `pacer_case_id`.
+
+### A Complete Example
+
+Pulling this all together, a docket upload might look like:
+
+```
+curl -v \
+  --form upload_type=1 \
+  --form "filepath_local=@docket.html" \
+  --form court=dcd \
+  --form pacer_case_id=<some-value> \
+  --form debug=true \
+  'https://www.courtlistener.com/api/rest/v4/recap/'
+  --header 'Authorization: Token <your-token-here>'
+```
+
+In response, you would receive an object like this:
+
+```json
+{
+  "id": 13684105,
+  "court": "dcd",
+  "docket": null,
+  "docket_entry": null,
+  "recap_document": null,
+  "date_created": "2024-05-18T08:01:14.457637-07:00",
+  "date_modified": "2024-05-18T08:01:14.953939-07:00",
+  "pacer_case_id": "",
+  "pacer_doc_id": "",
+  "acms_document_guid": "",
+  "document_number": null,
+  "attachment_number": null,
+  "status": 1,
+  "upload_type": 1,
+  "error_message": "",
+  "debug": false
+}
+```
+
+Then, to check the status, you can poll it with:
+
+```
+curl \
+  'https://www.courtlistener.com/api/rest/v4/recap/13684105/'
+  --header 'Authorization: Token <your-token-here>'
+```
+
+Which will soon return:
+
+```json
+{
+  "id": 13684105,
+  "court": "dcd",
+  "docket": "https://www.courtlistener.com/api/rest/v4/dockets/8903924/",
+  "docket_entry": null,
+  "recap_document": null,
+  "date_created": "2024-05-18T08:01:14.457637-07:00",
+  "date_modified": "2024-05-18T08:01:14.953939-07:00",
+  "pacer_case_id": "",
+  "pacer_doc_id": "",
+  "acms_document_guid": "",
+  "document_number": null,
+  "attachment_number": null,
+  "status": 2,
+  "upload_type": 1,
+  "error_message": "Successful upload! Nice work.",
+  "debug": false
+}
+```
+
+Note that:
+
+- The `error_message` and `docket` fields are completed.
+- The `status` field is now `2`.
+
+[recap-tests]: https://github.com/freelawproject/courtlistener/blob/main/cl/recap/tests/tests.py
+[pacer-api]: pacer-api.md

--- a/wiki-exports/rest-api-v1.md
+++ b/wiki-exports/rest-api-v1.md
@@ -1,0 +1,392 @@
+---
+title: "REST API, v1"
+description: "The first REST API for federal and state case law and still the best. Provided by Free Law Project, a 501(c)(3) non-profit."
+redirect_from: "/help/api/rest/v1/overview/"
+wiki_path: "/c/courtlistener/help/api/rest/v1/overview/"
+search_engines: false
+ai_assistants: false
+---
+
+> [!WARNING]
+> **Deprecated** — These notes are for a version of the API that has been deprecated and will soon be disabled completely. Please use the [latest version][rest-api], as these notes are only maintained to help with migrations.
+
+
+## General Notes
+
+For developers that wish to have a more granular API for our data, we provide a RESTful API based on the [tastypie toolkit][tastypie].
+
+This API currently has seven endpoints that can be consumed via GET requests:
+
+1. [/api/rest/v1/opinion/][api-v1-opinion]
+2. [/api/rest/v1/cites/][api-v1-cites]
+3. [/api/rest/v1/cited-by/][api-v1-cited-by]
+4. [/api/rest/v1/citation/][api-v1-citation]
+5. [/api/rest/v1/jurisdiction/][api-v1-jurisdiction]
+6. [/api/rest/v1/search/][api-v1-search]
+7. [/api/rest/v1/coverage/all/][api-v1-coverage]
+
+These endpoints can be used in combination to make sophisticated queries against our database or our search engine and are described in detail below. With the exception of the coverage endpoint, each of these have schema documents associated with them that can be found by appending "schema" to their location (e.g. [/api/rest/v1/opinion/schema/][api-v1-opinion-schema]).
+
+[api-v1-opinion]: https://www.courtlistener.com/api/rest/v1/opinion/
+[api-v1-cites]: https://www.courtlistener.com/api/rest/v1/cites/
+[api-v1-cited-by]: https://www.courtlistener.com/api/rest/v1/cited-by/
+[api-v1-citation]: https://www.courtlistener.com/api/rest/v1/citation/
+[api-v1-jurisdiction]: https://www.courtlistener.com/api/rest/v1/jurisdiction/
+[api-v1-search]: https://www.courtlistener.com/api/rest/v1/search/
+[api-v1-coverage]: https://www.courtlistener.com/api/rest/v1/coverage/all/
+[api-v1-opinion-schema]: https://www.courtlistener.com/api/rest/v1/opinion/schema/
+
+
+### Overview of Endpoints
+
+This section explains general principles of the API and rules that apply to all of our RESTful endpoints.
+
+
+#### Authentication
+
+With the exception of the coverage endpoint, all of the endpoints use either [HTTP Basic Authentication][basic-auth] or Django Session Authentication. To use the API, you must therefore either be logged into the CourtListener website (Session Authentication) or you must use your CourtListener credentials to set up HTTP Basic Authentication. Both of these authentication mechanisms protect your credentials on the wire via HTTPS.
+
+To do HTTP Basic Authentication using cURL, you might do something like this:
+
+```
+curl --user "harvey:your-password" "https://www.courtlistener.com/api/rest/v1/opinion/"
+```
+
+You can also do it in your browser with a url like:
+
+```
+https://harvey:your-password@www.courtlistener.com/api/rest/v1/opinion/
+```
+
+But that's not normally necessary because most browsers will provide you with a popup if you need to authenticate using HTTP Basic Authentication.
+
+Authentication is necessary so we can monitor usage of the system and so we can assist with any errors that may occur. Per our [privacy policy][privacy], we do not track your queries in the API, though we may collect statistical information for system monitoring.
+
+
+#### Serialization Formats
+
+With the exception of the coverage endpoint (which is only available as JSON), requests may be serialized as JSON, JSONP, or XML, with JSON as the default. The format you wish to receive may be requested via the HTTP `Accept` header or via the `format` GET parameter.
+
+Note that because your browser prioritizes `application/xml` over `application/json`, you'll always receive XML when using your browser to explore our APIs. If you wish to override this, you may wish to use a less opinionated way of GETting resources such as cURL or you can override it using the `format` GET parameter, like so:
+
+```
+https://www.courtlistener.com/api/rest/v1/opinion/?format=json
+```
+
+If you wish to receive XML via a tool such as cURL, set the Accept header manually, like so:
+
+```
+curl -H "Accept: application/xml" https://www.courtlistener.com/api/rest/v1/opinion/
+```
+
+Or again, you can use the `format` GET parameter:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/opinion/?format=xml
+```
+
+
+#### Views, Pagination and Subset Selection
+
+Each endpoint provides a list view, a detail view and a set view. The *list* view is what you see when you visit an endpoint, when it shows a list of results. The *detail* view shows all meta data for a single result and can be viewed by following the `resource_uri` field for a result on the list view. Occasionally, content is excluded from the list view for performance reasons, but it may be available on the detail view. With the exception of the coverage API, links to the next and previous pages are available in the `meta` section of the results.
+
+A subset of results may be selected by using the *set* view, and separating the IDs you wish to receive with semi-colons. For example this returns three jurisdictions using the `jurisdiction` endpoint:
+
+```
+curl "https://www.courtlistener.com/api/rest/v1/jurisdiction/set/scotus;ca9;cal"
+```
+
+Note that we use quotation marks in this query in order to escape shell interpretation of the semicolons.
+
+
+#### Filtering
+
+With the exception of the coverage endpoint, each endpoint can be filtered in various ways, as defined in their schema (available at `/api/rest/v1/$endpoint/schema/`). In the schemas you will find rules defining how each field can be filtered. These correspond to the [field lookups in the Django Queryset API][django-lookups]. If a field has `1` as its available rule, that indicates that *all* Django Queryset field lookups are available on that field.
+
+Field lookups can be used by appending them to a field with a double underscore as a separator (examples are below in the documentation for various endpoints).
+
+
+#### Ordering
+
+With the exception of the coverage endpoint, ordering can be done on fields defined in the *ordering* section of an endpoint's schema. Ordering is done using the `order_by` GET parameter, with descending ordering available by prepending the minus sign (e.g. `order_by=-date_modified`). However, because the *search* endpoint uses Solr for its backend, ordering is instead done using the `asc` and `desc`, as described in detail below. This allows the URLs used for the search endpoint to match those used in front-end queries.
+
+
+#### Field Selection
+
+To save bandwidth and speed up your queries, fields can be limited by using the `fields` GET parameter with a comma-separated list of fields you wish to receive. For example, if you wish to only receive the `resource_uri` and `absolute_url` fields from the `opinion` endpoint you could do so with:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/opinion/?fields=absolute_url,resource_uri
+```
+
+Using the double underscore syntax, this can also be used for nested resources. For example, the `opinion` endpoint nests the `citation` endpoint in its results and the `citation` endpoint has a field called `federal_cite_one`. If you wished to use the `opinion` endpoint to only get back the nested `federal_cite_one` field, you could do so with:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/opinion/?fields=citation__federal_cite_one
+```
+
+Using the `fields` parameter in these ways could save you time and bandwidth if you are making many requests.
+
+
+#### Limitations
+
+At present, this API is throttled to 1,000 queries per endpoint per user per hour, while we learn where our performance bottlenecks are. If you are hitting this limit or anticipate doing so, please get in touch so we can investigate easing your thresholds.
+
+On the list view, 20 results are shown at a time by default. This can be limited to show fewer results, but cannot be set to show more. The `jurisdiction` endpoint allows up to 1,000 results at a time by setting the `limit` GET parameter like so:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/jurisdiction/?limit=50
+```
+
+
+#### Date Formats
+
+As [required][xkcd-dates], all date formats are set to [ISO-8601 format][iso-8601].
+
+
+#### The `absolute_url` Field
+
+The `absolute_url` field shows the URL where a resource can be seen live on the site. It is absolute in the sense that it should never change.
+
+In some cases you might only have a URL, and you might want to look up the item in the API. `absolute_url`s generally look like this:
+
+```
+/$document-type/$numeric-id/$name-of-the-case/
+```
+
+There are three sections:
+
+1. **$document-type**: This is the type of document that has been returned, for example, "opinion" indicates that you have gotten an opinion as your result.
+2. **$numeric-id**: This is a numeric representation of the ID for the document. This value increments as we add content to the system. Note that due to deletions and modifications the numeric IDs are not guaranteed to be purely sequential — IDs will be missing.
+3. **$name-of-the-case**: This is the "[slug][slug-wiki]" of the document, and generally mirrors its case name. This value can change if we clean up a case name, but provided it is not omitted completely, this part of the URL can be any value without ever affecting the page that is loaded.
+
+
+#### IDs and SHA1 Sums
+
+Because of the way the data is organized in our backend, there is a unique ID for each citation and each opinion. This means that when you are working with the `citation` endpoint, you cannot use the opinion IDs, and vice versa. For example, this:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/opinion/111170/
+```
+
+Returns *[Strickland v. Washington][strickland]*. But this does not:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/citation/111170/
+```
+
+In addition to this, each opinion has a globally unique [SHA1][sha1] sum that can be queried using the search endpoint:
+
+```
+https://www.courtlistener.com/api/rest/v1/search/?q=a2daab35251795fc2621c6ac46b6031c95a4e0ba
+```
+
+[strickland]: https://www.courtlistener.com/opinion/111170/strickland-v-washington/
+
+
+#### Upgrades and Fixes
+
+Like the rest of the CourtListener platform, this API and its documentation are [open source][cl-api-source]. If it lacks functionality that you desire or if you find [these notes][cl-api-templates] lacking, pull requests providing improvements are very welcome. Just get in touch in [our developer forum][dev-forum] to discuss your ideas or, hey, go ahead and send us a pull request.
+
+[cl-api-source]: https://github.com/freelawproject/courtlistener/tree/main/alert/search/api.py
+[cl-api-templates]: https://github.com/freelawproject/courtlistener/tree/main/alert/assets/templates/api
+[dev-forum]: https://lists.freelawproject.org/cgi-bin/mailman/listinfo/dev
+
+
+### /api/rest/v1/opinion/
+
+This can be considered the main endpoint for many users. It provides access to the opinions in our database and can be filtered or ordered in various ways as mentioned above. As with all endpoints, field descriptions can be found in the schema document. Visiting this endpoint provides the metadata for 20 opinions at a time. The full text of the opinions may be found by visiting their detail page, which can be found by following the `resource_uri` attribute for a result. Full text is not provided by default to save on bandwidth and processing.
+
+The results at this endpoint can be filtered by a number of fields. Among others, this includes filtering by:
+
+- `blocked`: Whether the opinion should be blocked from search engines.
+- `citation_count`: The number of times the opinion has been cited by other opinions.
+- `court`: The ID of the court where the opinion was written.
+- `date_filed`: The date the opinion was filed by the court.
+- `date_modified`: The date and time the opinion was last modified.
+- `extracted_by_ocr`: Whether the text of the opinion was extracted from an image using OCR.
+- `precedential_status`: Whether the opinion has precedential value.
+- `time_retrieved`: The date and time the opinion was added to our system.
+
+For the full list of filtering fields, see the *filtering* section of the [schema document][api-v1-opinion-schema].
+
+As mentioned above, in the schema document you will find that each filtering field provides a list of field lookups that are available to it. The following query provides an example of these lookups in use. Observe the following query, which gets all items that were modified after June 9th, 2013 (`__gt`), ordered by `date_modified` (ascending).
+
+```
+curl https://www.courtlistener.com/api/rest/v1/opinion/?date_modified__gt=2013-06-09+00:00Z&order_by=date_modified
+```
+
+And remember, to flip the ordering, you can use a minus sign in your ordering argument (`order_by=-date_modified`).
+
+The results of this endpoint can also be ordered by `time_retrieved`, `date_modified`, `date_filed`, or `date_blocked`. Again, this is described in more detail in the schema.
+
+
+### /api/rest/v1/cites/ and /api/rest/v1/cited-by/
+
+These endpoints provide interfaces into the citation graph that CourtListener provides between opinions. `/cites/` provides a paginated display of the opinions that an opinion *cites*, and `cited-by` provides a paginated display of the opinions that cite an opinion. These can be thought of as compliments, though the results can be dramatically different. For example, a very important opinion, *[Strickland v. Washington][strickland-scotus]*, has been cited thousands of times (`cited-by`), however no opinion cites thousands of other opinions (`cites`).
+
+These endpoints only provide limited functionality. They cannot be filtered or ordered, and they do not provide a detail or set view. To use these endpoints, provide the ID of the opinion you wish to analyze, like so:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/cited-by/?id=111170
+```
+
+Or the reverse:
+
+```
+curl https://www.courtlistener.com/api/rest/v1/cites/?id=111170
+```
+
+The `id` parameter is required.
+
+[strickland-scotus]: https://www.courtlistener.com/scotus/z3J/strickland-v-washington/
+
+
+### /api/rest/v1/citation/
+
+This endpoint is integrated into the `/opinion/` endpoint and is also available individually. This endpoint provides each of the many citations that an opinion can have. Since opinions are often included in several written reporters, there are fields in this model for numerous [parallel citations][parallel-citations].
+
+After several years reorganizing our schema, we currently categorize citations into the following types:
+
+- Neutral (e.g. 2013 FL 1)
+- Federal (e.g. 5 F. 55)
+- State (e.g. Alabama Reports)
+- Regional (e.g. Atlantic Reporter)
+- Specialty (e.g. Lawyers' Edition)
+- Old Supreme Court (e.g. 5 Black. 55)
+- Lexis or West (e.g. 5 LEXIS 55, or 5 WL 55)
+
+Some opinions have multiple citations of a given type, and to support those instances we provide several fields of that type. For example, we have fields for `federal_cite_one`, `federal_cite_two`, and `federal_cite_three`, which together can hold three parallel federal citations for a single opinion.
+
+All of the filtering, ordering and field lookups described above can be used on this endpoint, as described in its [schema][api-v1-citation-schema]. This endpoint also provides a field called `opinion_uris`, which references the parent opinion for a citation.
+
+At present, for performance reasons it is not possible to filter based on a citation. For this purpose, we recommend the [search endpoint](#apirestv1search). For instance, when you know a citation and want to see what information we have about it, try something like: <https://www.courtlistener.com/api/rest/v1/search/?citation=101%20U.S.%2099>.
+
+[api-v1-citation-schema]: https://www.courtlistener.com/api/rest/v1/citation/schema/
+
+
+### /api/rest/v1/jurisdiction/
+
+This is the simplest of our REST endpoints and currently provides basic information about the hundreds of jurisdictions in the American court system that we support.
+
+This endpoint can be filtered or ordered in numerous ways as described in its [schema][api-v1-jurisdiction-schema]. Brief descriptions of the fields can be found there as well.
+
+[api-v1-jurisdiction-schema]: https://www.courtlistener.com/api/rest/v1/jurisdiction/schema/
+
+
+### /api/rest/v1/search/
+
+This endpoint allows you to query our search engine along the same lines as is possible in our front end. Because this endpoint does not use the Django models directly, this endpoint is quite different than the others. Several differences should be noted.
+
+First, the fields and results from this endpoint are slightly different than those in the other endpoints. For example, instead of using a minus sign to flip ordering, it uses `asc` and `desc`. And instead of the `court` field returning a reference to the `jurisdiction` endpoint, it provides the name of the jurisdiction where the opinion was issued. (See [the schema][api-v1-search-schema] and the notes below for all of the ordering options and field information).
+
+Similarly, since this endpoint hits against a Solr search index instead of a database, the filtering works slightly differently. To filter on this endpoint, we recommend identifying an effective query on the front end that generates the results you desire. Using that query (and variations thereof), it is possible to easily apply it to this endpoint.
+
+Finally, note that like the front end, only precedential results are returned by default. See below for an example that returns non-precedential results as well.
+
+When examining the *filtering* section of the schema, note that fields have been labeled as follows:
+
+**search**
+: These fields are filterable according to the syntax defined in the [advanced query techniques][advanced-search] available on the front end.
+
+**int**
+: These fields require ints as their arguments, and generally provide greater-than or less-than queries.
+
+**date**
+: These fields allow you to search for dates greater than or less than a given value. Input dates ascribe to ISO-8601 format, however, partial dates are allowed, and will be interpreted appropriately. For example, placing "2012" in the `filed_after` parameter will assume you mean opinions after "2012-01-01".
+
+**Boolean**
+: Only the stat_* field is currently available as boolean. This field is represented by checkboxes in the front end, and can be enabled by setting its value to "on". For example to include only Precedential documents, you might place a query like:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v1/search/?stat_Precedential=on
+  ```
+
+**CSV**
+: The `court` field is currently available as a list of comma separated values (CSV). Thus, to request multiple courts, you can simply separate their IDs with a comma. For example to get all documents from the Supreme Court (`scotus`) and the Ninth Circuit of Appeals (`ca9`), you would make a query like:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v1/search/?court=scotus,ca9
+  ```
+
+  IDs for all jurisdictions are available at the [jurisdictions page][jurisdictions].
+
+Four fields warrant special explanation:
+
+**`resource_uri`**
+: Because this endpoint is designed to help find opinions, once you've found the ones you want, we provide a `resource_uri` that directs you back to the `opinion` endpoint, which has all of the best meta data. This is in contrast to any of the other endpoints.
+
+**`snippet`**
+: This field contains the same values as are found on the front end, utilizing the HTML5 `<mark>` element to identify up to five matches in an opinion. If you wish to use the snippet but do not want highlighting, simply use CSS to give the `mark` element no styling, like a `span` element. This field only responds to arguments provided to the `q` parameter. If that parameter is not used, the `snippet` field will show the first 500 characters of the `text` field.
+
+**`stat_*`**
+: For this Boolean field, we provide opinionated default values. Because most searchers are not interested in non-precedential (unpublished) results, we leave them out by default. If you wish to receive these items, you must explicitly ask for them as you do on the front end. For example, this query returns both precedential (published) and non-precedential (unpublished) results:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v1/search/?stat_Precedential=on&stat_Non-Precedential=on
+  ```
+
+**`court`**
+: This field provides the name of the jurisdiction where the opinion was issued. In other endpoints, this field directs you to the `jurisdiction` endpoint.
+
+[api-v1-search-schema]: https://www.courtlistener.com/api/rest/v1/search/schema/
+
+
+### /api/rest/v1/coverage/
+
+Unlike the other endpoints in this API, the coverage endpoint is not based on the tastypie API framework. As a result it is much simpler, only providing data in a very specific manner, serialized as JSON. In the future we expect to expand this API to provide faceting along additional fields, but at present it simply provides jurisdiction counts by year for any requested jurisdiction. This API does not require authentication and is what powers our live [coverage page][coverage].
+
+To receive jurisdiction counts by year, simply provide the jurisdiction ID you wish to query or the special keyword, "all", which returns counts for all jurisdictions. For example, this provides annual counts for the Ninth Circuit of Appeals (`ca9`):
+
+```
+curl https://www.courtlistener.com/api/rest/v1/coverage/ca9/
+```
+
+[coverage]: https://www.courtlistener.com/coverage/
+
+
+## Available Jurisdictions
+
+We currently have hundreds of jurisdictions that can be accessed with our APIs. Details about the jurisdictions that are available can be found [here][jurisdictions].
+
+
+## CiteGeist Scores
+
+If you are interested in the CiteGeist score for each opinion, it is now available via our [bulk data API][bulk-data].
+
+
+## Maintenance Schedule
+
+We regularly perform bulk tasks on our servers and have [a public calendar][calendar] for tracking them. If you intend to do bulk crawling of our API, please be mindful of this schedule.
+
+
+## Browser Tools
+
+Several tools are available to help view JSON in your browser. If you are using Firefox, check out [JSONovitch][jsonovitch]. If you are using Chrome, check out [JSONView][jsonview].
+
+[jsonovitch]: https://addons.mozilla.org/en-US/firefox/addon/jsonovich/
+[jsonview]: https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=en
+
+
+## Copyright
+
+Our data is free of known copyright restrictions.
+
+[![Public Domain Mark][cc-pd-img]][cc-pd]
+
+[rest-api]: rest-api.md
+[tastypie]: https://django-tastypie.readthedocs.org/en/latest/
+[basic-auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
+[privacy]: https://www.courtlistener.com/terms/#privacy
+[django-lookups]: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+[xkcd-dates]: https://xkcd.com/1179/
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+[slug-wiki]: https://en.wikipedia.org/wiki/Slug_%28publishing%29
+[sha1]: https://en.wikipedia.org/wiki/SHA-1
+[parallel-citations]: https://legalresearchprinciples.pbworks.com/w/page/16129937/Parallel%20Citations
+[advanced-search]: https://www.courtlistener.com/help/search/
+[jurisdictions]: https://www.courtlistener.com/help/api/jurisdictions/
+[bulk-data]: https://www.courtlistener.com/help/api/bulk-data/
+[calendar]: https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles
+[cc-pd]: https://creativecommons.org/publicdomain/mark/1.0/
+[cc-pd-img]: https://www.courtlistener.com/static/png/cc-pd.png

--- a/wiki-exports/rest-api-v2.md
+++ b/wiki-exports/rest-api-v2.md
@@ -1,0 +1,444 @@
+---
+title: "REST API, v2"
+description: "The first REST API for federal and state case law and still the best. Provided by Free Law Project, a 501(c)(3) non-profit."
+redirect_from: "/help/api/rest/v2/overview/"
+wiki_path: "/c/courtlistener/help/api/rest/v2/overview/"
+search_engines: false
+ai_assistants: false
+---
+
+> [!WARNING]
+> **Deprecated** — These notes are for a version of the API that has been deprecated and will soon be disabled completely. Please use the [latest version][rest-api], as these notes are only maintained to help with migrations.
+
+
+## General Notes
+
+For developers that wish to have a more granular API for our data, we provide a RESTful API based on the [tastypie toolkit][tastypie].
+
+This API currently has nine endpoints that can be consumed via GET requests:
+
+1. [/api/rest/v2/docket/][api-v2-docket]
+2. [/api/rest/v2/audio/][api-v2-audio]
+3. [/api/rest/v2/document/][api-v2-document]
+4. [/api/rest/v2/cites/][api-v2-cites]
+5. [/api/rest/v2/cited-by/][api-v2-cited-by]
+6. [/api/rest/v2/citation/][api-v2-citation]
+7. [/api/rest/v2/jurisdiction/][api-v2-jurisdiction]
+8. [/api/rest/v2/search/][api-v2-search]
+9. [/api/rest/v2/coverage/all/][api-v2-coverage]
+
+These endpoints can be used in combination to make sophisticated queries against our database or our search engine and are described in detail below. With the exception of the coverage endpoint, each of these have schema documents associated with them that can be found by appending "schema" to their location (e.g. [/api/rest/v2/document/schema/][api-v2-document-schema]).
+
+The following representation of our database should be instructive when thinking about how these endpoints work together:
+
+![Schema design diagram][schema-design]
+
+(A more detailed version of this diagram [was posted to our developer mailing list][schema-detail].)
+
+[schema-design]: https://www.courtlistener.com/static/png/schema-design.png
+[schema-detail]: https://lists.freelawproject.org/pipermail/dev/2014-September/000084.html
+[api-v2-docket]: https://www.courtlistener.com/api/rest/v2/docket/
+[api-v2-audio]: https://www.courtlistener.com/api/rest/v2/audio/
+[api-v2-document]: https://www.courtlistener.com/api/rest/v2/document/
+[api-v2-cites]: https://www.courtlistener.com/api/rest/v2/cites/
+[api-v2-cited-by]: https://www.courtlistener.com/api/rest/v2/cited-by/
+[api-v2-citation]: https://www.courtlistener.com/api/rest/v2/citation/
+[api-v2-jurisdiction]: https://www.courtlistener.com/api/rest/v2/jurisdiction/
+[api-v2-search]: https://www.courtlistener.com/api/rest/v2/search/
+[api-v2-coverage]: https://www.courtlistener.com/api/rest/v2/coverage/all/
+[api-v2-document-schema]: https://www.courtlistener.com/api/rest/v2/document/schema/
+
+The basic ideas are:
+
+- Each Audio file and each Document are associated with a Docket, and each Docket can have many Documents or Audio files associated with it (sometimes thousands).
+- Each Docket is associated with a single jurisdiction. Generally, this is the court where the dispute was litigated. If the case moves between jurisdictions, each jurisdiction has its own docket.
+- Each Document, if it is an Opinion, has an associated Citation object.
+- Different Documents cite different Citations, forming a many to many relationship (cases_cited).
+
+
+### Overview of Endpoints
+
+This section explains general principles of the API and rules that apply to all of our RESTful endpoints.
+
+
+#### Authentication
+
+With the exception of the coverage endpoint, all of the endpoints use either [HTTP Basic Authentication][basic-auth] or Django Session Authentication. To use the API, you must therefore either be logged into the CourtListener website (Session Authentication) or you must use your CourtListener credentials to set up HTTP Basic Authentication. Both of these authentication mechanisms protect your credentials on the wire via HTTPS.
+
+To do HTTP Basic Authentication using cURL, you might do something like this:
+
+```
+curl --user "harvey:your-password" "https://www.courtlistener.com/api/rest/v2/document/"
+```
+
+You can also do it in your browser with a url like:
+
+```
+https://harvey:your-password@www.courtlistener.com/api/rest/v2/document/
+```
+
+But that's not normally necessary because most browsers will provide you with a popup if you need to authenticate using HTTP Basic Authentication.
+
+Authentication is necessary so we can monitor usage of the system and so we can assist with any errors that may occur. Per our [privacy policy][privacy], we do not track your queries in the API, though we may collect statistical information for system monitoring.
+
+
+#### Serialization Formats
+
+With the exception of the coverage endpoint (which is only available as JSON), requests may be serialized as JSON, JSONP, or XML, with JSON as the default. The format you wish to receive may be requested via the HTTP `Accept` header or via the `format` GET parameter.
+
+Note that because your browser prioritizes `application/xml` over `application/json`, you'll always receive XML when using your browser to explore our APIs. If you wish to override this, you may wish to use a less opinionated way of GETting resources such as cURL or you can override it using the `format` GET parameter, like so:
+
+```
+https://www.courtlistener.com/api/rest/v2/document/?format=json
+```
+
+If you wish to receive XML via a tool such as cURL, set the Accept header manually, like so:
+
+```
+curl -H "Accept: application/xml" https://www.courtlistener.com/api/rest/v2/document/
+```
+
+Or again, you can use the `format` GET parameter:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/document/?format=xml
+```
+
+
+#### Views, Pagination and Subset Selection
+
+Each endpoint provides a list view, a detail view and a set view. The *list* view is what you see when you visit an endpoint, when it shows a list of results. The *detail* view shows all meta data for a single result and can be viewed by following the `resource_uri` field for a result on the list view. Occasionally, content is excluded from the list view for performance reasons, but it may be available on the detail view. With the exception of the coverage API, links to the next and previous pages are available in the `meta` section of the results.
+
+A subset of results may be selected by using the *set* view, and separating the IDs you wish to receive with semi-colons. For example this returns three jurisdictions using the `jurisdiction` endpoint:
+
+```
+curl "https://www.courtlistener.com/api/rest/v2/jurisdiction/set/scotus;ca9;cal"
+```
+
+Note that we use quotation marks in this query in order to escape shell interpretation of the semicolons.
+
+
+#### Filtering
+
+With the exception of the coverage endpoint, each endpoint can be filtered in various ways, as defined in their schema (available at `/api/rest/v2/$endpoint/schema/`). In the schemas you will find rules defining how each field can be filtered. These correspond to the [field lookups in the Django Queryset API][django-lookups]. If a field has `1` as its available rule, that indicates that *all* Django Queryset field lookups are available on that field.
+
+Field lookups can be used by appending them to a field with a double underscore as a separator (examples are below in the documentation for various endpoints).
+
+
+#### Ordering
+
+With the exception of the coverage endpoint, ordering can be done on fields defined in the *ordering* section of an endpoint's schema. Ordering is done using the `order_by` GET parameter, with descending ordering available by prepending the minus sign (e.g. `order_by=-date_modified`). However, because the *search* endpoint uses Solr for its backend, ordering is instead done using the `asc` and `desc`, as described in detail below. This allows the URLs used for the search endpoint to match those used in front-end queries.
+
+
+#### Field Selection
+
+To save bandwidth and speed up your queries, fields can be limited by using the `fields` GET parameter with a comma-separated list of fields you wish to receive.
+
+For example, if you wish to only receive the `resource_uri` and `absolute_url` fields from the `document` endpoint you could do so with:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/document/?fields=absolute_url,resource_uri
+```
+
+Using the double underscore syntax, this can also be used for nested resources. For example, the `document` endpoint nests the `citation` endpoint in its results and the `citation` endpoint has a field called `federal_cite_one`. If you wished to use the `document` endpoint to only get back the nested `federal_cite_one` field, you could do so with:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/document/?fields=citation__federal_cite_one
+```
+
+Using the `fields` parameter in these ways could save both of us time and bandwidth if you are making many requests. Please consider using this parameter for your requests.
+
+
+#### Limitations
+
+At present, this API is throttled to 1,000 queries per endpoint per user per hour, while we learn where our performance bottlenecks are. If you are hitting this limit or anticipate doing so, please get in touch so we can investigate easing your thresholds.
+
+On the list view, 20 results are shown at a time by default. This can be limited to show fewer results, but cannot be set to show more. The `jurisdiction` endpoint allows up to 1,000 results at a time by setting the `limit` GET parameter like so:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/jurisdiction/?limit=50
+```
+
+
+#### Date Formats
+
+As [required by influential comic strips][xkcd-dates], all date formats are set to [ISO-8601 format][iso-8601].
+
+
+#### The `absolute_url` Field
+
+The `absolute_url` field shows the URL where a resource can be seen live on the site. It is absolute in the sense that it should never change and will always be backwards compatible if changes are ever needed (as in the upgrade to v2 of this API).
+
+In some cases you might only have a URL, and you might want to look up the item in the API. `absolute_url`s generally look like this:
+
+```
+/$document-type/$numeric-id/$name-of-the-case/
+```
+
+There are three sections:
+
+1. **$document-type**: This is the type of document that has been returned, for example, "opinion" indicates that you have gotten an opinion as your result.
+2. **$numeric-id**: This is a numeric representation of the ID for the document. This value increments as we add content to the system. Note that due to deletions and modifications the numeric IDs are not guaranteed to be purely sequential — IDs will be missing.
+3. **$name-of-the-case**: This is the "[slug][slug-wiki]" of the document, and generally mirrors its case name. This value can change if we clean up a case name, but provided it is not omitted completely, this part of the URL can be any value without ever affecting the page that is loaded. Put another way, we load pages based on the `$numeric-id` and `$document-type`, not by the name of the case.
+
+[slug-wiki]: https://en.wikipedia.org/wiki/Slug_%28publishing%29
+
+
+#### IDs and SHA1 Sums
+
+Because of the way the data is organized in our backend, there is a unique ID for each citation and each document. This means that when you are working with the `citation` endpoint, you cannot use the document IDs, and vice versa. For example, this:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/document/111170/
+```
+
+Returns *[Strickland v. Washington][strickland]*. But this does not:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/citation/111170/
+```
+
+Even though they have the same ID. Each document and audio file also has a globally unique [SHA1][sha1] sum that can be queried using the search endpoint:
+
+```
+https://www.courtlistener.com/api/rest/v2/search/?q=a2daab35251795fc2621c6ac46b6031c95a4e0ba
+```
+
+To get audio results, also set the type parameter to `oa`, for oral arguments.
+
+[strickland]: https://www.courtlistener.com/opinion/111170/strickland-v-washington/
+
+
+#### Upgrades and Fixes
+
+Like the rest of the CourtListener platform, this API and its documentation are [open source][cl-api-source]. If it lacks functionality that you desire or if you find [these notes][cl-api-templates] lacking, pull requests providing improvements are very welcome. Just get in touch in [our developer forum][dev-forum] to discuss your ideas or, if it's a quick thing, just go ahead and send us a pull request.
+
+[cl-api-source]: https://github.com/freelawproject/courtlistener/tree/main/alert/search/api2.py
+[cl-api-templates]: https://github.com/freelawproject/courtlistener/tree/main/alert/assets/templates/api
+[dev-forum]: https://lists.freelawproject.org/cgi-bin/mailman/listinfo/dev
+
+
+### /api/rest/v2/document/
+
+This can be considered the main endpoint for many users. It provides access to the documents in our database and can be filtered or ordered in various ways as mentioned above. As with all endpoints, field descriptions can be found in the schema document. Visiting this endpoint provides the metadata for 20 documents at a time. The full text of the documents may be found by visiting their detail page, which can be found by following the `resource_uri` attribute for a result. Full text is not provided by default to save on bandwidth and processing.
+
+The results at this endpoint can be filtered by a number of fields. Among others, this includes filtering by:
+
+- `blocked`: Whether the document should be blocked from search engines.
+- `citation_count`: The number of times the document has been cited by other documents.
+- `court`: The ID of the court where the document was written.
+- `date_filed`: The date the document was filed by the court.
+- `date_modified`: The date and time the document was last modified.
+- `extracted_by_ocr`: Whether the text of the document was extracted from an image using OCR.
+- `precedential_status`: Whether the document has precedential value.
+- `time_retrieved`: The date and time the document was added to our system.
+
+For the full list of filtering fields, see the *filtering* section of the [schema document][api-v2-document-schema-json].
+
+As mentioned above, in the schema document you will find that each filtering field provides a list of field lookups that are available to it. The following query provides an example of these lookups in use. Observe the following query, which gets all items that were modified after June 9th, 2013 (`__gt`), ordered by `date_modified` (ascending).
+
+```
+curl https://www.courtlistener.com/api/rest/v2/document/?date_modified__gt=2013-06-09+00:00Z&order_by=date_modified
+```
+
+And remember, to flip the ordering, you can use a minus sign in your ordering argument (`order_by=-date_modified`).
+
+The results of this endpoint can also be ordered by `time_retrieved`, `date_modified`, `date_filed`, or `date_blocked`. Again, this is described in more detail in the schema.
+
+[api-v2-document-schema-json]: https://www.courtlistener.com/api/rest/v2/document/schema/?format=json
+
+
+### /api/rest/v2/audio/
+
+The `audio` endpoint is modeled after the `document` endpoint and has very similar behavior, except instead of serving documents, it currently serves oral arguments and may later serve other similar audio files. As with the document endpoint, it can be filtered and ordered by various fields as described in its [schema document][api-v2-audio-schema].
+
+Aside from these few notes, the `audio` endpoint should be very familiar and should have no surprises.
+
+[api-v2-audio-schema]: https://www.courtlistener.com/api/rest/v2/audio/schema/?format=json
+
+
+### /api/rest/v2/cites/ and /api/rest/v2/cited-by/
+
+These endpoints provide interfaces into the citation graph that CourtListener provides between documents. `/cites/` provides a paginated display of the documents that a document *cites*, and `cited-by` provides a paginated display of the documents that cite a document. These can be thought of as compliments, though the results can be dramatically different. For example, a very important document, *[Strickland v. Washington][strickland-scotus]*, has been cited thousands of times (`cited-by`), however no document cites thousands of other documents (looking in the database, it appears the limit is around 400 authorities).
+
+These endpoints only provide limited functionality. They cannot be filtered or ordered and they do not provide a detail or set view. To use these endpoints, provide the ID of the document you wish to analyze, like so:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/cited-by/?id=111170
+```
+
+Or the reverse:
+
+```
+curl https://www.courtlistener.com/api/rest/v2/cites/?id=111170
+```
+
+The `id` parameter is required.
+
+[strickland-scotus]: https://www.courtlistener.com/opinion/111170/strickland-v-washington/
+
+
+### /api/rest/v2/citation/
+
+This endpoint is integrated into the `document` endpoint and is also available individually. This endpoint provides each of the many citations that an opinion can have. Since opinions are often included in several written reporters, there are fields in this model for numerous [parallel citations][parallel-citations].
+
+After several years reorganizing our schema, we currently categorize citations into the following types:
+
+- Neutral (e.g. 2013 FL 1)
+- Federal (e.g. 5 F. 55)
+- State (e.g. Alabama Reports)
+- Regional (e.g. Atlantic Reporter)
+- Specialty (e.g. Lawyers' Edition)
+- Old Supreme Court (e.g. 5 Black. 55)
+- Lexis or West (e.g. 5 LEXIS 55, or 5 WL 55)
+
+Some opinions have multiple citations of a given type, and to support those instances we provide several fields of that type. For example, we have fields for `federal_cite_one`, `federal_cite_two`, and `federal_cite_three`, which together can hold three parallel federal citations for a single opinion.
+
+All of the filtering, ordering and field lookups described above can be used on this endpoint, as described in its [schema][api-v2-citation-schema]. This endpoint also provides a field called `opinion_uris`, which references the parent opinion for a citation.
+
+At present, for performance reasons it is not possible to filter based on a citation. For this purpose, we recommend the [search endpoint](#apirestv2search). For instance, when you know a citation and want to see what information we have about it, try something like: <https://www.courtlistener.com/api/rest/v2/search/?citation=101%20U.S.%2099>.
+
+[api-v2-citation-schema]: https://www.courtlistener.com/api/rest/v2/citation/schema/?format=json
+
+
+### /api/rest/v2/jurisdiction/
+
+This is the simplest of our REST endpoints and currently provides basic information about the hundreds of jurisdictions in the American court system that we support.
+
+This endpoint can be filtered or ordered in numerous ways as described in its [schema][api-v2-jurisdiction-schema]. Brief descriptions of the fields can be found there as well.
+
+Over time this endpoint will contain more and more information about jurisdictions such as the address of the courthouses and other such information. We welcome data contributions in this area as much of this information will need to be gathered manually.
+
+[api-v2-jurisdiction-schema]: https://www.courtlistener.com/api/rest/v2/jurisdiction/schema/
+
+
+### /api/rest/v2/search/
+
+This endpoint allows you to query our search engine in a similar manner as is possible in our front end. Because this endpoint does not use the Django models directly, this endpoint is quite different than any other. Several differences should be noted.
+
+First, the fields and results from this endpoint are slightly different than those in the other endpoints. For example, instead of using a minus sign to flip ordering, it uses `asc` and `desc`. And instead of the `court` field returning a reference to the `jurisdiction` endpoint, it provides the name of the jurisdiction where the document was issued. (See [the schema][api-v2-search-schema] and the notes below for all of the ordering options and field information).
+
+A peculiarity of this endpoint is that, like the front end, it serves both `audio` and `document` results, depending on the value of the `type` argument. These results have many overlapping fields, so, for example, if you get back the field `download_url` and the `type` is set to the letter `o` (meaning opinions):
+
+```
+curl https://www.courtlistener.com/api/rest/v2/search/?type=o
+```
+
+...`download_url` will represent the location the opinion was downloaded from. Conversely, if `type` is set to the letters `oa` (meaning oral arguments), the `download_url` will represent the location the *audio file* was downloaded from, instead. This can be confusing, however, remember that the `type` field defaults to `o`, and that the fields that overlap should make sense for all result types.
+
+Because this endpoint hits against a Solr search index instead of a database, the filtering works differently. To filter on this endpoint, we recommend identifying an effective query on the front end that generates the results you desire and then using that query (and variations thereof) to query the API. On the backend, the same code serves both the API and the front end.
+
+When examining the *filtering* section of [the schema][api-v2-search-schema], note that fields have been labeled as follows:
+
+**search**
+: These fields are filterable according to the syntax defined in the [advanced query techniques][advanced-search] available on the front end.
+
+**int**
+: These fields require ints as their arguments, and generally provide greater-than or less-than queries.
+
+**date**
+: These fields allow you to search for dates greater than or less than a given value. Input dates ascribe to ISO-8601 format, however, partial dates are allowed, and will be interpreted appropriately. For example, placing "2012" in the `filed_after` parameter will assume you mean documents after "2012-01-01".
+
+**Boolean**
+: Only the stat_* field is currently available as boolean. This field is represented by checkboxes in the front end, and can be enabled by setting its value to "on". For example to include only Precedential documents, you might place a query like:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v2/search/?stat_Precedential=on
+  ```
+
+**CSV**
+: The `court` field is currently available as a list of comma separated values (CSV). Thus, to request multiple courts, you can simply separate their IDs with a comma. For example to get all documents from the Supreme Court (`scotus`) and the Ninth Circuit of Appeals (`ca9`), you would make a query like:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v2/search/?court=scotus,ca9
+  ```
+
+  IDs for all jurisdictions are available at the [jurisdictions page][jurisdictions].
+
+Finally, note that like the front end, when the `type` is set to `o` (the default), only precedential results are returned by default. See below for an example that also returns non-precedential results.
+
+Four fields in the search results require special explanation:
+
+**`resource_uri`**
+: Because this endpoint is designed to help find documents, once you've found the ones you want, we provide a `resource_uri` that directs you back to the `document` endpoint, which has all of the best meta data. This is in contrast to any of the other endpoints, but follows the pattern of searching for results and selecting them to examine the details.
+
+**`snippet`**
+: This field contains the same values as are found on the front end, utilizing the HTML5 `<mark>` element to identify up to five matches in a document. If you wish to use the snippet but do not want highlighting, simply use CSS to give the `mark` element no styling, like a `span` element. This field only responds to arguments provided to the `q` parameter. If that parameter is not used, the `snippet` field will show the first 500 characters of the `text` field.
+
+**`stat_*`**
+: For this Boolean field, we provide opinionated default values. Because most searchers are not interested in non-precedential (unpublished) results, we leave them out by default. If you wish to receive these items, you must explicitly ask for them as you do on the front end. For example, this query returns both precedential (published) and non-precedential (unpublished) results:
+
+  ```
+  curl https://www.courtlistener.com/api/rest/v2/search/?stat_Precedential=on&stat_Non-Precedential=on
+  ```
+
+**`court`**
+: This field provides the name of the jurisdiction where the document was issued. In other endpoints, this field directs you to the `jurisdiction` endpoint.
+
+[api-v2-search-schema]: https://www.courtlistener.com/api/rest/v2/search/schema/?format=json
+
+
+### /api/rest/v2/coverage/
+
+Unlike the other endpoints in this API, the coverage endpoint is not based on the [tastypie API framework][tastypie]. As a result it is much simpler, only providing data in a very specific manner, serialized as JSON. In the future we expect to expand this API to provide faceting along additional fields, but at present it simply provides jurisdiction counts by year for any requested jurisdiction. This API does not require authentication and is what powers our live [coverage page][coverage].
+
+To receive jurisdiction counts by year, simply provide the jurisdiction ID you wish to query or the special keyword, `all`, which returns counts for all jurisdictions. For example, this provides annual counts for the Ninth Circuit of Appeals (`ca9`):
+
+```
+curl https://www.courtlistener.com/api/rest/v2/coverage/ca9/
+```
+
+[coverage]: https://www.courtlistener.com/coverage/
+
+
+## Available Jurisdictions
+
+We currently have hundreds of jurisdictions that can be accessed with our APIs. Details about the jurisdictions that are available can be found [here][jurisdictions].
+
+
+## Powered By
+
+If you are interested, we have a variety of ["Powered By" logos][press-assets] available for your website or application. We appreciate a reference, but it's not required.
+
+[press-assets]: https://free.law/press-assets/
+
+
+## CiteGeist Scores
+
+If you are interested in the CiteGeist score for each opinion, it is now available via our [bulk data API][bulk-data].
+
+
+## Maintenance Schedule
+
+We regularly perform bulk tasks on our servers and maintain [a public calendar][calendar] for tracking them. If you intend to do bulk crawling of our API, please be mindful of this schedule.
+
+
+## Browser Tools
+
+Several tools are available to help view JSON in your browser. If you are using Firefox, check out [JSONovitch][jsonovitch]. If you are using Chrome, check out [JSONView][jsonview].
+
+[jsonovitch]: https://addons.mozilla.org/en-US/firefox/addon/jsonovich/
+[jsonview]: https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=en
+
+
+## Copyright
+
+Our data is free of known copyright restrictions.
+
+[![Public Domain Mark][cc-pd-img]][cc-pd]
+
+[rest-api]: rest-api.md
+[tastypie]: https://django-tastypie.readthedocs.org/en/latest/
+[basic-auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
+[privacy]: https://www.courtlistener.com/terms/#privacy
+[django-lookups]: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+[xkcd-dates]: https://xkcd.com/1179/
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+[sha1]: https://en.wikipedia.org/wiki/SHA-1
+[parallel-citations]: https://legalresearchprinciples.pbworks.com/w/page/16129937/Parallel%20Citations
+[advanced-search]: https://www.courtlistener.com/help/search/
+[jurisdictions]: https://www.courtlistener.com/help/api/jurisdictions/
+[bulk-data]: https://www.courtlistener.com/help/api/bulk-data/
+[calendar]: https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles
+[cc-pd]: https://creativecommons.org/publicdomain/mark/1.0/
+[cc-pd-img]: https://www.courtlistener.com/static/png/cc-pd.png

--- a/wiki-exports/rest-api-v3.md
+++ b/wiki-exports/rest-api-v3.md
@@ -1,0 +1,566 @@
+---
+title: "REST API, v3"
+description: "REST API for federal and state case law, PACER data, the searchable RECAP Archive, oral argument recordings and more."
+redirect_from: "/help/api/rest/v3/overview/"
+wiki_path: "/c/courtlistener/help/api/rest/v3/overview/"
+search_engines: false
+ai_assistants: false
+data_source: "https://www.courtlistener.com/api/rest/v4/wiki-data/"
+data_source_cache: 86400
+---
+
+> [!WARNING]
+> **Deprecated** — This is the documentation for v3.15 of the REST API. Please use the [latest version][rest-api] instead.
+
+<p class="lead">APIs for developers and researchers that need granular legal data.</p>
+
+After more than a decade of development, these APIs are powerful. Our [case law API][case-law-api] was the first. Our [PACER][pacer-api] and oral argument APIs are the biggest. Our [webhooks][webhooks] push data to you. Our citation lookup tool can fight hallucinations in AI tools.
+
+Let's get started. To see and browse all the API URLs, click the button below:
+
+**[Show the APIs](https://www.courtlistener.com/api/rest/v3/)**
+
+We could have also pulled up that same information using curl, with a command like:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/overview/"
+```
+
+Note that when you press the button in your browser, you get an HTML result, but when you run `curl` you get a JSON object. This is [discussed in more depth below](#serialization-formats).
+
+> **Listen Up!** Something else that's curious just happened. You didn't authenticate to the API. To encourage experimentation, many of our APIs are open by default. The biggest gotcha people have is that they forget to enable authentication before deploying their code. Don't make this mistake! Remember to add [authentication](#authentication).
+
+The APIs listed in this response can be used to make queries against our database or search engine.
+
+To learn more about an API, you can send an [HTTP OPTIONS][http-options] request to it, like so:
+
+```
+curl -X OPTIONS "https://www.courtlistener.com/api/rest/v3/overview/"
+```
+
+An `OPTIONS` request is one of the best ways to understand the API.
+
+[http-options]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
+
+
+## Support
+
+Questions about the APIs can be sent [to our GitHub Discussions forum][github-discussions] or via our [contact form][contact].
+
+We prefer that questions be posted in the forum so they can help others. If you are a private organization posting to that forum, we will avoid sharing details about your organization.
+
+**[Ask in GitHub Discussions](https://github.com/freelawproject/courtlistener/discussions)** | **[Send us a Private Message](https://www.courtlistener.com/contact/)**
+
+[github-discussions]: https://github.com/freelawproject/courtlistener/discussions
+[contact]: https://www.courtlistener.com/contact/
+
+
+## Data Models
+
+The two images below show how the APIs work together. The first image shows the models we use for people, and the second shows the models we use for documents and metadata about them. You can see that these models currently link together on the Docket, Person, and Court tables. ([Here's a version of this diagram that shows everything all at once][complete-model].)
+
+[![People model diagram][people-model-small]][people-model]
+
+[![Search model diagram][search-model-small]][search-model]
+
+[complete-model]: https://www.courtlistener.com/static/png/complete-model-v3.13.png
+[people-model]: https://www.courtlistener.com/static/png/people-model-v3.13.png
+[people-model-small]: https://www.courtlistener.com/static/png/people-model-v3.13-small.png
+[search-model]: https://www.courtlistener.com/static/png/search-model-v3.13.png
+[search-model-small]: https://www.courtlistener.com/static/png/search-model-v3.13-small.png
+
+
+## API Overview
+
+This section explains the general principles of the API. These principals are driven by the features supported by the [Django REST Framework][drf]. To go deep on any of these sections, we encourage you to check out the documentation there.
+
+[drf]: https://www.django-rest-framework.org/
+
+
+### Permissions
+
+Some of our APIs are only available to select users. If you need greater access to these APIs, [please get in touch][contact].
+
+All other endpoints are available according to the [throttling](#rate-limits) and [authentication](#authentication) limitations listed below.
+
+
+### Your Authorization Token
+
+[Sign in to see your token][sign-in].
+
+[sign-in]: https://www.courtlistener.com/sign-in/
+
+
+### Authentication
+
+Authentication is necessary to monitor and throttle usage of the system, and so we can assist with any errors that may occur.
+
+Per our [privacy policy][privacy], we do not track your queries in the API, though we do collect statistical information for system monitoring.
+
+[privacy]: https://www.courtlistener.com/terms/#privacy
+
+There are currently three types of authentication available on the API:
+
+1. [HTTP Token Authentication][token-auth-docs]
+2. [Cookie/Session Authentication][django-auth-docs]
+3. [HTTP Basic Authentication][basic-auth-wiki]
+
+[token-auth-docs]: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
+[django-auth-docs]: https://docs.djangoproject.com/en/dev/topics/auth/
+[basic-auth-wiki]: https://en.wikipedia.org/wiki/Basic_access_authentication
+
+All of these methods are secure, so the choice of which to use is generally a question of what's most convenient for the context of your work. Our recommendations are:
+
+- Use Token Authentication for programmatic API access.
+- Use Cookie/Session Authentication if you already have a user's cookie or are developing a system where you can ask the user to log into CourtListener.
+- Use Basic Authentication if that's all your client supports.
+
+#### Token Authentication
+
+To use token authentication, use the `Authorization` HTTP Header. The key should prefix the `Token`, with whitespace separating the two strings. For example:
+
+```
+Authorization: Token <your-token-here>
+```
+
+Using curl, this looks like:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/clusters/" \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+Note that quotes are used to enclose the whitespace in the header.
+
+> **Careful!** A common mistake is to forget the word "Token" in the header.
+
+[Sign in][sign-in] to see your authorization token in this documentation.
+
+#### Cookie Authentication
+
+To use Cookie Authentication [log into CourtListener][sign-in] and pass the cookie value using the standard cookie headers.
+
+#### HTTP Basic Authentication
+
+To do HTTP Basic Authentication using curl, you might do something like this:
+
+```
+curl --user "harvey:your-password" \
+  "https://www.courtlistener.com/api/rest/v3/clusters/"
+```
+
+You can also do it in your browser with a url like:
+
+```
+https://harvey:your-password@www.courtlistener.com/api/rest/v3/clusters/
+```
+
+But if you're using your browser, [you might as well just log in][sign-in].
+
+
+### Serialization Formats
+
+Requests may be serialized as HTML, JSON, or XML. JSON is the default if no format is specified. The format you wish to receive is requested via the HTTP `Accept` header.
+
+The following media types and parameters can be used:
+
+- **HTML**: The media type for HTML is `text/html`.
+- **JSON**: The media type for JSON is `application/json`. Providing the `indent` media type parameter allows clients to set the indenting for the response, for example: `Accept: application/json; indent=2`.
+- **XML**: The media type for XML is `application/xml`.
+
+By default, browsers send an `Accept` header similar to:
+
+```
+text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+```
+
+This states that `text/html` is the preferred serialization format. The API respects that, returning HTML when requested by a browser and returning JSON when no `Accept` header is provided, because JSON is the default.
+
+If you wish to set the `Accept` header using a tool like cURL, you can do so using the `--header` flag:
+
+```
+curl --header "Accept: application/xml" \
+  "https://www.courtlistener.com/api/rest/v3/clusters/"
+```
+
+All data is serialized using the utf-8 charset.
+
+
+### Parsing Uploaded Content
+
+If you are a user that has write access to these APIs (most users do not), you will need to use the `Content-Type` HTTP header to explicitly set the format of the content you are uploading. The header can be set to any of the values that are available for serialization or to `application/x-www-form-urlencoded` or `multipart/form-data`, if you are sending form data.
+
+
+### Filtering
+
+With the exception of the search API, these APIs can be filtered using a technique similar to [Django's field lookups][django-lookups].
+
+[django-lookups]: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+
+To see how an endpoint can be filtered, do an `OPTIONS` request on the API and inspect the `filters` key in the response.
+
+In the `filters` key, you'll find a dictionary listing the fields that can be used for filtering along with their types, lookup fields, and any values (aka choices) that can be used for specific lookups.
+
+For example, this uses `jq` to look at the filters on the docket API:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/dockets/" | jq '.filters'
+```
+
+That returns something like:
+
+```json
+{
+  "id": {
+    "type": "NumberRangeFilter",
+    "lookup_types": [
+      "exact",
+      "gte",
+      "gt",
+      "lte",
+      "lt",
+      "range"
+    ]
+  },
+...
+```
+
+This means that you can filter dockets using the ID field, and that you can do exact, greater than or equal, greater than, less than or equal, less than, or range filtering.
+
+You can use these filters with a double underscore. For example, this gets IDs greater than 500 and less than 1,000:
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/dockets/?id__gt=500&id__lt=1000" | jq '.count'
+499
+```
+
+It also allows ranges (inclusive):
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/dockets/?id__range=500,1000" | jq '.count'
+501
+```
+
+Filters can be combined using multiple `GET` parameters.
+
+There are a few special types of filters. The first are `Related Filters`, which allow you to join filters across APIs. For example, when you are using the docket API, you'll see that it has a filter for the court API:
+
+```json
+"court": {
+    "type": "RelatedFilter",
+    "lookup_types": "See available filters for 'Courts'"
+}
+```
+
+This means that you can use any of the court filters on the docket API. If you do an `OPTIONS` request on the court API, you'll see its filters:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/courts/" | jq '.filters'
+```
+
+Again, one of the filters is the ID field, but it only allows exact values on this API:
+
+```json
+"id": {
+    "type": "CharFilter",
+    "lookup_types": [
+        "exact"
+    ]
+}
+```
+
+Putting this together, here's how you look up dockets for a particular court:
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/dockets/?court=scotus&id__range=500,1000" | jq '.count'
+36
+```
+
+This opens up many possibilities. For example, another filter on the `Court` endpoint is for `jurisdictions`. To use it, you would use a GET parameter like `court__jurisdictions=FD`. In this case, the double underscore allows you to join the filter from the other court API to the docket API.
+
+If you want to join a filter, you could do something like `court__full_name__startswith=district`. That would return dockets in courts where the court's name starts with "district".
+
+`RelatedFilters` can span many objects. For example, if you want to get all the Supreme Court `Opinion` objects, you will need to do that with a query such as:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/opinions/?cluster__docket__court=scotus"
+```
+
+This uses the `Opinion` API to get `Opinions` that are part of `Opinion Clusters` that are on `Dockets` in the `Court` with the ID of `scotus`. To understand this data model better, see the [case law API documentation][case-law-api].
+
+To use date filters, supply dates in [ISO-8601 format][iso-8601].
+
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+
+A final trick that can be used with the filters is the exclusion parameter. Any filter can be converted into an exclusion filter by prepending it with an exclamation mark. For example, this returns `Dockets` from non-Federal Appellate jurisdictions:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/dockets/?court__jurisdiction!=F"
+```
+
+You can see more examples of filters in [our automated tests][cl-api-tests].
+
+[cl-api-tests]: https://github.com/freelawproject/courtlistener/blob/main/cl/api/tests.py
+
+
+### Ordering
+
+With the exception of the search API, you can see which fields can be used for ordering, by looking at the `ordering` key in an `OPTIONS` request. For example, the `Position` endpoint contains this:
+
+```json
+"ordering": [
+    "id",
+    "date_created",
+    "date_modified",
+    "date_nominated",
+    "date_elected",
+    "date_recess_appointment",
+    "date_referred_to_judicial_committee",
+    "date_judicial_committee_action",
+    "date_hearing",
+    "date_confirmation",
+    "date_start",
+    "date_retirement",
+    "date_termination"
+]
+```
+
+Thus, you can order using any of these fields in conjunction with the `order_by` parameter.
+
+Descending order can be done using a minus sign. Multiple fields can be requested using a comma-separated list. This, for example, returns judicial `Positions` ordered by the most recently modified, then by the most recently elected:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/positions/?order_by=-date_modified,-date_elected"
+```
+
+Ordering by fields with duplicate values is non-deterministic. If you wish to order by such a field, you should provide a second field as a tie-breaker to consistently order results. For example, ordering by `date_filed` will not return consistent ordering for items that have the same date, but this can be fixed by ordering by `date_filed,id`. In that case, if two items have the same `date_filed` value, the tie will be broken by the `id` field.
+
+
+### Field Selection
+
+To save bandwidth and increase serialization performance, fields can be limited by using the `fields` parameter with a comma-separated list of fields.
+
+For example, to only receive the `educations` and `date_modified` fields from the `Judge` endpoint you could do so with:
+
+```
+curl "https://www.courtlistener.com/api/rest/v3/people/?fields=educations,date_modified"
+{
+  "educations": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/v3/educations/12856/",
+      "id": 12856,
+      "school": {
+        "resource_uri": "https://www.courtlistener.com/api/rest/v3/schools/4240/",
+        "id": 4240,
+        "is_alias_of": null,
+        "date_created": "2010-06-07T17:00:00-07:00",
+        "date_modified": "2010-06-07T17:00:00-07:00",
+        "name": "University of Maine",
+        "ein": 16000769
+      },
+      "person": "https://www.courtlistener.com/api/rest/v3/people/16214/",
+      "date_created": "2023-03-31T07:15:28.556198-07:00",
+      "date_modified": "2023-03-31T07:15:28.556222-07:00",
+      "degree_level": "jd",
+      "degree_detail": "",
+      "degree_year": 1979
+    }
+  ],
+  "date_modified": "2023-03-31T07:15:28.409594-07:00"
+},
+...
+```
+
+You can also exclude fields using `fields!=educations,date_modified`.
+
+Unfortunately, this cannot be used for nested resources, though [there is an open issue tracking this][nested-fields-issue].
+
+[nested-fields-issue]: https://github.com/wimglenn/djangorestframework-queryfields/issues/8
+
+
+### Rate Limits
+
+Our APIs allow 5,000 queries per hour to authenticated users. Unauthenticated users are allowed 100 queries per day for experimentation.
+
+To debug throttling issues:
+
+1. Try browsing the API while logged into the website. If this works and your code fails, it usually means that your token authentication is not configured properly, and your code is getting throttled as an anonymous user, not according to your token.
+2. Review your recent API usage by looking in your [profile][api-usage], but remember that it will show stats for the browsable API as well.
+3. Review the [authentication/throttling tips in our forum][throttling-tips].
+
+If, after checking the above, you need your rate limit increased, [please get in touch][contact] so we can help.
+
+[api-usage]: https://www.courtlistener.com/profile/api/#usage
+[throttling-tips]: https://github.com/freelawproject/courtlistener/discussions/1497
+
+
+### Performance Tips
+
+A few things to consider that may increase your performance:
+
+1. When doing deep crawls of the data, going to very high page numbers will incur increasingly bad performance. This is common in databases because to go to a high page number means sorting the entire data set, then counting to the correct location. Page 50 isn't a big deal. Page 2,000 starts getting slower.
+
+   The fix to this solution is often to work with "slices" of the data. Instead of paginating across the whole result set, use a date field or another range-type field to only paginate over a smaller set of the data. For example, you could slice a large result set by the month of the date filing field to prevent deep pagination.
+
+   Be careful to slice using a field with a normal distribution. Do not use one like `date_created`, which could have extreme spikes of activity.
+
+2. Avoid doing queries like `court__id=xyz` when you can instead do `court=xyz`. Doing queries with the extra `__id` introduces a join that can be expensive.
+
+3. In general, less data is easier and faster to get than more. Could you use a field to filter your result set down to something smaller?
+
+4. When using the `search` endpoint, smaller result sets are faster. It isn't always possible to tweak your query to return fewer results, but sometimes it is possible to do a more precise query first, thus making a broader query unnecessary. For example, a search for an individual in their expected jurisdiction will be faster than doing it in the entire corpus. This will benefit from profiling in your use case and application.
+
+### Advanced Field Definitions
+
+Placing an HTTP `OPTIONS` request on an API is the best way to learn about its fields, but some fields require further explanation.
+
+**[Learn About Fields](https://www.courtlistener.com/help/api/rest/v4/fields/)**
+
+
+## APIs
+
+### Case Law APIs
+
+We started collecting case law in 2009 and launched this API in 2013 as the [first][first-api-announcement] API for legal decisions.
+
+Use this API to build your own collection of case law, complete complex legal research, and more.
+
+**[Learn More][case-law-api]**
+
+[first-api-announcement]: https://free.law/2013/11/19/free-law-project-unveils-api-for-american-opinions/
+
+### PACER Data APIs
+
+We have almost half a billion PACER-related objects in the RECAP Archive. Use these APIs to access and understand this data.
+
+**[Learn More][pacer-api]**
+
+### RECAP APIs
+
+Use these APIs to gather data from PACER and to share your PACER data with the public.
+
+**[Learn More][recap-api]**
+
+### Search API
+
+CourtListener allows you to search across hundreds of millions of items with advanced fields and operators. Use this API to automate the CourtListener search engine.
+
+**[Learn More][search-api-v3]**
+
+### Judge APIs
+
+Use these APIs to query and analyze thousands of federal and state court judges, including their biographical information, political affiliations, education and employment histories, and more.
+
+**[Learn More][judge-api]**
+
+[judge-api]: https://www.courtlistener.com/help/api/rest/v3/judges/
+
+### Financial Disclosure APIs
+
+All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have.
+
+Use these APIs to work with this information.
+
+**[Learn More][financial-disclosure-api]**
+
+[financial-disclosure-api]: https://www.courtlistener.com/help/api/rest/v3/financial-disclosures/
+
+### Oral Argument APIs
+
+CourtListener is home to the largest collection of oral argument recordings on the Internet. Use these APIs to gather and analyze our collection.
+
+**[Learn More][oral-argument-api]**
+
+[oral-argument-api]: https://www.courtlistener.com/help/api/rest/v3/oral-arguments/
+
+### Citation Lookup and Verification API
+
+Use this API to look up citations in CourtListener's database of millions of citations.
+
+This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
+
+**[Learn More][citation-lookup-api]**
+
+[citation-lookup-api]: https://www.courtlistener.com/help/api/rest/v3/citation-lookup/
+
+### Citation Network APIs
+
+Use these APIs to traverse and analyze our network of citations between legal decisions.
+
+**[Learn More][citation-network-api]**
+
+[citation-network-api]: https://www.courtlistener.com/help/api/rest/v3/citations/
+
+### Alert APIs
+
+CourtListener is a scalable system for sending alerts by email or [webhook][webhooks] based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.
+
+**[Learn More][alert-api]**
+
+[alert-api]: https://www.courtlistener.com/help/api/rest/v3/alerts/
+
+### Visualization APIs
+
+To see and make Supreme Court case visualizations, use these APIs.
+
+**[Learn More][visualization-api]**
+
+[visualization-api]: https://www.courtlistener.com/help/api/rest/v3/visualizations/
+
+
+## Available Jurisdictions
+
+We currently have **[[ court_count ]]** jurisdictions that can be accessed with our APIs. Details about the jurisdictions that are available, including all abbreviations, can [be found here][jurisdictions].
+
+
+## Upgrades and Fixes
+
+Like the rest of the CourtListener platform, this API and its documentation are [open source][cl-source]. If it lacks functionality that you desire or if you find this documentation lacking, pull requests providing improvements are encouraged. Just get in touch via our [contact form][contact] to discuss your ideas. Or, if it's something quick, just go ahead and send us a pull request.
+
+Getting this kind support is one of the most rewarding things possible for an organization like ours and is a major goal of [Free Law Project][free-law]. Many of the features you use on CourtListener were built this way. We're building something together.
+
+[cl-source]: https://github.com/freelawproject/courtlistener
+[free-law]: https://free.law
+
+
+## Maintenance Schedule
+
+There is a weekly maintenance window from 21:00-23:59PT on Thursday nights. If you are scheduling cron jobs or otherwise crawling the API, you may experience downtime during this window.
+
+Additionally, we regularly perform bulk tasks on our servers and maintain [a public calendar][calendar] for tracking them. You may encounter larger delays while bulk processing jobs are running.
+
+[calendar]: https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles
+
+
+## API Change Log
+
+**[View the Change Log][change-log]**
+
+
+## Copyright
+
+Our data is free of known copyright restrictions.
+
+[![Public Domain Mark][cc-pd-img]][cc-pd]
+
+[cc-pd]: https://creativecommons.org/publicdomain/mark/1.0/
+[cc-pd-img]: https://www.courtlistener.com/static/png/cc-pd.png
+
+[rest-api]: rest-api.md
+[case-law-api]: case-law-api.md
+[pacer-api]: pacer-api.md
+[recap-api]: recap-api.md
+[webhooks]: webhooks.md
+[change-log]: rest-change-log.md
+[search-api-v3]: search-api-v3.md
+[jurisdictions]: https://www.courtlistener.com/help/api/jurisdictions/

--- a/wiki-exports/rest-api.md
+++ b/wiki-exports/rest-api.md
@@ -1,0 +1,614 @@
+---
+title: "REST API, v4.4"
+description: "REST API for federal and state case law, PACER data, the searchable RECAP Archive, oral argument recordings and more."
+redirect_from: "/help/api/rest/v4/overview/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/overview/"
+data_source: "https://www.courtlistener.com/api/rest/v4/wiki-data/"
+data_source_cache: 86400
+---
+
+<p class="lead">APIs for developers and researchers that need granular legal data.</p>
+
+After more than a decade of development, these APIs are powerful. Our [case law API][case-law-api] was the first. Our [PACER][pacer-api] and [oral argument][oral-argument-api] APIs are the biggest. Our [webhooks][webhooks-getting-started] push data to you. Our [citation lookup tool][citation-lookup-api] can fight hallucinations in AI tools.
+
+Let's get started. To see and browse all the API URLs, click the button below:
+
+[Show the APIs](https://www.courtlistener.com/api/rest/v4/){button}
+
+We could have also pulled up that same information using curl, with a command like:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/overview/"
+```
+
+Note that when you press the button in your browser, you get an HTML result, but when you run `curl` you get a JSON object. This is [discussed in more depth below](#serialization-formats).
+
+> [!WARNING]
+> **Listen Up!** Something else that's curious just happened. You didn't authenticate to the API. To encourage experimentation, many of our APIs are open by default. The biggest gotcha people have is that they forget to enable authentication before deploying their code. Don't make this mistake! Remember to add [authentication](#authentication).
+
+The APIs listed in this response can be used to make queries against our database or search engine.
+
+To learn more about an API, you can send an [HTTP OPTIONS][http-options] request, like so:
+
+```
+curl -X OPTIONS "https://www.courtlistener.com/api/rest/v4/overview/"
+```
+
+An `OPTIONS` request is one of the best ways to understand the API.
+
+[case-law-api]: case-law-api.md
+[pacer-api]: pacer-api.md
+[oral-argument-api]: oral-argument-api.md
+[webhooks-getting-started]: webhooks-getting-started.md
+[citation-lookup-api]: citation-lookup-api.md
+[http-options]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
+
+
+## Support
+
+Questions about the APIs can be sent [to our GitHub Discussions forum][gh-discussions] or via our [contact form][contact].
+
+We prefer that questions be posted in the forum so they can help others. If you are a private organization posting to that forum, we will avoid sharing details about your organization.
+
+[Ask in GitHub Discussions](https://github.com/freelawproject/courtlistener/discussions){button}
+[Send us a Private Message](https://www.courtlistener.com/contact/){button}
+
+[gh-discussions]: https://github.com/freelawproject/courtlistener/discussions
+[contact]: https://www.courtlistener.com/contact/
+
+
+## Data Models
+
+The two images below show how the APIs work together. The first image shows the models we use for people, and the second shows the models we use for documents and metadata about them. You can see that these models currently link together on the Docket, Person, and Court tables. ([Here's a version of this diagram that shows everything all at once][complete-model].)
+
+[![People model schema diagram][people-model-small]][people-model]
+
+[![Search model schema diagram][search-model-small]][search-model]
+
+[complete-model]: https://www.courtlistener.com/static/png/complete-model-v3.13.png
+[people-model-small]: https://www.courtlistener.com/static/png/people-model-v3.13-small.png
+[people-model]: https://www.courtlistener.com/static/png/people-model-v3.13.png
+[search-model-small]: https://www.courtlistener.com/static/png/search-model-v3.13-small.png
+[search-model]: https://www.courtlistener.com/static/png/search-model-v3.13.png
+
+
+## API Overview
+
+This section explains the general principles of the API. These principals are driven by the features supported by the [Django REST Framework][drf]. To go deep on any of these sections, we encourage you to check out the documentation there.
+
+[drf]: https://www.django-rest-framework.org/
+
+
+### Permissions
+
+Some of our APIs are only available to select users. If you need greater access to these APIs, [please get in touch][contact].
+
+All other endpoints are available according to the [throttling](#rate-limits) and [authentication](#authentication) limitations listed below.
+
+
+### Your Authorization Token
+
+[Sign In To See Your Token](https://www.courtlistener.com/sign-in/){button}
+
+
+### Authentication
+
+Authentication is necessary to monitor and throttle the system, and so we can assist with any errors that may occur.
+
+Per our [privacy policy][privacy-policy], we do not track your queries in the API, though we do collect statistical information for system monitoring.
+
+There are currently three types of authentication available on the API:
+
+1. [HTTP Token Authentication][token-auth]
+2. [Cookie/Session Authentication][cookie-auth]
+3. [HTTP Basic Authentication][basic-auth]
+
+All of these methods are secure, so the choice of which to use is generally a question of what's most convenient for the context of your work. Our recommendations are:
+
+- Use Token Authentication for programmatic API access.
+- Use Cookie/Session Authentication if you already have a user's cookie or are developing a system where you can ask the user to log into CourtListener.
+- Use Basic Authentication if that's all your client supports.
+
+[privacy-policy]: https://www.courtlistener.com/terms/#privacy
+[token-auth]: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
+[cookie-auth]: https://docs.djangoproject.com/en/dev/topics/auth/
+[basic-auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
+
+#### Token Authentication
+
+To use token authentication, use the `Authorization` HTTP Header. The key should prefix the `Token`, with whitespace separating the two strings. For example:
+
+```
+Authorization: Token <your-token-here>
+```
+
+Using curl, this looks like:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/clusters/" \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+Note that quotes are used to enclose the whitespace in the header.
+
+> [!WARNING]
+> **Careful!** A common mistake is to forget the word "Token" in the header.
+
+[Sign in][sign-in] to see your authorization token in this documentation.
+
+[sign-in]: https://www.courtlistener.com/sign-in/
+
+#### Cookie Authentication
+
+To use Cookie Authentication [log into Courtlistener][sign-in] and pass the cookie value using the standard cookie headers.
+
+#### HTTP Basic Authentication
+
+To do HTTP Basic Authentication using curl, you might do something like this:
+
+```
+curl --user "harvey:your-password" \
+  "https://www.courtlistener.com/api/rest/v4/clusters/"
+```
+
+You can also do it in your browser with a url like:
+
+```
+https://harvey:your-password@www.courtlistener.com/api/rest/v4/clusters/
+```
+
+But if you're using your browser, [you might as well just log in][sign-in].
+
+
+### Serialization Formats
+
+Requests may be serialized as HTML, JSON, or XML. JSON is the default if no format is specified. The format you wish to receive is requested via the HTTP `Accept` header.
+
+The following media types and parameters can be used:
+
+- **HTML**: The media type for HTML is `text/html`.
+- **JSON**: The media type for JSON is `application/json`. Providing the `indent` media type parameter allows clients to set the indenting for the response, for example: `Accept: application/json; indent=2`.
+- **XML**: The media type for XML is `application/xml`.
+
+By default, browsers send an `Accept` header similar to:
+
+```
+text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+```
+
+This states that `text/html` is the preferred serialization format. The API respects that, returning HTML when requested by a browser and returning JSON when no `Accept` header is provided, because JSON is the default.
+
+If you wish to set the `Accept` header using a tool like cURL, you can do so using the `--header` flag:
+
+```
+curl --header "Accept: application/xml" \
+  "https://www.courtlistener.com/api/rest/v4/clusters/"
+```
+
+All data is serialized using the utf-8 charset.
+
+
+### Parsing Uploaded Content
+
+If you are a user that has write access to these APIs (most users do not), you will need to use the `Content-Type` HTTP header to explicitly set the format of the content you are uploading. The header can be set to any of the values that are available for serialization or to `application/x-www-form-urlencoded` or `multipart/form-data`, if you are sending form data.
+
+
+### Filtering
+
+With the exception of the search API, these APIs can be filtered using a technique similar to [Django's field lookups][django-field-lookups].
+
+To see how an endpoint can be filtered, do an `OPTIONS` request on the API and inspect the `filters` key in the response.
+
+In the `filters` key, you'll find a dictionary listing the fields that can be used for filtering along with their types, lookup fields, and any values (aka choices) that can be used for specific lookups.
+
+For example, this uses `jq` to look at the filters on the docket API:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/" | jq '.filters'
+```
+
+That returns something like:
+
+```json
+{
+  "id": {
+    "type": "NumberRangeFilter",
+    "lookup_types": [
+      "exact",
+      "gte",
+      "gt",
+      "lte",
+      "lt",
+      "range"
+    ]
+  },
+...
+```
+
+This means that you can filter dockets using the ID field, and that you can do exact, greater than or equal, greater than, less than or equal, less than, or range filtering.
+
+You can use these filters with a double underscore. For example, this gets IDs greater than 500 and less than 1,000:
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/?id__gt=500&id__lt=1000" | jq '.count'
+499
+```
+
+It also allows ranges (inclusive):
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/?id__range=500,1000" | jq '.count'
+501
+```
+
+Filters can be combined using multiple `GET` parameters.
+
+There are a few special types of filters. The first are `Related Filters`, which allow you to join filters across APIs. For example, when you are using the docket API, you'll see that it has a filter for the court API:
+
+```json
+"court": {
+    "type": "RelatedFilter",
+    "lookup_types": "See available filters for 'Courts'"
+}
+```
+
+This means that you can use any of the court filters on the docket API. If you do an `OPTIONS` request on the court API, you'll see its filters:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/courts/" | jq '.filters'
+```
+
+Again, one of the filters is the ID field, but it only allows exact values on this API:
+
+```json
+"id": {
+    "type": "CharFilter",
+    "lookup_types": [
+        "exact"
+    ]
+}
+```
+
+Putting this together, here's how you look up dockets for a particular court:
+
+```
+curl \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/?court=scotus&id__range=500,1000" | jq '.count'
+36
+```
+
+This opens up many possibilities. For example, another filter on the `Court` endpoint is for `jurisdictions`. To use it, you would use a GET parameter like `court__jurisdictions=FD`. In this case, the double underscore allows you to join the filter from the other court API to the docket API.
+
+If you want to join a filter, you could do something like `court__full_name__startswith=district`. That would return dockets in courts where the court's name starts with "district".
+
+`RelatedFilters` can span many objects. For example, if you want to get all the Supreme Court `Opinion` objects, you will need to do that with a query such as:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/opinions/?cluster__docket__court=scotus"
+```
+
+This uses the `Opinion` API to get `Opinions` that are part of `Opinion Clusters` that are on `Dockets` in the `Court` with the ID of `scotus`. To understand this data model better, see the [case law API documentation][case-law-api].
+
+To use date filters, supply dates in [ISO-8601 format][iso-8601].
+
+A final trick that can be used with the filters is the exclusion parameter. Any filter can be converted into an exclusion filter by prepending it with an exclamation mark. For example, this returns `Dockets` from non-Federal Appellate jurisdictions:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/dockets/?court__jurisdiction!=F"
+```
+
+You can see more examples of filters in [our automated tests][api-tests].
+
+[django-field-lookups]: https://docs.djangoproject.com/en/dev/ref/models/querysets/#field-lookups
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+[api-tests]: https://github.com/freelawproject/courtlistener/blob/main/cl/api/tests.py
+
+
+
+### Ordering
+
+With the exception of the search API, you can see which fields can be used for ordering, by looking at the `ordering` key in an `OPTIONS` request. For example, the `Position` endpoint contains this:
+
+```json
+"ordering": [
+    "id",
+    "date_created",
+    "date_modified",
+    "date_nominated",
+    "date_elected",
+    "date_recess_appointment",
+    "date_referred_to_judicial_committee",
+    "date_judicial_committee_action",
+    "date_hearing",
+    "date_confirmation",
+    "date_start",
+    "date_retirement",
+    "date_termination"
+]
+```
+
+Thus, you can order using any of these fields in conjunction with the `order_by` parameter.
+
+Descending order can be done using a minus sign. Multiple fields can be requested using a comma-separated list. This, for example, returns judicial `Positions` ordered by the most recently modified, then by the most recently elected:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/positions/?order_by=-date_modified,-date_elected"
+```
+
+Ordering by fields with duplicate values is non-deterministic. If you wish to order by such a field, you should provide a second field as a tie-breaker to consistently order results. For example, ordering by `date_filed` will not return consistent ordering for items that have the same date, but this can be fixed by ordering by `date_filed,id`. In that case, if two items have the same `date_filed` value, the tie will be broken by the `id` field.
+
+### Counting
+
+To retrieve the total number of items matching your query without fetching all the data, you can use the `count=on` parameter. This is useful for verifying filters and understanding the scope of your query results without incurring the overhead of retrieving full datasets.
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/opinions/?cited_opinion=32239&count=on"
+
+{"count": 3302}
+```
+
+When `count=on` is specified:
+
+- The API returns only the `count` key with the total number of matching items.
+- Pagination parameters like `cursor` are ignored.
+- The response does not include any result data, which can improve performance for large datasets.
+
+In standard paginated responses, a `count` key is included with the URL to obtain the total count for your query:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/opinions/?cited_opinion=32239"
+
+{
+  "count": "https://www.courtlistener.com/api/rest/v4/opinions/?cited_opinion=32239&count=on",
+  "next": "https://www.courtlistener.com/api/rest/v4/opinions/?cited_opinion=32239&cursor=2",
+  "previous": null,
+  "results": [
+    // paginated results
+  ]
+}
+```
+
+You can follow this URL to get the total count of items matching your query.
+
+### Field Selection
+
+To save bandwidth, increase serialization performance, and optimize our backend queries, fields can be limited by using the `fields` parameter to select only the fields you want and the `omit` parameter to omit fields you do not. Each parameter accepts a comma-separated list of fields. Double-underscore `__` notation is used to choose or omit nested fields.
+
+This is an important optimization, particularly for resources with large fields.
+
+For example, to only receive the `educations` and `date_modified` fields from the `Judge` endpoint you could do:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/people/?fields=educations,date_modified"
+{
+  "educations": [
+    ...nested values here...
+  ],
+  "date_modified": "2023-03-31T07:15:28.409594-07:00"
+},
+...
+```
+
+Or, to include only the `date_modified` and `id` fields within each education entry (note the use of the double-underscore):
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/people/?fields=educations__date_modified,educations__id"
+{
+  "educations": [
+    {
+      "id": 12856,
+      "date_modified": "2023-03-31T07:15:28.556222-07:00",
+    }
+  ]
+},
+...
+```
+
+And to exclude the nested `degree_detail` field within each education entry:
+
+```
+curl "https://www.courtlistener.com/api/rest/v4/people/?omit=educations__degree_detail"
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v4/educations/12856/",
+  "id": 12856,
+  "school": {
+    "resource_uri": "https://www.courtlistener.com/api/rest/v4/schools/4240/",
+    "id": 4240,
+    "is_alias_of": null,
+    "date_created": "2010-06-07T17:00:00-07:00",
+    "date_modified": "2010-06-07T17:00:00-07:00",
+    "name": "University of Maine",
+    "ein": 16000769
+  },
+  "person": "https://www.courtlistener.com/api/rest/v4/people/16214/",
+  "date_created": "2023-03-31T07:15:28.556198-07:00",
+  "date_modified": "2023-03-31T07:15:28.556222-07:00",
+  "degree_level": "jd",
+  "degree_year": 1979
+}
+...
+```
+
+We highly recommend using this feature to optimize your requests.
+
+### Pagination
+
+Most APIs can be paginated by using the `page` GET parameter, but that will be limited to 100 pages of results.
+
+As of API v4, deep pagination is generally enabled for requests that are ordered by the `id`, `date_modified`, or `date_created` field. When sorting by these fields, the `next` and `previous` keys of the response are how you must paginate results, and the `page` parameter will not work.
+
+Some API endpoints support slightly different fields for deep pagination:
+
+1. `/api/rest/v4/recap-fetch/` also supports the `date_completed` field.
+2. `/api/rest/v4/alerts/` and `/api/rest/v4/docket-alerts/` only support the `date_created` field.
+
+### Rate Limits
+
+Our APIs allow 5,000 queries per hour to authenticated users. Creating more than one account per project, person, or organization is forbidden. If you are in doubt, please contact us before creating multiple accounts.
+
+To debug throttling issues:
+
+1. Try browsing the API while logged into Courtlistener. If this works and your code fails, it usually means that your token authentication is not configured properly, and your code is getting throttled as an anonymous user, not according to your token.
+2. Review your recent API usage by looking in your [profile][api-usage], but remember that it will show stats for the browsable API as well.
+3. Review the [authentication/throttling tips in our forum][throttling-tips].
+
+If, after checking the above, you need your rate limit increased, [please get in touch][contact] so we can help.
+
+[api-usage]: https://www.courtlistener.com/profile/api/#usage
+[throttling-tips]: https://github.com/freelawproject/courtlistener/discussions/1497
+
+
+### Performance Tips
+
+A few things to consider that may increase your performance:
+
+1. Use [field selection](#field-selection) to limit the serialized payload and defer unused fields, reducing both payload size and database load, especially for large fields.
+
+2. Avoid doing queries like `court__id=xyz` when you can instead do `court=xyz`. Doing queries with the extra `__id` introduces a join that can be expensive.
+
+3. When using the `search` endpoint, smaller result sets are faster. It isn't always possible to tweak your query to return fewer results, but sometimes it is possible to do a more precise query first, thus making a broader query unnecessary. For example, a search for an individual in their expected jurisdiction will be faster than doing it in the entire corpus. This will benefit from profiling in your use case and application.
+
+### Advanced Field Definitions
+
+Placing an HTTP `OPTIONS` request on an API is the best way to learn about its fields, but some fields require further explanation. Click below to learn about these fields.
+
+[Learn About Fields](field-help.md){button}
+
+
+## APIs
+
+### Case Law APIs
+
+We started collecting case law in 2009 and launched this API in 2013 as the [first][first-api] API for legal decisions.
+
+Use this API to build your own collection of case law, complete complex legal research, and more.
+
+[Learn More](case-law-api.md){button}
+
+[first-api]: https://free.law/2013/11/19/free-law-project-unveils-api-for-american-opinions/
+
+### PACER Data APIs
+
+We have almost half a billion PACER-related objects in the RECAP Archive including dockets, entries, documents, parties, and attorneys. Use these APIs to access and understand this data.
+
+[Learn More](pacer-api.md){button}
+
+### RECAP APIs
+
+Use these APIs to gather data from PACER and to share your PACER data with the public.
+
+[Learn More](recap-api.md){button}
+
+### Pray and Pay API
+
+Request PACER documents that are not yet available in the RECAP Archive. When another user purchases a document you've prayed for, you'll be notified automatically.
+
+Use this API to programmatically create and manage prayer requests.
+
+[Learn More](recap-api.md#pray-and-pay-api){button}
+
+### Search API
+
+CourtListener allows you to search across hundreds of millions of items with advanced fields and operators. Use this API to automate the CourtListener search engine.
+
+[Learn More](search-api.md){button}
+
+### Judge APIs
+
+Use these APIs to query and analyze thousands of federal and state court judges, including their biographical information, political affiliations, education and employment histories, and more.
+
+[Learn More](judge-api.md){button}
+
+### Financial Disclosure APIs
+
+All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have.
+
+Use these APIs to work with this information.
+
+[Learn More](financial-disclosure-api.md){button}
+
+### Oral Argument APIs
+
+CourtListener is home to the largest collection of oral argument recordings on the Internet. Use these APIs to gather and analyze our collection.
+
+[Learn More](oral-argument-api.md){button}
+
+### Citation Lookup and Verification API
+
+Use this API to look up citations in CourtListener's database of millions of citations.
+
+This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
+
+[Learn More](citation-lookup-api.md){button}
+
+### Citation Network APIs
+
+Use these APIs to traverse and analyze our network of citations between legal decisions.
+
+[Learn More](citation-api.md){button}
+
+### Alert APIs
+
+CourtListener is a scalable system for sending alerts by email or [webhook][webhooks-getting-started] based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.
+
+[Learn More](alert-api.md){button}
+
+### Tag APIs
+
+Use these APIs to create, organize, and manage tags on dockets. Tags help you organize and share collections of cases.
+
+[Learn More](tag-api.md){button}
+
+### Visualization APIs
+
+To see and make Supreme Court case visualizations, use these APIs.
+
+[Learn More](visualizations-api.md){button}
+
+
+
+## Available Jurisdictions
+
+We currently have **[[ court_count ]]** jurisdictions that can be accessed with our APIs. Details about the jurisdictions that are available, including all abbreviations, can [be found here][jurisdictions].
+
+[jurisdictions]: https://www.courtlistener.com/help/api/jurisdictions/
+
+## Upgrades and Fixes
+
+Like the rest of the CourtListener platform, this API and its documentation are [open source][cl-github]. If it lacks functionality that you desire or if you find this documentation lacking, pull requests providing improvements are encouraged. Just get in touch via our [contact form][contact] to discuss your ideas. Or, if it's something quick, just go ahead and send us a pull request.
+
+Getting this kind support is one of the most rewarding things possible for an organization like ours and is a major goal of [Free Law Project][flp]. Many of the features you use on CourtListener were built this way. We're building something together.
+
+[cl-github]: https://github.com/freelawproject/courtlistener
+[flp]: https://free.law
+
+## Maintenance Schedule
+
+There is a weekly maintenance window from 21:00-23:59PT on Thursday nights. If you are scheduling cron jobs or otherwise crawling the API, you may experience downtime during this window.
+
+Additionally, we regularly perform bulk tasks on our servers and maintain [a public calendar][maintenance-calendar] for tracking them. You may encounter larger delays while bulk processing jobs are running.
+
+[maintenance-calendar]: https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles
+
+
+## API Change Log
+
+[View the Change Log](rest-change-log.md){button}
+
+## Copyright
+
+Our data is free of known copyright restrictions.
+
+[![Public Domain Mark][cc-pd-img]][cc-pd]
+
+[cc-pd-img]: https://www.courtlistener.com/static/png/cc-pd.png
+[cc-pd]: https://creativecommons.org/publicdomain/mark/1.0/

--- a/wiki-exports/rest-change-log.md
+++ b/wiki-exports/rest-change-log.md
@@ -1,0 +1,131 @@
+---
+title: "REST API Change Log"
+description: "A log of changes to the CourtListener REST API across all versions."
+redirect_from: "/help/api/rest/changes/"
+wiki_path: "/c/courtlistener/help/api/rest/change-log/"
+---
+
+**v4.4**
+: Adds bankruptcy information support. This release introduces:
+  - A new `bankruptcy_information` field in the [/dockets][pacer-dockets] endpoint that links to detailed bankruptcy metadata when available.
+  - A new [/bankruptcy-information][pacer-bankruptcy] endpoint providing access to bankruptcy-specific data including chapter, trustee information, and key dates.
+
+**v4.3**
+: Enhances security by enforcing authentication in V4 API endpoints. Anonymous requests now receive a `401 Unauthorized` response. This change affects the following endpoints:
+  - [/dockets][pacer-dockets]
+  - [/opinion-clusters][cluster-endpoint]
+  - [/opinions][opinion-endpoint]
+
+**v4.2**
+: Enhances support for [Field Selection][field-selection] in nested resources via the `fields` and `omit` parameters to reduce payload size and improve response times. Clients can now select nested fields (e.g. `fields=educations__date_modified`) or exclude them (e.g. `omit=recap_documents__plain_text`), allowing fine-grained control over serialized nested data. ([Issue #5748][issue-5748], [PR #5973][pr-5973])
+
+**v4.1**
+: This release introduces a number of enhancements aimed at improving the efficiency and flexibility of your data retrieval.
+  - **Enhanced Paginated Endpoints:** Introduced the [count=on][counting] query parameter to efficiently retrieve total item counts without fetching actual data ([Issue #4506][issue-4506], [PR #4715][pr-4715]).
+  - **Search Results:** Improved search results across all search types by incorporating [score values][search-notes] to the payload ([Issue #4312][issue-4312], [PR #4712][pr-4712]).
+  - **Flexible Docket Entry Sorting:** The [Docket Entry endpoint][docket-entries] now supports sorting results by `recap_sequence_number` and `entry_number`. This added flexibility allows you to customize your data retrieval to meet specific requirements. ([Issue #4061][issue-4061], [PR #4700][pr-4700]).
+  - **Deeper Filtering for Parties and Attorneys:** The [parties][parties] and [attorneys][attorneys] API endpoints has been upgraded with the `filter_nested_results=True` query parameter. This enables granular filtering of nested data, providing more control over the retrieved information. ([Issue #4054][issue-4054], [PR #4729][pr-4729]).
+  - **Enhanced Court Filtering:** The `parent_court` query parameter has been added to the [Court endpoint][courts], allowing you to filter results based on parent-child relationships between courts. ([Issue #4711][issue-4711], [PR #4744][pr-4744]).
+
+**v4.0**
+: Migrate search to ElasticSearch and enable cursor-based pagination. See the [Migration Guide][migration-guide] for details.
+
+**v3.15**
+: Allow deep pagination on the Court endpoint, add `docket_id` to the Clusters endpoint, and add `cluster_id` and `author_id` to the Opinions endpoint.
+
+**v3.14**
+: This release blocks users from paginating past page 100 in the API. This release is not backwards incompatible, but is being released on an emergency basis to stop crawlers that have been impacting our database tier. In our performance documentation, we have long warned against using deep pagination. Now it is blocked. If you need this functionality for your application, please consider using filters to complete your crawling instead.
+
+**v3.13**
+: This version adds data from newly added judicial financial disclosure documents. This data is now included in a series of new endpoints to explore financial disclosures. For example, you can filter by gifts received by a specific federal judge or district.
+
+  The new endpoints include `gifts`, `reimbursements`, `disclosure-positions`, `agreements`, `debts`, `investments`, `spouse-income`, `non-investment-incomes` and `financial-disclosures`. For an understanding of these fields, see the endpoint documentation.
+
+**v3.12**
+: This version deprecates the experimental Core API interface we tried previously. Swagger/OpenAPI has become the standard. Our support of OpenAPI remains experimental, but our toolkit should support it better than previously.
+
+  Many endpoints can only be filtered by specific values. For example, to filter the `educations` endpoint to only bachelor's degrees, you'd use `degree_level=ba` as part of your GET request. In the past, if invalid filter values were used, zero results would be returned because zero items would match that query. This made sense, but did not help users identify their error. These values now return a `400` status code and an error message instead.
+
+**v3.11**
+: This version adds several fields and changes one.
+
+  `Person.date_completed`: The date and time the person was last considered complete.
+
+  `Person.dod_country` and `Person.dob_country`: The country where a person was born or died.
+
+  `Position.sector`: Whether a position was in the private or public sector.
+
+  `Court.date_last_pacer_contact`: This will track the last time we contacted PACER for a court.
+
+  `Court.pacer_rss_entry_types`: This will track the types of entries available in a court's PACER RSS feed.
+
+  `Position.date_started` is now a nullable field.
+
+**v3.10**
+: This version introduces the visualization APIs.
+
+**v3.9**
+: This version adds attachment page fetching to the RECAP fetch API.
+
+**v3.8**
+: This version adds fields to support Harvard case law data. This includes `correction`, `cross_reference`, `disposition`, `headnotes`, `history`, `other_dates` and `summary` fields for Cluster endpoint, and `joined_by_str` and `xml_harvard` fields for Opinion endpoint.
+
+**v3.7**
+: This version adds data from the Federal Judicial Center's Integrated Database. This data is now included in a new endpoint and as a new `idb_data` key in the Docket object. For an understanding of these fields, see the endpoint documentation.
+
+**v3.6**
+: This version deprecated the numerous `federal_cite_one`, `neutral_cite`, `lexis_cite`, and other citation fields, replacing them with a nested field called `citations`. The old fields will continue receiving updates until February 1, 2019, and will be removed on May 1, 2019.
+
+**v3.5**
+: This version adds the `mdl_status` field to the docket endpoint.
+
+**v3.4**
+: This version adds the `file_size` field to the RECAP document endpoint. This field contains the size (in bytes) of any document that we have.
+
+**v3.3**
+: This version added a variety of appellate fields to the docket object including a new related item called the `OriginalCourtInformation`. See the [Original Court endpoint documentation][orig-court-info].
+
+  The new fields added to the docket include `appeal_from`, `appeal_from_str`, `originating_court_information`, `panel`, `panel_str`, `appellate_fee_status`, and `appellate_case_type_information`.
+
+**v3.2**
+: This version added the `id` field to many of the endpoints.
+
+**v3.1**
+: This version added experimental Swagger and Core API implementations.
+
+**v3.0**
+: Upgraded and overhauled the API to use the Django REST Framework.
+
+**v2**
+: [For original documentation, see: /help/api/rest/v2/][rest-v2]
+
+**v1**
+: [For original documentation, see: /help/api/rest/v1/][rest-v1]
+
+[pacer-dockets]: pacer-api.md#dockets
+[pacer-bankruptcy]: pacer-api.md#bankruptcy-information
+[cluster-endpoint]: case-law-api.md#clusters
+[opinion-endpoint]: case-law-api.md#opinions
+[field-selection]: rest-api.md#field-selection
+[issue-5748]: https://github.com/freelawproject/courtlistener/issues/5748
+[pr-5973]: https://github.com/freelawproject/courtlistener/pull/5973
+[counting]: rest-api.md#counting
+[issue-4506]: https://github.com/freelawproject/courtlistener/issues/4506
+[pr-4715]: https://github.com/freelawproject/courtlistener/pull/4715
+[search-notes]: search-api.md#special-notes
+[issue-4312]: https://github.com/freelawproject/courtlistener/issues/4312
+[pr-4712]: https://github.com/freelawproject/courtlistener/pull/4712
+[docket-entries]: pacer-api.md#docket-entries
+[issue-4061]: https://github.com/freelawproject/courtlistener/issues/4061
+[pr-4700]: https://github.com/freelawproject/courtlistener/pull/4700
+[parties]: pacer-api.md#parties
+[attorneys]: pacer-api.md#attorneys
+[issue-4054]: https://github.com/freelawproject/courtlistener/issues/4054
+[pr-4729]: https://github.com/freelawproject/courtlistener/pull/4729
+[courts]: pacer-api.md#courts
+[issue-4711]: https://github.com/freelawproject/courtlistener/issues/4711
+[pr-4744]: https://github.com/freelawproject/courtlistener/pull/4744
+[migration-guide]: migration-guide.md
+[orig-court-info]: pacer-api.md#originating-court-info
+[rest-v2]: https://www.courtlistener.com/help/api/rest/v2/
+[rest-v1]: https://www.courtlistener.com/help/api/rest/v1/

--- a/wiki-exports/search-api-v3.md
+++ b/wiki-exports/search-api-v3.md
@@ -1,0 +1,215 @@
+---
+title: "Search API, v3"
+description: "Use this API to search case law, federal filings and cases, judges, and oral argument audio files."
+redirect_from: "/help/api/rest/v3/search/"
+wiki_path: "/c/courtlistener/help/api/rest/v3/search/"
+search_engines: false
+ai_assistants: false
+---
+
+> [!WARNING]
+> **Deprecated** — This is the documentation for the v3 Search API. Please use the [latest version][rest-api] instead.
+
+## Overview
+`/api/rest/v3/search/`
+
+Use this API to search case law, PACER data, judges, and oral argument audio recordings.
+
+To get the most out of this API, see our [coverage][coverage] and [advanced operators][advanced-search] documentation.
+
+[coverage]: https://www.courtlistener.com/coverage/
+
+
+## Basic Usage
+
+This API uses the same GET parameters as the front end of the website. To use this API, place a search query on the front end of the website. That will give you a URL like:
+
+```
+https://www.courtlistener.com/q=foo
+```
+
+To make this into an API request, copy the GET parameters from this URL to the API endpoint, creating a request like:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  'https://www.courtlistener.com/api/rest/v3/search/?q=foo'
+```
+
+That returns:
+
+```json
+{
+  "count": 2369,
+  "next": "https://www.courtlistener.com/api/rest/v3/search/?page=2&q=foo",
+  "previous": null,
+  "results": [
+    {
+      "absolute_url": "/opinion/106359/fong-foo-v-united-states/",
+      "attorney": "Arthur Richenthal argued the causes for petitioners and filed briefs for petitioner in No. 65. David E. Feller filed briefs for petitioners in No. 64., Solicitor General Cox argued the causes for the United States. With him on the briefs were Assistant Attorney General Miller, Stephen J. Poliak, Beatrice Rosenberg, Philip R. Monahan and J. F. Bishop.",
+      "author_id": null,
+      "caseName": "Fong Foo v. United States",
+      "caseNameShort": "Fong Foo",
+      "citation": [
+        "7 L. Ed. 2d 629",
+        "82 S. Ct. 671",
+        "369 U.S. 141",
+        "1962 U.S. LEXIS 1600"
+      ],
+      "citeCount": 357,
+      "cites": [
+        94515,
+        98794,
+        100989,
+        101974,
+        106273,
+        253004
+      ],
+      "cluster_id": 106359,
+      "court": "Supreme Court of the United States",
+      "court_citation_string": "SCOTUS",
+      "court_exact": "scotus",
+      "court_id": "scotus",
+      "dateArgued": null,
+      "dateFiled": "1962-03-19T00:00:00-08:00",
+      "dateReargued": null,
+      "dateReargumentDenied": null,
+      "docketNumber": "64",
+      "docket_id": 1153854,
+      "download_url": null,
+      "id": 106359,
+      "joined_by_ids": null,
+      "judge": "Harlan, Clark, Whittaker",
+      "lexisCite": "1962 U.S. LEXIS 1600",
+      "local_path": null,
+      "neutralCite": null,
+      "non_participating_judge_ids": null,
+      "pagerank": null,
+      "panel_ids": null,
+      "per_curiam": null,
+      "scdb_id": "1961-048",
+      "sibling_ids": [
+        106359,
+        9422362,
+        9422363,
+        9422364
+      ],
+      "snippet": "\n\n\n    \n369 U.S. 141 (1962)\nFONG FOO ET AL.\nv.\nUNITED STATES.\nNo. 64.\nSupreme Court of United States...",
+      "source": "LRU",
+      "status": "Precedential",
+      "status_exact": "Precedential",
+      "suitNature": "",
+      "timestamp": "2024-03-01T14:12:07.892000-08:00",
+      "type": "010combined"
+    },
+    ...
+```
+
+That's the simple version. Read on to learn the rest.
+
+
+## Understanding the API
+
+Unlike most APIs on CourtListener, this API is powered by our search engine, not our database.
+
+This means that it does not use the same approach to ordering, filtering, or field definitions as our other APIs, and sending an HTTP `OPTIONS` request won't be useful.
+
+
+### Setting the Result `type`
+
+The most important parameter in this API is `type`. This parameter sets the type of object you are querying:
+
+| Type | Definition |
+|------|------------|
+| `o` | Case law opinions |
+| `r` | Federal filing documents from PACER |
+| `d` | Federal cases (dockets) from PACER |
+| `p` | Judges |
+| `oa` | Oral argument audio files |
+
+For example, this query searches case law:
+
+```
+https://www.courtlistener.com/q=foo&type=o
+```
+
+And this query searches federal filings in the PACER system:
+
+```
+https://www.courtlistener.com/q=foo&type=r
+```
+
+If the `type` parameter is not provided, the default is to search case law.
+
+
+### Ordering Results
+
+Each search `type` can be sorted by certain fields. These are available on the front end in the ordering drop down, which sets the `order_by` parameter.
+
+
+### Filtering Results
+
+Results can be filtered with the input boxes provided on the front end or by [advanced query operators][advanced-search] provided to the `q` parameter.
+
+The best way to refine your query is to do so on the front end, and then copy the GET parameters to the API.
+
+
+### Fields
+
+Unlike most of the fields on CourtListener, many fields on this API are provided in camelCase instead of snake_case. This is to make it easier for users to place queries like:
+
+```
+caseName:foo
+```
+
+Instead of:
+
+```
+case_name:foo
+```
+
+All available fields are listed on the [advanced operators help page][advanced-search].
+
+To understand the meaning of a field, find the object in our regular APIs that it corresponds to, and send an HTTP `OPTIONS` request to the API.
+
+For example, the `docketNumber` field in the search engine corresponds to the `docket_number` field in the `docket` API, so an HTTP `OPTIONS` request to that API returns its definition:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v3/dockets/" \
+  | jq '.actions.POST.docket_number'
+```
+
+After filtering through [`jq`][jq], that returns:
+
+```json
+{
+  "type": "string",
+  "required": false,
+  "read_only": false,
+  "label": "Docket number",
+  "help_text": "The docket numbers of a case, can be consolidated and quite long. In some instances they are too long to be indexed by postgres and we store the full docket in the correction field on the Opinion Cluster."
+}
+```
+
+[jq]: https://github.com/jqlang/jq
+
+
+### Special Notes
+
+A few fields deserve special consideration:
+
+1. As in the front end, when the `type` is set to return case law, only published results are returned by default. To include unpublished and other statuses, you need to explicitly request them.
+
+2. The `snippet` field contains the same values as are found on the front end. This uses the HTML5 `<mark>` element to identify up to five matches in a document.
+
+   This field only responds to arguments provided to the `q` parameter. If the `q` parameter is not used, the `snippet` field will show the first 500 characters of the `text` field.
+
+
+## Monitoring a Query for New Results
+
+To monitor queries for new results, use the Alert API, which will send emails or webhook events when there are new results.
+
+[rest-api]: rest-api.md
+[advanced-search]: https://www.courtlistener.com/help/search/

--- a/wiki-exports/search-api.md
+++ b/wiki-exports/search-api.md
@@ -1,0 +1,268 @@
+---
+title: "Legal Search API"
+description: "Use this API to search case law, federal filings and cases, judges, and oral argument audio files."
+redirect_from: "/help/api/rest/v4/search/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/search/"
+---
+
+## Overview
+`/api/rest/v4/search/`
+
+<p class="lead">Use this API to search case law, PACER data, judges, and oral argument audio recordings.</p>
+
+To get the most out of this API, see our [coverage][coverage], [advanced operators][search-operators], and [relative date queries][relative-dates] documentation.
+
+[coverage]: https://www.courtlistener.com/help/coverage/
+[search-operators]: https://www.courtlistener.com/help/search-operators/
+[relative-dates]: https://www.courtlistener.com/help/relative-dates/
+
+## Basic Usage
+
+This API uses the same GET parameters as the front end of the website. To use this API, place a search query on the front end of the website. That will give you a URL like:
+
+```
+https://www.courtlistener.com/q=foo
+```
+
+To make this into an API request, copy the GET parameters from this URL to the API endpoint, creating a request like:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  'https://www.courtlistener.com/api/rest/v4/search/?q=foo'
+```
+
+That returns:
+
+```json
+{
+  "count": 2343,
+    "next": "https://www.courtlistener.com/api/rest/v4/search/?cursor=cz0yMzUuODcxMjUmcz04MDUzNTUzJnQ9byZkPTIwMjQtMDktMTY%3D&q=foo",
+    "previous": null,
+    "results": [
+        {
+            "absolute_url": "/opinion/6613686/foo-v-foo/",
+            "attorney": "",
+            "caseName": "Foo v. Foo",
+            "caseNameFull": "Foo v. Foo",
+            "citation": [
+                "101 Haw. 235",
+                "65 P.3d 182"
+            ],
+            "citeCount": 0,
+            "cluster_id": 6613686,
+            "court": "Hawaii Intermediate Court of Appeals",
+            "court_citation_string": "Haw. App.",
+            "court_id": "hawapp",
+            "dateArgued": null,
+            "dateFiled": "2003-01-10",
+            "dateReargued": null,
+            "dateReargumentDenied": null,
+            "docketNumber": "24158",
+            "docket_id": 63544014,
+            "judge": "",
+            "lexisCite": "",
+            "meta": {
+                "timestamp": "2024-06-22T10:26:35.320787Z",
+                "date_created": "2022-06-26T23:24:18.926040Z",
+                "score": {
+                    "bm25": 2.1369965
+                }
+            },
+            "neutralCite": "",
+            "non_participating_judge_ids": [],
+            "opinions": [
+                {
+                    "author_id": null,
+                    "cites": [],
+                    "download_url": null,
+                    "id": 6489975,
+                    "joined_by_ids": [],
+                    "local_path": null,
+                    "meta": {
+                        "timestamp": "2024-06-24T21:14:41.408206Z",
+                        "date_created": "2022-06-26T23:24:18.931912Z"
+                    },
+                    "per_curiam": false,
+                    "sha1": "",
+                    "snippet": "\nAffirmed in part, reversed in part, vacated and remanded\n",
+                    "type": "lead-opinion"
+                }
+            ],
+            "panel_ids": [],
+            "panel_names": [],
+            "posture": "",
+            "procedural_history": "",
+            "scdb_id": "",
+            "sibling_ids": [
+                6489975
+            ],
+            "source": "U",
+            "status": "Published",
+            "suitNature": "",
+            "syllabus": ""
+        },
+...
+```
+
+That's the simple version. Read on to learn the rest.
+
+## Understanding the API
+
+Unlike most APIs on CourtListener, this API is powered by our search engine, not our database.
+
+This means that it does not use the same approach to ordering, filtering, or field definitions as our other APIs, and sending an HTTP `OPTIONS` request won't be useful.
+
+CourtListener's search results are powered by the [Citegeist Relevancy Engine][citegeist], which supports both keyword search and semantic search.
+
+Semantic search makes it possible to query the case law database using plain language queries, instead of keywords. It can be a better tool for untrained users, while keyword search provides a powerful ranking system with deep pagination that may be more familiar to attorneys.
+
+For a deeper treatment of the pros and cons of these systems, please read [our help page on Citegeist][citegeist].
+
+[citegeist]: https://www.courtlistener.com/help/citegeist/
+
+### Semantic Search vs. Keyword Search
+
+By default, API requests will be handled by our keyword search engine.
+
+To use semantic search instead, special `GET` parameters or `POST` requests are needed. Whether to use `GET` or `POST` depends on the privacy requirements of your application:
+
+- **GET** — If you are able to send search queries to CourtListener, using a `GET` request is best and simplest.
+
+  To use semantic search with a `GET` request, add `semantic=true` to your request, and you will place a semantic query instead of a keyword query. It's that simple.
+
+- **POST** — If regulatory or privacy requirements prevent you from sending search queries to CourtListener — or if you just prefer a more private approach — we have another solution.
+
+  When you use a `GET` request, we receive the query, embed it on our system and calculate results. If you use a `POST` request, you can do the embedding in your system and send us *only* the resulting embedding, instead of sending the query.
+
+  To `POST` pre-computed embeddings to this endpoint, include a JSON body in the POST request:
+
+  ```json
+  {
+    "embedding": [0.123, 0.456, -0.789, ...]
+  }
+  ```
+
+  The `embedding` key in your request body is a list of floating-point numbers representing a vector of your query. It should have a length of 768 dimensions and is required for `POST` requests.
+
+  To calculate embeddings, we recommend our [Inception microservice][inception]. For it to work properly, you will need to use [our fine-tuned model][semantic-search-model].
+
+Semantic search is only available for the case law search engine.
+
+[inception]: https://github.com/freelawproject/inception
+[semantic-search-model]: https://free.law/2025/03/11/semantic-search
+
+### Setting the Result Type
+
+The most important parameter in this API is `type`. This parameter sets the type of object you are querying:
+
+| Type | Definition |
+|------|------------|
+| `o` | Case law opinion clusters with nested Opinion documents. |
+| `r` | List of Federal cases (dockets) with up to three nested documents. If there are more than three matching documents, the `more_docs` field for the docket result will be `true`. |
+| `rd` | Federal filing documents from PACER |
+| `d` | Federal cases (dockets) from PACER |
+| `p` | Judges |
+| `oa` | Oral argument audio files |
+
+For example, this query searches case law:
+
+```
+https://www.courtlistener.com/q=foo&type=o
+```
+
+And this query searches federal filings in the PACER system:
+
+```
+https://www.courtlistener.com/q=foo&type=r
+```
+
+If the `type` parameter is not provided, the default is to search case law.
+
+### Ordering Results
+
+Each search `type` can be sorted by certain fields. These are available on the front end in the ordering drop down, which sets the `order_by` parameter.
+
+Our [Citegeist Relevancy Engine][citegeist] sorts results when you order by relevancy. It uses a combination of factors to provide the most important results first.
+
+If your sorting field has null values, those results will be sorted at the end of the query, regardless of whether you sort in ascending or descending order. For example, if you sort by a date that is null for an opinion, that opinion will go at the end of the result set.
+
+### Filtering Results
+
+Results can be filtered with the input boxes provided on the front end or by [advanced query operators][search-operators] provided to the `q` parameter.
+
+The best way to refine your query is to do so on the front end, and then copy the GET parameters to the API.
+
+### Fields
+
+Unlike most of the fields on CourtListener, many fields on this API are provided in camelCase instead of snake_case. This is to make it easier for users to place queries like:
+
+```
+caseName:foo
+```
+
+Instead of:
+
+```
+case_name:foo
+```
+
+All available fields are listed on the [advanced operators help page][search-operators].
+
+To understand the meaning of a field, find the object in our regular APIs that it corresponds to, and send an HTTP `OPTIONS` request to the API.
+
+For example, the `docketNumber` field in the search engine corresponds to the `docket_number` field in the `docket` API, so an HTTP `OPTIONS` request to that API returns its definition:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/dockets/" \
+  | jq '.actions.POST.docket_number'
+```
+
+After filtering through [`jq`][jq], that returns:
+
+```json
+{
+  "type": "string",
+  "required": false,
+  "read_only": false,
+  "label": "Docket number",
+  "help_text": "The docket numbers of a case, can be consolidated and quite long. In some instances they are too long to be indexed by postgres and we store the full docket in the correction field on the Opinion Cluster."
+}
+```
+
+[jq]: https://github.com/jqlang/jq
+
+### Highlighting Results
+
+To enhance performance, results are not highlighted by default. To enable highlighting, include `highlight=on` in your request.
+
+When highlighting is disabled, the first 500 characters of snippet fields are returned for fields `o`, `r`, and `rd`.
+
+### Result Counts
+
+`type=d` and `type=r` use cardinality aggregation to compute the result count. This enhances performance, but has an error of +/-6% if results are over 2000. We recommend noting this in your interface by saying something like, "About 10,000 results."
+
+### Special Notes
+
+A few fields deserve special consideration:
+
+1. As in the front end, when the `type` is set to return case law, only published results are returned by default. To include unpublished and other statuses, you need to explicitly request them.
+
+2. The `snippet` field contains the same values as are found on the front end. This uses the HTML5 `<mark>` element to identify up to five matches in a document.
+
+   This field only responds to arguments provided to the `q` parameter. If the `q` parameter is not used, the `snippet` field will show the first 500 characters of the `text` field.
+
+   This field only displays Opinion text content.
+
+3. The `meta` field in main documents contains the `score` field, which is currently a JSON object that includes the `bm25` score used by Elasticsearch to rank results. Additional scores may be introduced in the future.
+
+## Monitoring a Query for New Results
+
+All query results are cached for ten minutes. This provides instant responses to front-end users who frequently refresh or paginate results.
+
+Because of this, we do not recommend polling as a mechanism for monitoring queries for new results. Instead, use the [Alert API][alert-api], which will send emails or [webhook events][webhooks] when there are new hits.
+
+[alert-api]: alert-api.md
+[webhooks]: webhooks.md

--- a/wiki-exports/tag-api.md
+++ b/wiki-exports/tag-api.md
@@ -1,0 +1,167 @@
+---
+title: "Tag APIs"
+description: "Use these APIs to create, organize, and manage tags on dockets."
+redirect_from: "/help/api/rest/v4/tags/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/tags/"
+---
+
+<p class="lead">Use these APIs to create, organize, and manage tags on dockets in our system.</p>
+
+Tags help you organize and share collections of cases. You can create public tags that others can view or keep them private for your own use. Tags can be described using markdown to create sharable collections.
+
+This page focuses on the tags API itself. To learn more about tags generally and how to use them in the web interface, read the tags documentation.
+
+[Learn About Tags](https://www.courtlistener.com/help/tags-notes/){button}
+
+## User Tags
+`/api/rest/v4/tags/`
+
+User Tags are collections you create to organize dockets. Each tag has a name, optional description, and can be made public or kept private.
+
+### Fields
+
+- **`name`** (required) — A unique slug for your tag (lowercase, no spaces)
+- **`title`** (optional) — A human-friendly title for display
+- **`description`** (optional) — Markdown description of the tag
+- **`published`** (optional) — Boolean, whether the tag is public (default: false)
+- **`view_count`** (read-only) — Number of times the tag page has been viewed
+
+To learn more about this API, make an HTTP `OPTIONS` request:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/tags/"
+```
+
+### Example Usage
+
+#### Creating a Tag
+
+Create a new tag with a POST request:
+
+```
+curl -X POST \
+  --data 'name=my-important-cases' \
+  --data 'title=My Important Cases' \
+  --data 'description=Cases I am tracking for work' \
+  --data 'published=false' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/tags/"
+```
+
+The response:
+
+```json
+{
+  "id": 123,
+  "date_created": "2024-12-08T10:30:00.000000-08:00",
+  "date_modified": "2024-12-08T10:30:00.000000-08:00",
+  "user": 456,
+  "name": "my-important-cases",
+  "title": "My Important Cases",
+  "description": "Cases I am tracking for work",
+  "published": false,
+  "view_count": 0,
+  "dockets": []
+}
+```
+
+#### Updating a Tag
+
+Update a tag with a PATCH request:
+
+```
+curl -X PATCH \
+  --data 'published=true' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/tags/123/"
+```
+
+#### Listing Your Tags
+
+List all your tags with a GET request:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/tags/"
+```
+
+#### Deleting a Tag
+
+Delete a tag with a DELETE request:
+
+```
+curl -X DELETE \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/tags/123/"
+```
+
+## Docket Tags
+`/api/rest/v4/docket-tags/`
+
+Docket Tags connect your User Tags to specific dockets. This is a many-to-many relationship managed through this API.
+
+### Fields
+
+- **`tag`** (required) — The ID of the User Tag
+- **`docket`** (required) — The ID of the docket to tag
+
+To learn more about this API, make an HTTP `OPTIONS` request:
+
+```
+curl -X OPTIONS \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-tags/"
+```
+
+### Example Usage
+
+#### Tagging a Docket
+
+Add a docket to a tag with a POST request:
+
+```
+curl -X POST \
+  --data 'tag=123' \
+  --data 'docket=456789' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-tags/"
+```
+
+The response:
+
+```json
+{
+  "id": 789,
+  "tag": 123,
+  "docket": 456789
+}
+```
+
+#### Listing Tagged Dockets
+
+To see all dockets tagged with a specific tag, filter by tag ID:
+
+```
+curl -X GET \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-tags/?tag=123"
+```
+
+#### Untagging a Docket
+
+To untag a docket, delete the Docket Tag object:
+
+```
+curl -X DELETE \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-tags/789/"
+```
+
+## Related APIs
+
+Tags are related to the Pray and Pay program, which allows you to request PACER documents for cases you're tracking. When using Pray and Pay, you can organize the cases you're monitoring using tags, making it easy to manage large collections of cases.
+
+[Learn About Pray and Pay](https://www.courtlistener.com/help/pray-and-pay/){button}

--- a/wiki-exports/visualizations-api.md
+++ b/wiki-exports/visualizations-api.md
@@ -1,0 +1,107 @@
+---
+title: "Supreme Court Visualization API"
+description: "Use these APIs to make and modify Supreme Court Visualizations."
+redirect_from: "/help/api/rest/v4/visualizations/"
+wiki_path: "/c/courtlistener/help/api/rest/v4/visualizations/"
+---
+
+## Overview
+`/api/rest/v4/visualizations/`
+
+<p class="lead">Use this API to programmatically create and manage Supreme Court network visualizations in CourtListener.</p>
+
+All visualizations are associated with a user and are private by default. When you GET these endpoints, you will see data for visualizations that have been made public by their owners or that you have created yourself.
+
+To learn more about opinion clusters, see the [case law API documentation][case-law-api]. To learn more about citations between decisions see the [citation API documentation][citation-api].
+
+[case-law-api]: case-law-api.md
+[citation-api]: citation-api.md
+
+## Creating Visualizations
+
+To create a new visualization, send an HTTP `POST` with a title, a starting cluster ID, and an ending cluster ID:
+
+```
+curl -X POST \
+  --data 'cluster_start=/api/rest/v4/clusters/105659/' \
+  --data 'cluster_end=/api/rest/v4/clusters/111891/' \
+  --data 'title=A map from Trop to Salerno' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/visualizations/"
+```
+
+The `cluster_start` and `cluster_end` parameters use URLs instead of IDs.
+
+The above command creates a visualization unless there are no connections between the start and end clusters or the network becomes too large to generate.
+
+Once created, the visualization will have nested JSON data representing the visualization itself, a list of clusters that are in it, and various other metadata.
+
+## Editing and Deleting Visualizations
+
+Changing data for an existing visualization can be done via an HTTP `PATCH` request. For example, to make a visualization publicly accessible:
+
+```
+curl -X PATCH \
+  --data 'published=True' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/visualizations/1/"
+```
+
+Similar commands can be used to update other non-readonly fields.
+
+To soft-delete a visualization, flip the `deleted` field to `True`. To hard-delete, send an HTTP `DELETE` request.
+
+## Deprecation Notice
+
+> [!WARNING]
+> Our system for visualizing Supreme Court networks has not gotten much traction among users, and is largely deprecated as of late 2025.
+
+If you are interested in creating, deleting, or updating visualizations, you can still do so through our APIs, but it is no longer possible to display visualizations on CourtListener.com itself. Moving forward, to support existing users, the only way to display visualizations is through their embed links.
+
+To embed a visualization on a website you control, use code like the following on your site:
+
+```html
+<iframe height="540" width="560" src="https://www.courtlistener.com/visualizations/scotus-mapper/YOUR_ID_HERE/embed/" frameborder="0" allowfullscreen></iframe>
+```
+
+Just replace YOUR_ID_HERE with the ID of your visualization, and it should work on your website.
+
+The following `GET` parameters may be used to adjust the display:
+
+- **`type`** — Use this to set the y-axis. `spread` opens up the visualization with random locations for the nodes so they can all be seen. `geneology` makes many paths lighter to highlight the most direct paths. `spaeth` uses the Supreme Court Database's vote count and decision direction fields.
+- **`xaxis`** — The x-axis may be set to either equal spacing (`cat`) or accurate chronological spacing (`time`)
+- **`dos`** — Use this to set the Degree of Separation, which represents the maximum number of hops between the first and last nodes.
+
+For example, GET parameters like these will provide a clean, equally spaced chart with up to five nodes of separation: `?type=geneology&xaxis=cat&dos=5`.
+
+We apologize for this deprecation and hope you understand that we cannot always maintain all the features and experiments we undertake.
+
+## Frequently Asked Questions
+
+### Why do the case circles change size?
+
+Circles change size based on the number of citations to it by other cases in the network. The more cases that cite to *Case A*, the larger it will be. The only exception to this rule is the rightmost case on network (with the most recent date). For visual clarity, this anchor case is always represented with a large circle.
+
+### How can I find out what the cases in my network mean?
+
+This tool will not read the cases for you, but it will make your reading more efficient. You can read opinion text directly by clicking on opinions in the visualization. You can see all the Supreme Court Database information for a case. Information will open in a separate window and includes issue area, legal provision involved, and detailed voting information. By using SCDB information and skimming opinion text, you can figure out what is going on in the case fairly quickly. Some networks also have helpful user descriptions.
+
+### Why did my network default to 2-degrees?
+
+We do not generate 3-degree networks when it will contain more than 70 cases. We have found networks larger than 70 are too unwieldy and so default those networks to 2-degrees.
+
+### Why is a case missing from my network?
+
+When the Supreme Court cites to recently decided cases, the citation form is non-standard such as citing to *Slip. Op* or *555 S.Ct ___*. This currently confounds our automatic citation parser. It's a problem we're working on.
+
+### How do I embed a network in my blog?
+
+Use the iframe code shown in the deprecation notice above. Replace YOUR_ID_HERE with the ID of your visualization. You can then put this code in your WordPress blog (or LibGuides site, etc.) just as you would embed a video from YouTube.
+
+### What do you mean by "Degree of Dissent"?
+
+We use *Degree of Dissent* (DoD) in our visualizations of Supreme Court networks to indicate the average level of disagreement in the cases shown. For example, in a network that shows two cases, each with unanimous 9-0 votes, there would be no dissent, and so the score would be 0. By contrast, if a network had only two cases, each with 5-4 decisions, the DoD would be 1.0, indicating a highly dissenting network.
+
+Mathematically, the DoD for a given case is calculated by multiplying the number of dissents by 0.25. This means that a 9-0 case will have the same DoD as a 8-0 case (0.0) and a 6-3 will have the same DoD as 5-3 case.
+
+In some cases you may see that the DoD is not using all of the cases in a network, stating something like: "Degree of Dissent: 0.73 for 16 cases of 17." This occurs because some cases do not have vote information in the Supreme Court Database (Spaeth).

--- a/wiki-exports/webhooks-getting-started.md
+++ b/wiki-exports/webhooks-getting-started.md
@@ -1,0 +1,126 @@
+---
+title: "Getting Started With Webhooks"
+description: "Step-by-step guide to creating your first webhook on CourtListener."
+redirect_from: "/help/api/webhooks/getting-started/"
+wiki_path: "/c/courtlistener/help/api/webhooks/getting-started/"
+---
+
+<p class="lead">To create your first webhook, there are a handful of steps you will need to take:</p>
+
+1. Creating and receiving webhooks does not require any special access, but sooner or later you will want to have access to the RECAP API endpoints. [Send us a note with your username and use case][contact] to get that process started.
+
+2. You need to [create a URL on your server](#receive-a-webhook-event-on-your-server) to receive events from CourtListener.
+
+3. You need to [configure CourtListener to send events](#set-up-a-webhook-endpoint-in-courtlistener) to that URL.
+
+Once you have created the URL on your server and linked it up to ours, you can [send test events from CourtListener](#testing-a-webhook-endpoint) and you can wait for events to be triggered. As you send test events or events are automatically triggered, they appear in the [logs section of your webhooks panel][webhook-logs].
+
+Read on to learn more about setting up your first webhook.
+
+## Receive a Webhook Event on Your Server
+
+Webhook events are nothing more than HTTP POST requests sent to your server. To receive these events, you will need to begin by creating a URL in your application.
+
+Some requirements to consider for the URL that you create:
+
+- [Our webhook system does not support authentication][webhook-security], so the URL you create should be long and random.
+- Our POST requests will come from one of two static IP addresses, `34.210.230.218` and `54.189.59.91`. We recommend only allowing traffic from these addresses.
+- Your URL must receive POST requests and should not accept any other HTTP verbs.
+- If you are using a web framework like Django or Ruby on Rails, the webhook URL will need to be exempted from the cross site request forgery (CSRF) protection system. If this is not done, most web frameworks will block POST requests from outside domains like ours.
+- To avoid [timeout errors and event retries][webhook-retries], your application may need to process events asynchronously.
+- Your application must respond to events with a 2xx HTTP status code or else the event will be retried.
+- Your application should use the [Idempotency-Key included in the event headers][webhook-headers] to ensure that it only processes the event once.
+
+Below are examples of endpoints configured in Flask and Django
+
+**Flask**
+
+```python
+from flask import Flask, request, Response
+app = Flask(__name__)
+
+@app.route("/webhooks/a-long-random-url-here/", methods=["POST"])
+def respond():
+    # Do your event processing.
+    print(request.json)
+    return Response(status=200)
+```
+
+**Django**
+
+```python
+from django.views.decorators.csrf import csrf_exempt
+from django.http import HttpRequest, HttpResponse
+
+@csrf_exempt
+def testing_webhook(request: HttpRequest) -> HttpResponse:
+    if request.method == "POST":
+        print("Headers: ",request.headers)
+        body = request.body.decode("utf-8")
+        print("Body: ", body)
+
+    return HttpResponse("OK")
+```
+
+## Set Up a Webhook Endpoint in CourtListener
+
+To set up a webhook endpoint, begin by logging into CourtListener and going to the [Webhooks panel in your profile][webhooks-panel]:
+
+![screenshot of the webhook panel](https://www.courtlistener.com/static/png/webhooks-panel-v2.png)
+
+Click the "Add webhook" button and the "Add webhook endpoint" modal pops up:
+
+![screenshot of how to add a webhook endpoint](https://www.courtlistener.com/static/png/add-webhook-endpoint-v2.png)
+
+Complete the box with the following information:
+
+1. The Endpoint URL should be a URL on your server that is long and random. It must be securely served with valid HTTPS.
+
+2. Select the Event Type for which you wish to receive events.
+
+3. Choose the webhook version you wish to set up.
+
+   We recommend selecting the highest available version for your webhook. Refer to the [Change Log][webhook-changelog] for more details on webhook versions.
+
+   You can only create one Webhook endpoint for each type of event and version. Please get in touch if this limitation causes difficulty for your application.
+
+4. If you are ready to start receiving events at that URL, check the box to enable the webhook.
+
+   In order to avoid unnecessary errors and retries, we recommend keeping your endpoint disabled until it is live in your application.
+
+Click "Create webhook"
+
+Your Webhook endpoint is now created:
+
+![screenshot of the developer tools panel listing a disabled webhook endpoint](https://www.courtlistener.com/static/png/webhook-disabled-v2.png)
+
+## Testing a Webhook Endpoint
+
+Getting a webhook working properly can be difficult, so we have a testing tool that will send you a sample webhook event on demand.
+
+To use the tool, go to webhooks panel and click the "Test" button for the endpoint you wish to test:
+
+![screenshot of the developer tools panel listing a disabled webhook endpoint](https://www.courtlistener.com/static/png/webhook-disabled-v2.png)
+
+In the modal that pops up, there are two methods to test your webhook endpoint.
+
+1. **In the "As JSON" tab**, you can ask our server to send a test event to your endpoint. When you click "Send Webhook Test Event" a new event is created with the information shown and is sent to your endpoint. Test events are not retried, but can be seen in the "Test Logs" tab.
+
+   ![screenshot of the webhook json test modal](https://www.courtlistener.com/static/png/test-json-webhook-event-v2.png)
+
+2. **In the "As cURL"** tab, you can copy/paste a curl command that can be used to send a test event to your local dev environment.
+
+   ![screenshot of the webhook curl test modal](https://www.courtlistener.com/static/png/test-curl-webhook-event-v2.png)
+
+### Use `ngrok` to test your local endpoint.
+
+During the development process, you may want to test your endpoint in your local environment, before moving it to production. To allow CourtListener to reach your development machine over the Internet, you can use a tool like `ngrok` which will give you a temporary public HTTPS URL that you can use for testing. To learn more about this, read [ngrok's documentation][ngrok-docs].
+
+[contact]: https://www.courtlistener.com/contact/
+[webhook-logs]: https://www.courtlistener.com/profile/webhooks/logs/
+[webhook-security]: webhooks.md#webhook-security
+[webhook-retries]: webhooks.md#retries-and-automatic-endpoint-disablement
+[webhook-headers]: webhooks.md#standard-headers
+[webhooks-panel]: https://www.courtlistener.com/profile/webhooks/
+[webhook-changelog]: https://www.courtlistener.com/help/api/webhooks/v2/#change-log
+[ngrok-docs]: https://ngrok.com/docs/getting-started

--- a/wiki-exports/webhooks.md
+++ b/wiki-exports/webhooks.md
@@ -1,0 +1,391 @@
+---
+title: "Webhook API"
+description: "CourtListener's webhook system allows us to push information to you, enabling bi-directional APIs without polling."
+redirect_from: "/help/api/webhooks/"
+wiki_path: "/c/courtlistener/help/api/webhooks/about/"
+---
+
+<p class="lead">CourtListener's webhook system allows us to push information to you, enabling bi-directional APIs without polling.</p>
+
+To set this up, you create a URL on your server where CourtListener can send data. Then, whenever something important happens in CourtListener, we will POST an "event" to that URL as JSON data. When you receive the event, you can process it and perform whatever actions your system needs in response.
+
+Currently, CourtListener can send webhook events whenever dockets are updated, search alerts are triggered, docket alerts expire, RECAP Fetch tasks complete, or when pray-and-pay requests are granted. If you have other events of interest, please get in touch.
+
+## Pricing
+
+CourtListener is hosted by [Free Law Project][free-law], a non-profit that has "Free" in its name, but we do charge reasonable fees to organizations using advanced features like Webhooks and APIs. We use these fees to maintain our paid and free services.
+
+When we see an organization starting a new project using Webhooks, we will get in touch to discuss the project and set up an agreement that works for everybody.
+
+Questions? Get in touch to start the conversation.
+
+[Contact Us](https://www.courtlistener.com/contact/){button}
+
+## Getting Started With Webhooks
+
+Creating your first webhook working can be complicated. To get an overview of the process, please read our documentation on getting started.
+
+[Get Started](webhooks-getting-started.md){button}
+
+## Overview of Events
+
+### Standard Headers
+
+Each webhook event contains two HTTP headers with additional context for the event:
+
+- **Content-Type**: Indicates the content type of the payload request. For now, our events only support `"application/json"`.
+
+- **Idempotency-Key**: This is a unique 128 bit UUID that corresponds to each event. This value should be used by your application to ensure that you do not process events more than once.
+
+  If you do not take advantage of this feature, we may resend an event that appeared to fail, and you may receive and process it multiple times. More details about this are available in [the section on retries below](#retries).
+
+### Standard Fields
+
+Each webhook event is a JSON hash with two keys, `payload` and `webhook`. The `payload` key contains the specific data for the event that occurred. Its values are described in the [event-specific descriptions below](#event-types).
+
+The `webhook` key helps with maintenance and compatibility. It contains information about the webhook itself. This key should be monitored by administrators and used to track the deprecation schedule for the webhook events.
+
+It has the following structure:
+
+**webhook** *JSON hash*
+
+Information related to the webhook endpoint to which the event belongs.
+
+- **version** *integer* — The specific version of the webhook event.
+
+- **event_type** *integer* — The webhook event type.
+  - DOCKET_ALERT = 1
+  - SEARCH_ALERT = 2
+  - RECAP_FETCH = 3
+  - OLD_DOCKET_ALERTS_REPORT = 4
+  - PRAY_AND_PAY = 5
+
+- **date_created** *ISO 8601 string* — The date time the webhook endpoint was created.
+
+- **deprecation_date** *ISO 8601 string or null* — The next deprecation date if scheduled, otherwise null.
+
+---
+
+### Webhook Security
+
+Our webhook events will be sent from one of two IP addresses:
+
+1. `34.210.230.218`
+2. `54.189.59.91`
+
+We recommend adding these IP addresses to your network allow list and/or verifying that the webhook events you receive come from these addresses.
+
+We also recommend you protect your webhook endpoints by giving them long, random, secret URLs instead of short predictable ones.
+
+Beyond this, our webhook system does not have an authentication mechanism to verify that a POST to your endpoint came from CourtListener. The [decision not to support an authentication mechanism][auth-decision] was made after analyzing the risk of lacking authentication and after completing a review of the Stripe payments platform (which defaults to not using authentication despite being a high-risk environment).
+
+If the need for webhook authentication is a blocker for your organization, [please let us know][contact] and we can revisit this decision.
+
+### Retries and Automatic Endpoint Disablement
+
+Errors across distributed systems are inevitable. To make our webhook system resilient, we automatically retry events POSTed to your application that do not receive a 2xx status code response within one second.
+
+Events are retried up to seven times after the first failure. The retry logic uses an exponential backoff starting at roughly three minutes with a 3x multiplier. As shown in the table below, this gives you around 54 hours to fix any issues in your system.
+
+The next attempt date and time for a specific event can be found [in your webhook logs][webhook-logs].
+
+As webhooks fail to be delivered, we will send emails to your account to inform you of the issue. Email notifications are sent per webhook endpoint based on the first failing event for that endpoint — Notifications are not sent for every failing event, since that would flood your inbox.
+
+This table explains the retry and notification schedule for failing events (in minutes):
+
+| Retry Count | New Delay | Elapsed | Send Failure Notification Email? |
+|:-----------:|:---------:|:-------:|:--------------------------------:|
+| Initial Event | N/A | 0:00 | No |
+| 1 | 0:03 | 0:03 | Yes |
+| 2 | 0:09 | 0:12 | No |
+| 3 | 0:27 | 0:39 | No |
+| 4 | 1:21 | 2:00 | No |
+| 5 | 4:03 | 6:03 | Yes |
+| 6 | 12:09 | 18:12 | No |
+| 7 | 36:27 | 54:39 | Yes |
+
+After a webhook fails eight times, it is disabled in our system and we immediately stop sending it new or undelivered events.
+
+At that point, you will have received two warning emails about the issue, and a third informing you that the endpoint is disabled. Webhooks can be re-enabled at any time, but will get disabled again if errors continue.
+
+Fixed webhook endpoints can be re-enabled in the webhooks panel.
+
+![screenshot of how to re-enable a webhook endpoint](https://www.courtlistener.com/static/png/re-enable-webhook-v2.png)
+
+Once your webhook endpoint is re-enabled, we will continue attempting to deliver failed webhook events that we stopped retrying when the endpoint was disabled, if those events occurred within the last two days.
+
+## Event Types
+
+### Docket Alert Events
+
+If you wish to receive events when particular dockets are updated in CourtListener, you must first "subscribe" to dockets.
+
+A docket subscription can be created in one of three ways:
+
+1. **For normal users**, the best way is [via the CourtListener website itself][recap-alerts].
+
+2. **For servers**, the best way is to use the [Docket Alert API][docket-alert-api].
+
+   For example, this shell code searches for the [Trump Mar-A-Lago][trump-case] case and then subscribes your account to it:
+
+   ```bash
+   curl --silent \
+     --url 'https://www.courtlistener.com/api/rest/v4/search/?type=d&docket_number=22-cv-81294&case_name=trump' \
+     --header 'Authorization: Token <your-token-here>' | \
+   jq '.results[0].docket_id' | \
+   xargs -I % curl -X POST \
+     --url 'https://www.courtlistener.com/api/rest/v4/docket-alerts/' \
+     --header 'Authorization: Token <your-token-here>' \
+     --data 'docket=%'
+   ```
+
+3. **For users** of [@recap.email][recap-email], the best way to subscribe to a case is to have [auto-subscribe turned on in your settings][recap-email-settings].
+
+   When auto-subscribe is on, you will automatically be subscribed to cases when we receive your PACER notifications for them. For users that wish to subscribe to all the cases for which they get PACER notifications, this is usually the best way to do so.
+
+Once subscribed to a case, we will begin POSTing events to your Docket Alert webhook endpoint whenever that case gets new filings.
+
+The docket alert event is a JSON hash with two keys, `webhook` and `payload`. `payload` has a key for new filings that is called `results`.
+
+The shape of the data is thus:
+
+```json
+{
+  "payload": {
+    "results": [...]
+  },
+  "webhook": {...}
+}
+```
+
+The `results` key is based on the [Docket Entry API][docket-entry-api]. It has all the same fields except for the `resource_uri` and `tags` fields, which are omitted, and the `docket` field is an `ID` instead of a URL. If you already have access to that API, you can [see an example object here][docket-entry-example], and do an HTTP OPTIONS request to get a description of the fields:
+
+```bash
+curl -X OPTIONS \
+  --url 'https://www.courtlistener.com/api/rest/v4/docket-entries/' \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+If you do not yet have access to the Docket Entry API, please [let us know][contact]. In the meantime, another way to see an example event is via [the webhook testing tool][webhook-testing].
+
+### Search Alert Events
+
+[Search alerts in CourtListener][search-alerts] allow you to subscribe to a particular query so that you are sent a webhook event whenever it has new results. For example, you can use search alerts to get a notification whenever a case is cited or whenever a particular keyword appears in a legal decision.
+
+To get search alert events, begin by subscribing to particular queries in CourtListener. This can be done in one of two ways:
+
+1. **For normal users**, subscribe to a query [via the CourtListener website itself][search-alerts].
+
+2. **For servers**, the best way is to use the [Search Alert API][search-alert-api].
+
+   For example, this shell code creates a Search Alert for new legal decisions mentioning the [Obergefell v. Hodges case][obergefell]:
+
+   ```bash
+   curl -X POST \
+     --url https://www.courtlistener.com/api/rest/v4/alerts/ \
+     --header 'Authorization: Token <your-token-here>' \
+     --data 'name=My Obergefell Alert' \
+     --data 'query=q=Obergefell+v.+Hodges&type=o&order_by=score+desc&stat_Precedential=on&docket_number=14-556' \
+     --data 'rate=wly'
+   ```
+
+After you've created a Search Alert, we'll send webhook events to your endpoint each time new results are available for your query.
+
+The Search Alert event is a JSON hash with two keys, `webhook` and `payload`. `payload` has two keys, `results` that contains the search results and `alert` for the Search Alert details.
+
+The shape of the data is thus:
+
+```json
+{
+   "payload": {
+      "results": [...],
+      "alert": {...}
+   },
+   "webhook": {...}
+}
+```
+
+The `results` key is based on the Search API endpoint and has all the same fields. Review [the Search API documentation][search-api] for details on how it works; it is slightly different than all of our other API endpoints.
+
+The `alert` key is based on the [Search Alert endpoint][search-alert-api] and has all the same fields except for the `resource_uri` field, which is omitted.
+
+To get a description of the Search Alert object, do an HTTP `OPTIONS` request to the API endpoint:
+
+```bash
+curl -X OPTIONS \
+  --url 'https://www.courtlistener.com/api/rest/v4/alerts/' \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+### Old Docket Alert Events
+
+If a case stops receiving updates due to being terminated or otherwise dormant, we automatically disable any [docket alerts][recap-alerts] that may be configured for it. This helps ease the load on our servers, and helps users in our free tier identify cases that they may wish to stop following.
+
+To help our users manage this, we send a weekly email telling our users about any docket alerts they have that will soon be automatically disabled. This allows them to take one of three actions on the alert:
+
+1. **Do nothing** — If the user does this, the alert will soon be deleted during the next week's automatic process.
+
+2. **Delete the alert** — The user will immediately stop getting alerts for the case.
+
+3. **Re-up the alert** — This tells us that the user wishes to continue getting alerts for the case and pushes out the automatic disablement by about six months.
+
+By subscribing to this webhook your server will get a notification similar to the weekly email we send to users. At that time, your server can decide whether to continue monitoring stagnant cases (by re-upping them; see below) or let the automatic disablement occur.
+
+As with our other events, this webhook event is a JSON hash with two keys, `webhook` and `payload`. `payload` has two keys:
+
+- `disabled_alerts` (Automatically Disabled Alerts):
+
+  Contains a list of docket alerts that have been automatically disabled by our system on terminated cases that haven't had updates for over 180 days. You can re-enable these alerts if they were disabled by mistake.
+
+- `old_alerts` (Old Terminated Cases):
+
+  Contains a list of docket alerts on terminated cases that were last updated about 180 days ago. These alerts will be disabled during the next week's process if you do not re-up them for another six months.
+
+The shape of the data is thus:
+
+```json
+{
+   "payload":{
+      "old_alerts":[
+         {
+            "id":1,
+            "date_created":"2022-09-23T19:53:36.903277-07:00",
+            "date_last_hit":null,
+            "secret_key":"ehT7V9rmnBNIOV6rTMmMH0x6EvxeA0nYXfpN3Ks3",
+            "alert_type":1,
+            "docket":1
+         }
+      ],
+      "disabled_alerts":[...]
+   },
+   "webhook":{...}
+}
+```
+
+`old_alerts` and `disabled_alerts` contain a list of docket alert objects based on the [Docket Alerts API][docket-alert-api] and have all the same fields.
+
+#### Re-upping a docket alert
+
+If a case has been dormant for a long time, and you wish to continue monitoring it, you must re-up the alert. To do this, send an HTTP PATCH request to the [Docket Alerts API][docket-alert-api]:
+
+```bash
+curl -X PATCH \
+  --data 'alert_type=1' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/{id}/"
+```
+
+Doing the above will tell our system that the alert was recently modified and thus should not be disabled for another six months.
+
+A similar request can be used to disable any docket alert:
+
+```bash
+curl -X PATCH \
+  --data 'alert_type=0' \
+  --header 'Authorization: Token <your-token-here>' \
+  "https://www.courtlistener.com/api/rest/v4/docket-alerts/{id}/"
+```
+
+### RECAP Fetch Events
+
+The [RECAP Fetch API][pacer-fetch] lets you use our servers and infrastructure to purchase items on PACER. Your server simply places a `POST` request to the API. In response, the API provides an ID for your request and your download is enqueued for processing.
+
+By listening to this webhook endpoint, your server can monitor your requests and take action when they are complete. This avoids the need to poll the API to check when your request has completed.
+
+As with our other events, this webhook event is a JSON hash with two keys, `webhook` and `payload`.
+
+The shape of the data is thus:
+
+```json
+{
+   "payload":{...},
+   "webhook":{...}
+}
+```
+
+The `payload` key is based on the [RECAP Fetch API][pacer-fetch] endpoint and has all the same fields.
+
+To get a description of the `payload` object, do an HTTP `OPTIONS` request to the API endpoint:
+
+```bash
+curl -X OPTIONS \
+  --url 'https://www.courtlistener.com/api/rest/v4/recap-fetch/' \
+  --header 'Authorization: Token <your-token-here>'
+```
+
+After you set up this endpoint, you will be notified whenever one of your fetch requests terminates in success or failure.
+
+### Pray And Pay Events
+
+The [Pray and Pay system][pray-and-pay] allows users to request PACER documents that are not yet available in CourtListener's RECAP Archive. When a requested document becomes available, users who requested it are notified via email.
+
+To programmatically create and manage prayers, see the [Pray and Pay API documentation][pray-and-pay-api].
+
+By subscribing to this webhook endpoint, your server can be notified when a Pray and Pay request you made has been granted and the document is now available.
+
+As with our other events, this webhook event is a JSON hash with two keys, `webhook` and `payload`.
+
+The shape of the data is thus:
+
+```json
+{
+   "payload":{
+      "id": 1,
+      "date_created": "2025-04-16T21:24:18.879312-07:00",
+      "status": 2,
+      "recap_document": 436149610
+   },
+   "webhook":{...}
+}
+```
+
+The `payload` contains the following fields:
+
+- **id** - The unique identifier for this prayer
+- **date_created** - When the prayer was originally created
+- **status** - The status of the prayer (1 = Waiting, 2 = Granted)
+- **recap_document** - The ID of the RECAP document that was requested
+
+Webhook events are only sent when a prayer's status changes to `GRANTED` (status = 2), indicating the document is now available in the RECAP Archive.
+
+You can retrieve the full document details using the [RECAP Document API][recap-endpoint] with the `recap_document` ID provided in the payload.
+
+## Maintenance Schedule
+
+Major server maintenance is scheduled on Thursday nights from 21:00PT to 23:59PT. If you are scheduling cron jobs or otherwise crawling the API, you may experience downtime during this window.
+
+Bulk processing tasks on our servers can create delays while running. We maintain [a public calendar][public-calendar] for tracking these tasks.
+
+## Change Log
+
+- **v1** First release
+
+- **v2** - This release introduces support for Case Law Search Alerts results with nested documents.
+
+  You can now select the webhook version when configuring an endpoint. For most webhook event types, there are no differences between `v1` and `v2`, as the payload remains unchanged.
+
+  In the Search Alert webhook event type, the Oral Arguments search response remains identical between `v1` and `v2`.
+
+  For Case Law and RECAP `v2` now includes nested results, which are based on the new changes introduced in `v4` of the [Search API.][search-api]
+
+[free-law]: https://free.law
+[contact]: https://www.courtlistener.com/contact/
+[auth-decision]: https://github.com/freelawproject/courtlistener/issues/1650
+[webhook-logs]: https://www.courtlistener.com/profile/webhooks/logs/
+[recap-alerts]: https://www.courtlistener.com/help/alerts/#recap-alerts
+[docket-alert-api]: alert-api.md#docket-alerts
+[trump-case]: https://www.courtlistener.com/docket/64911367/trump-v-united-states/
+[recap-email]: https://www.courtlistener.com/help/recap/email/
+[recap-email-settings]: https://www.courtlistener.com/profile/recap-email/
+[docket-entry-api]: pacer-api.md#docket-entries
+[docket-entry-example]: https://www.courtlistener.com/api/rest/v4/docket-entries/20615503/
+[webhook-testing]: webhooks-getting-started.md#testing-a-webhook-endpoint
+[search-alerts]: https://www.courtlistener.com/help/alerts/#search-alerts
+[search-alert-api]: alert-api.md#search-alerts
+[obergefell]: https://www.courtlistener.com/opinion/2812209/obergefell-v-hodges/
+[search-api]: search-api.md
+[pacer-fetch]: recap-api.md#pacer-fetch
+[pray-and-pay]: https://www.courtlistener.com/help/pray-and-pay/
+[pray-and-pay-api]: recap-api.md#pray-and-pay-api
+[recap-endpoint]: pacer-api.md#documents
+[public-calendar]: https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles

--- a/wiki/pages/management/commands/import_api_docs.py
+++ b/wiki/pages/management/commands/import_api_docs.py
@@ -25,6 +25,8 @@ from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from django.urls import reverse
+from django.utils import timezone
 
 from wiki.directories.models import Directory
 from wiki.pages.models import FileUpload, Page, PageRevision
@@ -344,7 +346,11 @@ class Command(BaseCommand):
                 original_filename=filename, uploaded_by=owner
             ).first()
             if existing:
-                mapping[url] = f"/files/{existing.pk}/{filename}"
+                file_url = reverse(
+                    "file_serve",
+                    kwargs={"file_id": existing.pk, "filename": filename},
+                )
+                mapping[url] = file_url
                 self.stdout.write(f"  Image reused: {filename}")
                 continue
 
@@ -367,8 +373,12 @@ class Command(BaseCommand):
                     content_type=ct,
                 )
                 upload.file.save(filename, ContentFile(data), save=True)
-                mapping[url] = f"/files/{upload.pk}/{filename}"
-                self.stdout.write(f"  Saved: /files/{upload.pk}/{filename}")
+                file_url = reverse(
+                    "file_serve",
+                    kwargs={"file_id": upload.pk, "filename": filename},
+                )
+                mapping[url] = file_url
+                self.stdout.write(f"  Saved: {file_url}")
             except Exception as exc:
                 self.stderr.write(
                     self.style.WARNING(
@@ -454,11 +464,13 @@ class Command(BaseCommand):
 
         changed["change_message"] = "Updated by import_api_docs"
         changed["updated_by"] = owner
-        Page.objects.filter(pk=page.pk).update(**changed)
-        page.refresh_from_db()
-        page._update_search_vector()
-        page._update_page_links()
-        page.create_revision(owner, "Updated by import_api_docs")
+        changed["updated_at"] = timezone.now()
+        with transaction.atomic():
+            Page.objects.filter(pk=page.pk).update(**changed)
+            page.refresh_from_db()
+            page._update_search_vector()
+            page._update_page_links()
+            page.create_revision(owner, "Updated by import_api_docs")
         self.stdout.write(f"  Updated: {page.title}")
         return page, "updated"
 
@@ -479,15 +491,9 @@ class Command(BaseCommand):
                 if url not in body:
                     continue
                 dir_path, slug = parse_wiki_path(meta["wiki_path"])
-                page = (
-                    Page.objects.filter(
-                        directory__path=dir_path, slug=slug
-                    ).first()
-                    if dir_path
-                    else Page.objects.filter(
-                        directory__isnull=True, slug=slug
-                    ).first()
-                )
+                page = Page.objects.filter(
+                    directory__path=dir_path, slug=slug
+                ).first()
                 if page:
                     upload.page = page
                     upload.save(update_fields=["page"])

--- a/wiki/pages/management/commands/import_api_docs.py
+++ b/wiki/pages/management/commands/import_api_docs.py
@@ -1,0 +1,494 @@
+"""Import CourtListener API docs from a wiki-exports directory.
+
+Reads markdown files with YAML front matter, creates the directory tree,
+downloads images, rewrites inter-page links, and creates/updates wiki
+pages.  Idempotent — safe to run multiple times.
+
+Each export file must have a ``wiki_path`` front matter field that
+specifies the target path on the wiki (e.g., ``/c/api/rest/v4/``).
+The script derives the directory structure and page slug from this path.
+
+Usage (from docker/wiki/):
+
+    docker compose exec wiki-django python manage.py import_api_docs /path/to/wiki-exports
+    docker compose exec wiki-django python manage.py import_api_docs /path/to/wiki-exports --skip-images
+    docker compose exec wiki-django python manage.py import_api_docs /path/to/wiki-exports --dry-run
+"""
+
+import mimetypes
+import re
+import urllib.request
+from pathlib import Path
+
+import yaml
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from wiki.directories.models import Directory
+from wiki.pages.models import FileUpload, Page, PageRevision
+from wiki.users.models import SystemConfig
+
+SKIP_FILES = {"README.md", "LINK_MAP.md"}
+
+# Words that should stay uppercase when generating directory titles.
+UPPERCASE_WORDS = {"api", "rest"}
+
+# Finds all courtlistener.com/static/ URLs in markdown content.
+CL_STATIC_URL_RE = re.compile(
+    r"https://www\.courtlistener\.com/static/[^\s\)\]\"\'>]+"
+)
+
+# Fields compared when deciding whether an existing page needs updating.
+UPDATABLE_FIELDS = [
+    "title",
+    "content",
+    "seo_description",
+    "directory",
+    "is_pinned",
+    "visibility",
+    "data_source_url",
+    "data_source_ttl",
+    "in_sitemap",
+    "in_llms_txt",
+]
+
+
+# ---------------------------------------------------------------------------
+# Parsing & link rewriting
+# ---------------------------------------------------------------------------
+
+
+def parse_front_matter(text):
+    """Split YAML front matter from markdown body.
+
+    Returns (metadata_dict, body_without_frontmatter).
+    """
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    front_matter = text[3:end].strip()
+    body = text[end + 4 :].strip()
+    return yaml.safe_load(front_matter) or {}, body
+
+
+def parse_wiki_path(wiki_path):
+    """Extract (directory_path, slug) from a wiki_path like ``/c/api/rest/v4/``.
+
+    Returns e.g. ``("api/rest", "v4")``.
+    """
+    # Strip /c/ prefix and trailing slash
+    path = wiki_path.strip("/")
+    if path.startswith("c/"):
+        path = path[2:]
+    parts = path.rsplit("/", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return "", parts[0]
+
+
+def build_file_to_path_map(parsed_files):
+    """Return {filename: wiki_url_path} built from wiki_path front matter."""
+    mapping = {}
+    for filename, (meta, _) in parsed_files.items():
+        wiki_path = meta.get("wiki_path", "")
+        if wiki_path:
+            # Normalize: ensure it ends without trailing slash for links
+            mapping[filename] = wiki_path.rstrip("/") + "/"
+    return mapping
+
+
+def _rewrite_target(target, file_to_path, image_map):
+    """Rewrite a single link/image target if it matches a known file or image URL."""
+    base, _, fragment = target.partition("#")
+    anchor = f"#{fragment}" if fragment else ""
+
+    if base in file_to_path:
+        return file_to_path[base] + anchor
+    if base in image_map:
+        return image_map[base] + anchor
+    return target
+
+
+def rewrite_content_links(content, file_to_path, image_map):
+    """Rewrite inter-page file refs and CL static image URLs in markdown."""
+
+    # 1. Reference-style definitions:  [label]: target  or  [label]: url "title"
+    def _ref(m):
+        label, raw_target = m.group(1), m.group(2).strip()
+        title_m = re.match(r'^(\S+)\s+"(.*)"$', raw_target)
+        if title_m:
+            url, title = title_m.group(1), title_m.group(2)
+            return f'{label}: {_rewrite_target(url, file_to_path, image_map)} "{title}"'
+        return (
+            f"{label}: {_rewrite_target(raw_target, file_to_path, image_map)}"
+        )
+
+    content = re.sub(
+        r"^(\[[^\]]+\]):\s*(.+)$", _ref, content, flags=re.MULTILINE
+    )
+
+    # 2. Inline links:  [text](target)  and  ![alt](target)
+    def _inline(m):
+        prefix, target = m.group(1), m.group(2)
+        return f"{prefix}({_rewrite_target(target, file_to_path, image_map)})"
+
+    content = re.sub(r"(!?\[[^\]]*\])\(([^)]+)\)", _inline, content)
+
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Management command
+# ---------------------------------------------------------------------------
+
+
+class Command(BaseCommand):
+    help = "Import CourtListener API docs from a wiki-exports directory."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "source_dir",
+            help="Path to the wiki-exports directory containing .md files.",
+        )
+        parser.add_argument(
+            "--skip-images",
+            action="store_true",
+            help="Skip downloading images from CourtListener.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be done without writing to the database.",
+        )
+
+    def handle(self, *args, **options):
+        source_dir = Path(options["source_dir"])
+        if not source_dir.is_dir():
+            raise CommandError(f"Source directory not found: {source_dir}")
+
+        self.dry_run = options["dry_run"]
+        self.skip_images = options["skip_images"]
+
+        owner = self._get_owner()
+        if not owner:
+            return
+
+        # 1. Parse all export files and collect image URLs
+        parsed = {}  # filename → (metadata, body)
+        image_urls = set()
+
+        for filepath in sorted(source_dir.glob("*.md")):
+            if filepath.name in SKIP_FILES:
+                continue
+            text = filepath.read_text(encoding="utf-8")
+            meta, body = parse_front_matter(text)
+            if not meta.get("wiki_path"):
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"Skipping {filepath.name}: no wiki_path"
+                    )
+                )
+                continue
+            parsed[filepath.name] = (meta, body)
+            image_urls.update(CL_STATIC_URL_RE.findall(body))
+
+        # 2. Build file→path map and determine needed directories
+        file_to_path = build_file_to_path_map(parsed)
+        dir_paths = set()
+        for filename, (meta, _) in parsed.items():
+            dir_path, _ = parse_wiki_path(meta["wiki_path"])
+            if dir_path:
+                dir_paths.add(dir_path)
+
+        # 3. Create directory structure
+        directories = self._ensure_directories(dir_paths, owner)
+
+        # 4. Download images
+        image_map = {}
+        if not self.skip_images and image_urls:
+            image_map = self._download_images(image_urls, owner)
+
+        # 5. Create / update pages
+        created = updated = unchanged = 0
+        for filename, (meta, body) in parsed.items():
+            dir_path, slug = parse_wiki_path(meta["wiki_path"])
+            directory = directories.get(dir_path)
+            content = rewrite_content_links(body, file_to_path, image_map)
+            kwargs = self._page_kwargs(meta, content, slug, directory, owner)
+
+            if self.dry_run:
+                exists = Page.objects.filter(
+                    directory=directory, slug=slug
+                ).exists()
+                verb = "update" if exists else "create"
+                self.stdout.write(
+                    f"  Would {verb}: {kwargs['title']} → {meta['wiki_path']}"
+                )
+                continue
+
+            page, status = self._upsert_page(kwargs, owner)
+            if status == "created":
+                created += 1
+            elif status == "updated":
+                updated += 1
+            else:
+                unchanged += 1
+
+        # 6. Attach orphaned images to pages
+        if not self.dry_run and image_map:
+            self._attach_images(image_map, parsed)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done: {created} created, {updated} updated, "
+                f"{unchanged} unchanged."
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_owner(self):
+        """Return the system owner, first superuser, or first user."""
+        config = SystemConfig.objects.first()
+        if config:
+            return config.owner
+        user = User.objects.filter(is_superuser=True).first()
+        if user:
+            return user
+        user = User.objects.first()
+        if user:
+            return user
+        self.stderr.write(self.style.ERROR("No users — cannot import."))
+        return None
+
+    def _ensure_directories(self, dir_paths, owner):
+        """Create all directories needed by the imported pages.
+
+        Accepts a set of directory paths (e.g. ``{"api/rest", "api/rest/v3",
+        "api/webhooks"}``).  Creates each path and all its ancestors.
+
+        Returns ``{path_str: Directory}`` including the wiki root (``""``).
+        """
+        root, _ = Directory.objects.get_or_create(
+            path="",
+            defaults={
+                "title": "Home",
+                "owner": owner,
+                "created_by": owner,
+            },
+        )
+        dirs = {"": root}
+
+        # Expand to include all ancestor paths
+        all_paths = set()
+        for dp in dir_paths:
+            parts = dp.split("/")
+            for i in range(len(parts)):
+                all_paths.add("/".join(parts[: i + 1]))
+
+        for dir_path in sorted(all_paths):
+            if self.dry_run:
+                self.stdout.write(f"  Would ensure dir: /{dir_path}/")
+                dirs[dir_path] = None
+                continue
+
+            parts = dir_path.split("/")
+            parent_path = "/".join(parts[:-1])
+            parent = dirs[parent_path]
+            words = parts[-1].replace("-", " ").split()
+            title = " ".join(
+                w.upper() if w.lower() in UPPERCASE_WORDS else w.title()
+                for w in words
+            )
+
+            d, was_created = Directory.objects.get_or_create(
+                path=dir_path,
+                defaults={
+                    "title": title,
+                    "parent": parent,
+                    "owner": owner,
+                    "created_by": owner,
+                    "visibility": Directory.Visibility.INHERIT,
+                    "editability": Directory.Editability.INHERIT,
+                    "in_sitemap": Directory.SitemapStatus.INHERIT,
+                    "in_llms_txt": Directory.LlmsTxtStatus.INHERIT,
+                },
+            )
+            if not was_created and d.title != title:
+                d.title = title
+                d.save(update_fields=["title"])
+                self.stdout.write(f"  Renamed dir: /{dir_path}/ → {title}")
+            dirs[dir_path] = d
+            if was_created:
+                self.stdout.write(f"  Created dir: /{dir_path}/")
+
+        return dirs
+
+    def _download_images(self, image_urls, owner):
+        """Download CL static images, create FileUpload records.
+
+        Returns ``{original_url: /files/<id>/<filename>}``.
+        """
+        mapping = {}
+        for url in sorted(image_urls):
+            filename = url.rsplit("/", 1)[-1]
+
+            # Re-use if already downloaded in a previous run
+            existing = FileUpload.objects.filter(
+                original_filename=filename, uploaded_by=owner
+            ).first()
+            if existing:
+                mapping[url] = f"/files/{existing.pk}/{filename}"
+                self.stdout.write(f"  Image reused: {filename}")
+                continue
+
+            if self.dry_run:
+                mapping[url] = f"/files/TBD/{filename}"
+                self.stdout.write(f"  Would download: {filename}")
+                continue
+
+            try:
+                self.stdout.write(f"  Downloading: {filename} ...")
+                req = urllib.request.Request(
+                    url, headers={"User-Agent": "FLP-Wiki-Import/1.0"}
+                )
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    data = resp.read()
+                ct = mimetypes.guess_type(filename)[0] or "image/png"
+                upload = FileUpload(
+                    uploaded_by=owner,
+                    original_filename=filename,
+                    content_type=ct,
+                )
+                upload.file.save(filename, ContentFile(data), save=True)
+                mapping[url] = f"/files/{upload.pk}/{filename}"
+                self.stdout.write(f"  Saved: /files/{upload.pk}/{filename}")
+            except Exception as exc:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  Download failed ({filename}): {exc}"
+                    )
+                )
+        return mapping
+
+    def _page_kwargs(self, meta, content, slug, directory, owner):
+        """Build a dict of Page field values from front matter + content."""
+        kw = {
+            "title": meta.get("title", slug),
+            "slug": slug,
+            "content": content,
+            "directory": directory,
+            "owner": owner,
+            "visibility": Page.Visibility.INHERIT,
+            "editability": Page.Editability.INHERIT,
+            "in_sitemap": Page.SitemapStatus.INHERIT,
+            "in_llms_txt": Page.LlmsTxtStatus.INHERIT,
+            "is_pinned": False,
+            "created_by": owner,
+            "updated_by": owner,
+        }
+        if meta.get("description"):
+            kw["seo_description"] = meta["description"][:300]
+        if meta.get("data_source"):
+            kw["data_source_url"] = meta["data_source"]
+        if meta.get("data_source_cache"):
+            kw["data_source_ttl"] = int(meta["data_source_cache"])
+        if meta.get("search_engines") is False:
+            kw["in_sitemap"] = Page.SitemapStatus.EXCLUDE
+        if meta.get("ai_assistants") is False:
+            kw["in_llms_txt"] = Page.LlmsTxtStatus.EXCLUDE
+        return kw
+
+    def _upsert_page(self, kwargs, owner):
+        """Create or update a page.
+
+        Returns ``(page, status)`` where status is
+        ``"created"``, ``"updated"``, or ``"unchanged"``.
+        """
+        slug = kwargs["slug"]
+        directory = kwargs.get("directory")
+        existing = Page.objects.filter(directory=directory, slug=slug).first()
+
+        if existing:
+            return self._update_page(existing, kwargs, owner)
+
+        # --- create -------------------------------------------------------
+        with transaction.atomic():
+            page = Page(**kwargs)
+            page.change_message = "Imported from CourtListener"
+            page.save()
+            PageRevision.objects.create(
+                page=page,
+                title=page.title,
+                content=page.content,
+                change_message="Imported from CourtListener",
+                revision_number=1,
+                created_by=owner,
+            )
+        self.stdout.write(f"  Created: {page.title}")
+        return page, "created"
+
+    def _update_page(self, page, kwargs, owner):
+        """Update an existing page if any tracked field differs.
+
+        Uses ``QuerySet.update()`` to bypass ``Page.save()``'s slug
+        regeneration logic, then manually refreshes the search vector
+        and page-link graph.
+        """
+        changed = {}
+        for field in UPDATABLE_FIELDS:
+            if field not in kwargs:
+                continue
+            if getattr(page, field) != kwargs[field]:
+                changed[field] = kwargs[field]
+
+        if not changed:
+            self.stdout.write(f"  Unchanged: {page.title}")
+            return page, "unchanged"
+
+        changed["change_message"] = "Updated by import_api_docs"
+        changed["updated_by"] = owner
+        Page.objects.filter(pk=page.pk).update(**changed)
+        page.refresh_from_db()
+        page._update_search_vector()
+        page._update_page_links()
+        page.create_revision(owner, "Updated by import_api_docs")
+        self.stdout.write(f"  Updated: {page.title}")
+        return page, "updated"
+
+    def _attach_images(self, image_map, parsed_files):
+        """Attach orphaned FileUpload records to the first page that uses them."""
+        for url, wiki_path in image_map.items():
+            m = re.match(r"/files/(\d+)/", wiki_path)
+            if not m:
+                continue
+            file_id = int(m.group(1))
+            upload = FileUpload.objects.filter(
+                pk=file_id, page__isnull=True
+            ).first()
+            if not upload:
+                continue  # already attached
+
+            for filename, (meta, body) in parsed_files.items():
+                if url not in body:
+                    continue
+                dir_path, slug = parse_wiki_path(meta["wiki_path"])
+                page = (
+                    Page.objects.filter(
+                        directory__path=dir_path, slug=slug
+                    ).first()
+                    if dir_path
+                    else Page.objects.filter(
+                        directory__isnull=True, slug=slug
+                    ).first()
+                )
+                if page:
+                    upload.page = page
+                    upload.save(update_fields=["page"])
+                    break


### PR DESCRIPTION
## Fixes

Part of https://github.com/freelawproject/courtlistener/issues/7130

## Summary

Adds a management command `import_api_docs` and the 22 markdown export files from CourtListener's `/help/api/*` pages.

The command:
- Reads markdown files with YAML front matter from the `wiki-exports/` directory
- Derives directory structure and page slugs from the `wiki_path` front matter field
- Creates the directory tree with inherited permissions
- Downloads images from `courtlistener.com/static/` and creates `FileUpload` records
- Rewrites inter-page links (`filename.md` → wiki paths from `wiki_path` front matter)
- Rewrites image URLs to wiki `/files/<id>/filename` paths
- Maps front matter fields to page settings: `description` → `seo_description`, `data_source`/`data_source_cache` → data source config, `search_engines`/`ai_assistants` → sitemap/llms.txt exclusions
- Idempotent — safe to run multiple times; detects unchanged pages

Usage: `docker compose exec wiki-django python manage.py import_api_docs wiki-exports/ --skip-images`

Flags: `--skip-images`, `--dry-run`

## Deployment

**This PR should:**

1. After deploy, run the import command: `python manage.py import_api_docs wiki-exports/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)