### PR TITLE
Format external data source numbers with commas

### DIFF
--- a/wiki/lib/data_source.py
+++ b/wiki/lib/data_source.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from django.conf import settings
+from django.contrib.humanize.templatetags.humanize import intcomma
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,20 @@ def _do_fetch(url):
     return json.loads(body)
 
 
+def _format_value(value):
+    """Render a JSON value as a string for placeholder substitution.
+
+    Numbers are formatted with comma thousands separators (1000 → "1,000")
+    so big counts pulled from external APIs read nicely. Booleans are kept
+    as plain str() output even though bool subclasses int.
+    """
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (int, float)):
+        return intcomma(value, use_l10n=False)
+    return str(value)
+
+
 def substitute_data_variables(content, data):
     """Replace ``[[ key ]]`` placeholders with values from *data*.
 
@@ -138,7 +153,7 @@ def substitute_data_variables(content, data):
                 return match.group(0)  # leave as-is
         if value is None:
             return match.group(0)
-        return str(value)
+        return _format_value(value)
 
     content = DATA_VAR_RE.sub(_replace, content)
 

--- a/wiki/lib/tests_data_source.py
+++ b/wiki/lib/tests_data_source.py
@@ -74,6 +74,36 @@ class TestSubstituteDataVariables:
         data = {"num": 7}
         assert substitute_data_variables(content, data) == "7"
 
+    def test_integer_value_formatted_with_commas(self):
+        content = "[[ num ]]"
+        data = {"num": 1000}
+        assert substitute_data_variables(content, data) == "1,000"
+
+    def test_large_integer_value_formatted_with_commas(self):
+        content = "[[ num ]]"
+        data = {"num": 1234567}
+        assert substitute_data_variables(content, data) == "1,234,567"
+
+    def test_negative_integer_formatted_with_commas(self):
+        content = "[[ num ]]"
+        data = {"num": -1234567}
+        assert substitute_data_variables(content, data) == "-1,234,567"
+
+    def test_float_value_formatted_with_commas(self):
+        content = "[[ num ]]"
+        data = {"num": 1234.5}
+        assert substitute_data_variables(content, data) == "1,234.5"
+
+    def test_boolean_value_not_formatted(self):
+        content = "[[ flag ]]"
+        data = {"flag": True}
+        assert substitute_data_variables(content, data) == "True"
+
+    def test_string_digits_not_formatted(self):
+        content = "[[ num ]]"
+        data = {"num": "1000"}
+        assert substitute_data_variables(content, data) == "1000"
+
     def test_multiple_placeholders(self):
         content = "[[ a ]] and [[ b ]]"
         data = {"a": "1", "b": "2"}


### PR DESCRIPTION
## Fixes
Fixes: #98

## Summary
Numbers from imported JSON data sources were being rendered via `str()`, so big counts like `court_count` came out as `1234567` instead of `1,234,567`.

This PR applies Django's `intcomma` to numeric values in `substitute_data_variables`:
- `int` and `float` values are formatted with comma thousands separators (`1000` → `"1,000"`, `1234.5` → `"1,234.5"`).
- `bool` (which subclasses `int`) is kept as plain `str()` output (`True` stays `"True"`).
- Strings, including digit-only strings, are left untouched — the issue scopes the change to JSON integers, and JSON distinguishes ints from strings.
- `use_l10n=False` is passed to `intcomma` since the issue says we don't need internationalization.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

The data source rendering happens at request time off cached JSON; no migrations or special steps.