### PR TITLE
Add wiki-exports to .dockerignore allowlist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !manage.py
 !package.json
 !package-lock.json
+!wiki-exports
 
 # But no matter what, ignore these things.
 wiki/assets/media


### PR DESCRIPTION
## Fixes

Fixes the missing `wiki-exports/` directory in the production Docker image (follow-up to #95).

## Summary

The `.dockerignore` uses a deny-all `*` pattern with specific allowlist entries. The `wiki-exports/` directory wasn't on the allowlist, so the CourtListener API doc export files weren't included in the production image. The import command couldn't find them.

## Deployment

**This PR should:**

1. After deploy, run the import: `python manage.py import_api_docs wiki-exports/ --skip-images`

🤖 Generated with [Claude Code](https://claude.com/claude-code)