### PR TITLE
Disable Gunicorn control socket to prevent permission errors

### DIFF
--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -18,6 +18,7 @@ case "$1" in
         --group www-data \
         --workers ${NUM_WORKERS:-4} \
         --worker-class wiki.workers.UvicornWorker \
+        --no-control-socket \
         --timeout 180 \
         --max-requests ${MAX_REQUESTS:-2500} \
         --max-requests-jitter 100 \


### PR DESCRIPTION
## Fixes
N/A — mirrors the fix from freelawproject/scanning#48 for the same Gunicorn 25 issue.

## Summary
Adds `--no-control-socket` to the Gunicorn production command to disable the control socket feature introduced in Gunicorn 25.

Gunicorn 25 enables a control socket by default, writing to `$XDG_RUNTIME_DIR/gunicorn.ctl` or `$HOME/.gunicorn/gunicorn.ctl`. In our pods, `\$HOME` resolves to `/var/www`, which the `www-data` user cannot write to, producing repeated arbiter errors:

```
Control server error: [Errno 13] Permission denied: '/var/www'
```

Since we don't use `gunicornctl` for runtime worker management, disabling the socket is the right fix.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No special deployment steps required — the change takes effect on next web tier rollout.