### PR TITLE
Add CloudFront CDN caching, invalidations, and deploy hook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,11 +164,14 @@ jobs:
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon
 
   invalidate-cdn:
-    needs: [deploy-web, deploy-daemon]
+    needs: [deploy-web]
     runs-on: ubuntu-latest
-    # Only invalidate if both deploys succeeded — invalidating after a
-    # failed deploy would push stale-but-rolled-back HTML into more caches.
-    if: ${{ needs.deploy-web.result == 'success' && needs.deploy-daemon.result == 'success' }}
+    # Only invalidate if the web tier deployed successfully — invalidating
+    # after a failed deploy would push stale-but-rolled-back HTML into
+    # more caches. The daemon doesn't affect what gets served to viewers,
+    # so we don't gate on it (and `skip-daemon-deploy` is a real workflow
+    # input we'd otherwise ignore).
+    if: ${{ needs.deploy-web.result == 'success' }}
     steps:
       - name: Skip if distribution ID is unset
         id: check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,47 @@ jobs:
       - name: Watch wiki-daemon rollout status
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/wiki-daemon
 
+  invalidate-cdn:
+    needs: [deploy-web, deploy-daemon]
+    runs-on: ubuntu-latest
+    # Only invalidate if both deploys succeeded — invalidating after a
+    # failed deploy would push stale-but-rolled-back HTML into more caches.
+    if: ${{ needs.deploy-web.result == 'success' && needs.deploy-daemon.result == 'success' }}
+    steps:
+      - name: Skip if distribution ID is unset
+        id: check
+        run: |
+          if [ -z "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "CLOUDFRONT_DISTRIBUTION_ID secret is unset — skipping invalidation."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.check.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Invalidate CloudFront cache
+        if: steps.check.outputs.configured == 'true'
+        # Failure here is non-fatal — the deploy already happened. The CDN
+        # entries will TTL out on their own (and the next edit invalidates
+        # them properly via post_save signals).
+        continue-on-error: true
+        # Distribution ID is interpolated via env var rather than directly
+        # into the shell to avoid command injection if the secret ever
+        # contains shell metacharacters.
+        env:
+          DIST_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "$DIST_ID" \
+            --paths "/*"
+
   complete-deploy:
     needs:
       [

--- a/wiki/assets/static-global/js/view-tally.js
+++ b/wiki/assets/static-global/js/view-tally.js
@@ -1,0 +1,42 @@
+/**
+ * Records a page-view tally on load and refreshes the displayed count.
+ *
+ * The page itself is served by a CDN with a long TTL, so the count
+ * rendered into the HTML can be very stale. This script:
+ *   1. POSTs to /api/page-view/ with the page id (CSRF-exempt endpoint).
+ *   2. Replaces the rendered count with the value returned by the server.
+ *
+ * Reads config from <script type="application/json" id="view-tally-config">:
+ *   { pageId: <int>, url: "<endpoint>" }
+ * Updates the element with id="page-view-count" if present.
+ */
+(function () {
+  var configEl = document.getElementById('view-tally-config');
+  if (!configEl) return;
+
+  var config;
+  try {
+    config = JSON.parse(configEl.textContent);
+  } catch (e) {
+    return;
+  }
+  if (!config.pageId || !config.url) return;
+
+  fetch(config.url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ page_id: config.pageId }),
+    credentials: 'same-origin',
+    keepalive: true,
+  })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      if (!data || typeof data.count !== 'number') return;
+      var el = document.getElementById('page-view-count');
+      if (!el) return;
+      var formatted = data.count.toLocaleString();
+      var label = data.count === 1 ? 'view' : 'views';
+      el.textContent = formatted + ' ' + label;
+    })
+    .catch(function () { /* network errors are not actionable here */ });
+})();

--- a/wiki/assets/templates/base.html
+++ b/wiki/assets/templates/base.html
@@ -24,7 +24,7 @@
   {% block head %}{% endblock %}
 </head>
 
-<body class="min-h-screen flex flex-col" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+<body class="min-h-screen flex flex-col"{% if user.is_authenticated %} hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'{% endif %}>
   {% block header %}<c-header />{% endblock %}
 
   {% block messages %}

--- a/wiki/directories/apps.py
+++ b/wiki/directories/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DirectoriesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "wiki.directories"
+
+    def ready(self):
+        from wiki.directories import signals  # noqa: F401

--- a/wiki/directories/signals.py
+++ b/wiki/directories/signals.py
@@ -1,0 +1,94 @@
+"""CDN cache invalidation when directories change.
+
+Saving a directory invalidates its own listing URL. A rename also
+invalidates ``/c/<old>/*`` and ``/c/<new>/*`` wildcards so every
+descendant page URL gets re-fetched (a parent rename changes every
+child's URL even though the child rows aren't re-saved).
+
+Invalidations fire via ``transaction.on_commit`` so rolled-back saves
+don't burn CloudFront invalidation paths.
+"""
+
+from django.db import transaction
+from django.db.models.signals import post_save, pre_save
+from django.dispatch import receiver
+
+from wiki.lib.cloudfront import invalidate_paths
+
+from .models import Directory
+
+
+def _listing_paths(path):
+    """Return the URL(s) of a directory listing.
+
+    Django routes both ``/c/foo`` and ``/c/foo/`` to the directory view,
+    and both forms are cacheable. Invalidate both.
+    """
+    if path:
+        return [f"/c/{path}", f"/c/{path}/"]
+    return ["/"]
+
+
+def _wildcard_paths(path):
+    """Return wildcard(s) covering every descendant URL under a directory.
+
+    ``/c/foo/*`` matches ``/c/foo/x`` and ``/c/foo/`` but NOT ``/c/foo``
+    itself, so we emit the directory's own URL alongside the wildcard.
+    """
+    if path:
+        return [f"/c/{path}", f"/c/{path}/*"]
+    return ["/*"]
+
+
+@receiver(pre_save, sender=Directory)
+def capture_old_state(sender, instance, **kwargs):
+    if not instance.pk:
+        instance._old_path = None
+        instance._old_parent_id = None
+        return
+    old = (
+        Directory.objects.filter(pk=instance.pk)
+        .values("path", "parent_id")
+        .first()
+    )
+    if old is None:
+        instance._old_path = None
+        instance._old_parent_id = None
+        return
+    instance._old_path = old["path"]
+    instance._old_parent_id = old["parent_id"]
+
+
+@receiver(post_save, sender=Directory)
+def invalidate_on_directory_save(sender, instance, **kwargs):
+    paths = set(_listing_paths(instance.path))
+
+    # Parent listing also needs to drop — child counts may have changed.
+    parent_path = _parent_path_lookup(instance.parent_id)
+    paths.update(_listing_paths(parent_path))
+
+    old_path = getattr(instance, "_old_path", None)
+    if old_path is not None and old_path != instance.path:
+        # Rename — every descendant URL changed, blow them all away.
+        paths.update(_wildcard_paths(old_path))
+        paths.update(_wildcard_paths(instance.path))
+
+    old_parent_id = getattr(instance, "_old_parent_id", None)
+    if old_parent_id is not None and old_parent_id != instance.parent_id:
+        # Move — old parent listed this directory as a child.
+        old_parent_path = _parent_path_lookup(old_parent_id)
+        paths.update(_listing_paths(old_parent_path))
+
+    transaction.on_commit(lambda: invalidate_paths(paths))
+
+
+def _parent_path_lookup(parent_id):
+    """Return the path of the directory with the given id, or "" for root/None."""
+    if parent_id is None:
+        return ""
+    return (
+        Directory.objects.filter(pk=parent_id)
+        .values_list("path", flat=True)
+        .first()
+        or ""
+    )

--- a/wiki/directories/signals.py
+++ b/wiki/directories/signals.py
@@ -15,6 +15,7 @@ don't burn CloudFront invalidation paths.
 from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+from django.urls import reverse
 
 from wiki.lib.cloudfront import invalidate_paths
 
@@ -28,8 +29,21 @@ def _listing_paths(path):
     and both forms are cacheable. Invalidate both.
     """
     if path:
-        return [f"/c/{path}", f"/c/{path}/"]
-    return ["/"]
+        base = reverse("resolve_path", kwargs={"path": path})
+        return [base, f"{base}/"]
+    return [reverse("root")]
+
+
+def _parent_path_lookup(parent_id):
+    """Return the path of the directory with the given id, or "" for root/None."""
+    if parent_id is None:
+        return ""
+    return (
+        Directory.objects.filter(pk=parent_id)
+        .values_list("path", flat=True)
+        .first()
+        or ""
+    )
 
 
 def _wildcard_paths(path):
@@ -39,8 +53,9 @@ def _wildcard_paths(path):
     itself, so we emit the directory's own URL alongside the wildcard.
     """
     if path:
-        return [f"/c/{path}", f"/c/{path}/*"]
-    return ["/*"]
+        base = reverse("resolve_path", kwargs={"path": path})
+        return [base, f"{base}/*"]
+    return [f"{reverse('root')}*"]
 
 
 @receiver(pre_save, sender=Directory)
@@ -86,15 +101,3 @@ def invalidate_on_directory_save(sender, instance, **kwargs):
         paths.update(_listing_paths(old_parent_path))
 
     transaction.on_commit(lambda: invalidate_paths(paths))
-
-
-def _parent_path_lookup(parent_id):
-    """Return the path of the directory with the given id, or "" for root/None."""
-    if parent_id is None:
-        return ""
-    return (
-        Directory.objects.filter(pk=parent_id)
-        .values_list("path", flat=True)
-        .first()
-        or ""
-    )

--- a/wiki/directories/signals.py
+++ b/wiki/directories/signals.py
@@ -1,9 +1,12 @@
 """CDN cache invalidation when directories change.
 
-Saving a directory invalidates its own listing URL. A rename also
-invalidates ``/c/<old>/*`` and ``/c/<new>/*`` wildcards so every
-descendant page URL gets re-fetched (a parent rename changes every
-child's URL even though the child rows aren't re-saved).
+Saving a directory invalidates its own listing URL and the descendant
+wildcard ``/c/<path>/*`` unconditionally. The wildcard always fires
+because directory-level fields (e.g. ``visibility``) cascade to
+descendant pages with ``visibility='inherit'`` — those page rows aren't
+re-saved when the directory changes, so ``Page.post_save`` won't drop
+their cached HTML. A rename additionally invalidates ``/c/<old>/*`` so
+descendants at the previous path drop too.
 
 Invalidations fire via ``transaction.on_commit`` so rolled-back saves
 don't burn CloudFront invalidation paths.
@@ -63,15 +66,18 @@ def capture_old_state(sender, instance, **kwargs):
 def invalidate_on_directory_save(sender, instance, **kwargs):
     paths = set(_listing_paths(instance.path))
 
+    # Descendant wildcard always fires — directory-level fields like
+    # `visibility` cascade to inheriting pages whose rows aren't re-saved.
+    paths.update(_wildcard_paths(instance.path))
+
     # Parent listing also needs to drop — child counts may have changed.
     parent_path = _parent_path_lookup(instance.parent_id)
     paths.update(_listing_paths(parent_path))
 
     old_path = getattr(instance, "_old_path", None)
     if old_path is not None and old_path != instance.path:
-        # Rename — every descendant URL changed, blow them all away.
+        # Rename — descendants at the OLD path also need to drop.
         paths.update(_wildcard_paths(old_path))
-        paths.update(_wildcard_paths(instance.path))
 
     old_parent_id = getattr(instance, "_old_parent_id", None)
     if old_parent_id is not None and old_parent_id != instance.parent_id:

--- a/wiki/directories/tests_cdn.py
+++ b/wiki/directories/tests_cdn.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
+from wiki.directories.models import Directory
+
 
 @pytest.fixture
 def mock_invalidate():
@@ -15,8 +17,6 @@ def mock_invalidate():
 def test_create_directory_invalidates_listing(
     mock_invalidate, user, root_directory
 ):
-    from wiki.directories.models import Directory
-
     d = Directory.objects.create(
         path="ops",
         title="Ops",
@@ -58,8 +58,6 @@ def test_directory_move_invalidates_old_parent(
 ):
     """Moving a directory must drop the old parent's listing too — its
     child count just changed."""
-    from wiki.directories.models import Directory
-
     # Create a new parent and move sub_directory under it.
     new_parent = Directory.objects.create(
         path="orgs", title="Orgs", parent=root_directory
@@ -78,13 +76,39 @@ def test_directory_move_invalidates_old_parent(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_no_op_directory_save_skips_wildcards(mock_invalidate, sub_directory):
-    """Saving without a path change should not include wildcards."""
+def test_directory_save_always_invalidates_wildcard(
+    mock_invalidate, sub_directory
+):
+    """Every directory save fires the descendant wildcard.
+
+    Directory-level fields (e.g. ``visibility``) cascade to inheriting
+    pages whose rows aren't re-saved, so we must always drop their
+    cached HTML.
+    """
     mock_invalidate.reset_mock()
     sub_directory.description = "Updated."
     sub_directory.save()
     paths = mock_invalidate.call_args.args[0]
-    assert not any("*" in p for p in paths)
+    assert "/c/engineering/*" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_visibility_flip_invalidates_descendant_wildcard(
+    mock_invalidate, sub_directory
+):
+    """Flipping visibility public -> private must drop descendant
+    pages from the CDN, even though their rows aren't re-saved.
+
+    Regression test for the privacy leak where inheriting pages stayed
+    cached at the edge for up to 30 days after a directory was made
+    private.
+    """
+    assert sub_directory.visibility == Directory.Visibility.PUBLIC
+    mock_invalidate.reset_mock()
+    sub_directory.visibility = Directory.Visibility.PRIVATE
+    sub_directory.save()
+    paths = mock_invalidate.call_args.args[0]
+    assert "/c/engineering/*" in paths
 
 
 @pytest.mark.django_db(transaction=True)

--- a/wiki/directories/tests_cdn.py
+++ b/wiki/directories/tests_cdn.py
@@ -78,9 +78,7 @@ def test_directory_move_invalidates_old_parent(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_no_op_directory_save_skips_wildcards(
-    mock_invalidate, sub_directory
-):
+def test_no_op_directory_save_skips_wildcards(mock_invalidate, sub_directory):
     """Saving without a path change should not include wildcards."""
     mock_invalidate.reset_mock()
     sub_directory.description = "Updated."
@@ -90,9 +88,7 @@ def test_no_op_directory_save_skips_wildcards(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_root_directory_save_invalidates_root(
-    mock_invalidate, root_directory
-):
+def test_root_directory_save_invalidates_root(mock_invalidate, root_directory):
     root_directory.description = "Welcome."
     root_directory.save()
     paths = mock_invalidate.call_args.args[0]

--- a/wiki/directories/tests_cdn.py
+++ b/wiki/directories/tests_cdn.py
@@ -1,0 +1,99 @@
+"""Tests for CDN invalidation when directories change."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_invalidate():
+    with patch("wiki.directories.signals.invalidate_paths") as m:
+        yield m
+
+
+@pytest.mark.django_db(transaction=True)
+def test_create_directory_invalidates_listing(
+    mock_invalidate, user, root_directory
+):
+    from wiki.directories.models import Directory
+
+    d = Directory.objects.create(
+        path="ops",
+        title="Ops",
+        parent=root_directory,
+        owner=user,
+        created_by=user,
+    )
+    paths = mock_invalidate.call_args.args[0]
+    # Both slash-forms of the new directory listing.
+    assert "/c/ops" in paths
+    assert "/c/ops/" in paths
+    # Parent (root) listing.
+    assert "/" in paths
+    assert d.path == "ops"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_directory_rename_invalidates_wildcards_and_self(
+    mock_invalidate, sub_directory
+):
+    """A rename changes every descendant URL.
+
+    The wildcard catches descendants but NOT the directory's own URL
+    (per AWS docs: ``/c/foo/*`` matches ``/c/foo/x`` but not ``/c/foo``).
+    Both forms must be in the invalidation set.
+    """
+    sub_directory.path = "platform"
+    sub_directory.save()
+    paths = mock_invalidate.call_args.args[0]
+    assert "/c/engineering/*" in paths
+    assert "/c/engineering" in paths
+    assert "/c/platform/*" in paths
+    assert "/c/platform" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_directory_move_invalidates_old_parent(
+    mock_invalidate, sub_directory, root_directory
+):
+    """Moving a directory must drop the old parent's listing too — its
+    child count just changed."""
+    from wiki.directories.models import Directory
+
+    # Create a new parent and move sub_directory under it.
+    new_parent = Directory.objects.create(
+        path="orgs", title="Orgs", parent=root_directory
+    )
+    mock_invalidate.reset_mock()
+
+    sub_directory.parent = new_parent
+    sub_directory.path = "orgs/engineering"
+    sub_directory.save()
+
+    paths = mock_invalidate.call_args.args[0]
+    # New parent listing.
+    assert "/c/orgs/" in paths
+    # OLD parent listing — root, in this case.
+    assert "/" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_op_directory_save_skips_wildcards(
+    mock_invalidate, sub_directory
+):
+    """Saving without a path change should not include wildcards."""
+    mock_invalidate.reset_mock()
+    sub_directory.description = "Updated."
+    sub_directory.save()
+    paths = mock_invalidate.call_args.args[0]
+    assert not any("*" in p for p in paths)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_root_directory_save_invalidates_root(
+    mock_invalidate, root_directory
+):
+    root_directory.description = "Welcome."
+    root_directory.save()
+    paths = mock_invalidate.call_args.args[0]
+    assert "/" in paths

--- a/wiki/directories/tests_cdn.py
+++ b/wiki/directories/tests_cdn.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.urls import reverse
 
 from wiki.directories.models import Directory
 
@@ -26,10 +27,10 @@ def test_create_directory_invalidates_listing(
     )
     paths = mock_invalidate.call_args.args[0]
     # Both slash-forms of the new directory listing.
-    assert "/c/ops" in paths
-    assert "/c/ops/" in paths
+    assert d.get_absolute_url() in paths
+    assert f"{d.get_absolute_url()}/" in paths
     # Parent (root) listing.
-    assert "/" in paths
+    assert root_directory.get_absolute_url() in paths
     assert d.path == "ops"
 
 
@@ -43,13 +44,14 @@ def test_directory_rename_invalidates_wildcards_and_self(
     (per AWS docs: ``/c/foo/*`` matches ``/c/foo/x`` but not ``/c/foo``).
     Both forms must be in the invalidation set.
     """
+    old_url = sub_directory.get_absolute_url()
     sub_directory.path = "platform"
     sub_directory.save()
     paths = mock_invalidate.call_args.args[0]
-    assert "/c/engineering/*" in paths
-    assert "/c/engineering" in paths
-    assert "/c/platform/*" in paths
-    assert "/c/platform" in paths
+    assert f"{old_url}/*" in paths
+    assert old_url in paths
+    assert f"{sub_directory.get_absolute_url()}/*" in paths
+    assert sub_directory.get_absolute_url() in paths
 
 
 @pytest.mark.django_db(transaction=True)
@@ -70,9 +72,9 @@ def test_directory_move_invalidates_old_parent(
 
     paths = mock_invalidate.call_args.args[0]
     # New parent listing.
-    assert "/c/orgs/" in paths
+    assert f"{new_parent.get_absolute_url()}/" in paths
     # OLD parent listing — root, in this case.
-    assert "/" in paths
+    assert root_directory.get_absolute_url() in paths
 
 
 @pytest.mark.django_db(transaction=True)
@@ -89,7 +91,7 @@ def test_directory_save_always_invalidates_wildcard(
     sub_directory.description = "Updated."
     sub_directory.save()
     paths = mock_invalidate.call_args.args[0]
-    assert "/c/engineering/*" in paths
+    assert f"{sub_directory.get_absolute_url()}/*" in paths
 
 
 @pytest.mark.django_db(transaction=True)
@@ -108,7 +110,7 @@ def test_visibility_flip_invalidates_descendant_wildcard(
     sub_directory.visibility = Directory.Visibility.PRIVATE
     sub_directory.save()
     paths = mock_invalidate.call_args.args[0]
-    assert "/c/engineering/*" in paths
+    assert f"{sub_directory.get_absolute_url()}/*" in paths
 
 
 @pytest.mark.django_db(transaction=True)
@@ -116,4 +118,4 @@ def test_root_directory_save_invalidates_root(mock_invalidate, root_directory):
     root_directory.description = "Welcome."
     root_directory.save()
     paths = mock_invalidate.call_args.args[0]
-    assert "/" in paths
+    assert reverse("root") in paths

--- a/wiki/directories/views.py
+++ b/wiki/directories/views.py
@@ -955,14 +955,12 @@ def _directory_history_inner(request, directory):
     )
 
 
-@cache_for_anonymous
 def directory_history(request, path):
     """Show revision history for a directory."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_history_inner(request, directory)
 
 
-@cache_for_anonymous
 def directory_history_root(request):
     """Show revision history for the root directory."""
     root = get_object_or_404(Directory, path="")
@@ -1027,14 +1025,12 @@ def _directory_diff_inner(request, directory, v1, v2):
     )
 
 
-@cache_for_anonymous
 def directory_diff(request, path, v1, v2):
     """Show diff between two directory revisions."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_diff_inner(request, directory, v1, v2)
 
 
-@cache_for_anonymous
 def directory_diff_root(request, v1, v2):
     """Show diff between two root directory revisions."""
     root = get_object_or_404(Directory, path="")

--- a/wiki/directories/views.py
+++ b/wiki/directories/views.py
@@ -8,6 +8,7 @@ from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.text import slugify
+from django.views.decorators.cache import never_cache
 
 from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.edit_lock import (
@@ -955,12 +956,14 @@ def _directory_history_inner(request, directory):
     )
 
 
+@never_cache
 def directory_history(request, path):
     """Show revision history for a directory."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_history_inner(request, directory)
 
 
+@never_cache
 def directory_history_root(request):
     """Show revision history for the root directory."""
     root = get_object_or_404(Directory, path="")
@@ -1025,12 +1028,14 @@ def _directory_diff_inner(request, directory, v1, v2):
     )
 
 
+@never_cache
 def directory_diff(request, path, v1, v2):
     """Show diff between two directory revisions."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_diff_inner(request, directory, v1, v2)
 
 
+@never_cache
 def directory_diff_root(request, v1, v2):
     """Show diff between two root directory revisions."""
     root = get_object_or_404(Directory, path="")

--- a/wiki/directories/views.py
+++ b/wiki/directories/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.text import slugify
 
+from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.edit_lock import (
     acquire_lock_for_directory,
     get_active_lock_for_directory,
@@ -104,6 +105,7 @@ def _sort_directories(dirs, sort):
     return sorted(dirs, key=lambda d: d.title.lower())
 
 
+@cache_for_anonymous
 def root_view(request):
     """Root directory view — shows top-level directories and pages."""
     root, _ = Directory.objects.get_or_create(
@@ -237,6 +239,7 @@ def directory_edit_root(request):
     )
 
 
+@cache_for_anonymous
 def directory_detail(request, path):
     """Display a directory's contents."""
     directory = Directory.objects.filter(path=path.strip("/")).first()
@@ -952,12 +955,14 @@ def _directory_history_inner(request, directory):
     )
 
 
+@cache_for_anonymous
 def directory_history(request, path):
     """Show revision history for a directory."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_history_inner(request, directory)
 
 
+@cache_for_anonymous
 def directory_history_root(request):
     """Show revision history for the root directory."""
     root = get_object_or_404(Directory, path="")
@@ -1022,12 +1027,14 @@ def _directory_diff_inner(request, directory, v1, v2):
     )
 
 
+@cache_for_anonymous
 def directory_diff(request, path, v1, v2):
     """Show diff between two directory revisions."""
     directory = get_object_or_404(Directory, path=path.strip("/"))
     return _directory_diff_inner(request, directory, v1, v2)
 
 
+@cache_for_anonymous
 def directory_diff_root(request, v1, v2):
     """Show diff between two root directory revisions."""
     root = get_object_or_404(Directory, path="")

--- a/wiki/lib/cache_headers.py
+++ b/wiki/lib/cache_headers.py
@@ -67,6 +67,10 @@ class AnonymousCacheHeadersMiddleware:
             # Non-GET/HEAD aren't CDN-cacheable; don't clutter headers.
             return response
 
+        # Set Vary: Cookie unconditionally — even if we end up at
+        # `private, no-store`, any intermediate cache (browser, corporate
+        # proxy, non-CloudFront CDN) that ignores us must still key by
+        # cookie state so it can't serve a logged-in response to anyone else.
         _patch_vary(response)
 
         if request.user.is_authenticated:

--- a/wiki/lib/cache_headers.py
+++ b/wiki/lib/cache_headers.py
@@ -1,0 +1,98 @@
+"""Cache-Control header logic for CDN-fronted views.
+
+The wiki sits behind CloudFront, which caches anonymous (no ``sessionid``
+cookie) GETs of public content. Views that should be CDN-cacheable are
+marked with the :func:`cache_for_anonymous` decorator. The actual
+``Cache-Control``/``Vary`` decision is deferred to
+:class:`AnonymousCacheHeadersMiddleware`, which runs after every other
+response-phase middleware — including ``CsrfViewMiddleware`` and
+``MessageMiddleware``, both of which can attach ``Set-Cookie`` headers
+that would carry per-visitor state into a cached response.
+
+If we made the decision inside the decorator (i.e. before the rest of
+the middleware chain processes the response), we'd miss those late-set
+cookies and silently cache them. The middleware sees the final
+response and can drop to ``private, no-store`` whenever any cookie is
+about to be sent.
+"""
+
+from functools import wraps
+
+# 30 seconds in browsers; 30 days at the CDN. The CDN value is high
+# because we invalidate on every change. The browser value is low so a
+# user who lingers sees an edit reasonably quickly even if invalidation
+# propagation is on the slow side.
+ANON_CACHE_CONTROL = "public, max-age=30, s-maxage=2592000"
+PRIVATE_CACHE_CONTROL = "private, no-store"
+
+# Attribute set by the decorator to opt the response in. Read by the
+# middleware. Anything not marked is left alone.
+_MARKER_ATTR = "_cache_for_anonymous"
+
+
+def cache_for_anonymous(view_func):
+    """Mark a view's response as eligible for anonymous CDN caching.
+
+    The actual ``Cache-Control``/``Vary`` decision happens in
+    :class:`AnonymousCacheHeadersMiddleware`, which runs after every
+    other response-phase middleware so it sees ``Set-Cookie`` headers
+    written by ``MessageMiddleware``, ``CsrfViewMiddleware``, etc.
+    """
+
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        response = view_func(request, *args, **kwargs)
+        setattr(response, _MARKER_ATTR, True)
+        return response
+
+    return wrapper
+
+
+class AnonymousCacheHeadersMiddleware:
+    """Finalize cache headers for views marked by ``cache_for_anonymous``.
+
+    Must be installed at the *top* of MIDDLEWARE so its response phase
+    runs LAST — i.e. after every other middleware that might attach a
+    ``Set-Cookie`` header.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if not getattr(response, _MARKER_ATTR, False):
+            return response
+        if request.method not in ("GET", "HEAD"):
+            # Non-GET/HEAD aren't CDN-cacheable; don't clutter headers.
+            return response
+
+        _patch_vary(response)
+
+        if request.user.is_authenticated:
+            response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
+            return response
+        if not (200 <= response.status_code < 300):
+            return response
+        if response.has_header("Cache-Control"):
+            # View / earlier middleware set its own policy — respect it.
+            return response
+        if response.cookies:
+            # Anything that emits Set-Cookie (Django messages on a
+            # post-redirect-get, a freshly minted CSRF cookie, a
+            # gradual-rollout Waffle cookie) carries per-visitor state.
+            # Caching this response would replay the cookie and the
+            # personalized HTML it implies to subsequent anonymous
+            # visitors.
+            response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
+            return response
+        response.headers["Cache-Control"] = ANON_CACHE_CONTROL
+        return response
+
+
+def _patch_vary(response):
+    existing = response.headers.get("Vary", "")
+    parts = [p.strip() for p in existing.split(",") if p.strip()]
+    if not any(p.lower() == "cookie" for p in parts):
+        parts.append("Cookie")
+        response.headers["Vary"] = ", ".join(parts)

--- a/wiki/lib/cloudfront.py
+++ b/wiki/lib/cloudfront.py
@@ -1,0 +1,70 @@
+import logging
+import uuid
+from collections.abc import Iterable
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _get_client():
+    return boto3.client(
+        "cloudfront",
+        # CloudFront is global; its control plane lives in us-east-1.
+        # Pin the region so this works in containers without
+        # AWS_DEFAULT_REGION (otherwise calls fail silently — errors
+        # are swallowed by ``invalidate_paths`` to keep writes from
+        # rolling back over a CDN issue).
+        region_name="us-east-1",
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+    )
+
+
+# CloudFront caps a single invalidation batch at 3,000 paths.
+_MAX_BATCH = 3000
+
+
+def _normalize(path: str) -> str:
+    # CloudFront keys exclude query strings and fragments by default,
+    # so an invalidation against ``/c/foo?bar=1`` would burn a slot for
+    # nothing. Strip both before sending.
+    path = path.split("?", 1)[0].split("#", 1)[0]
+    return path if path.startswith("/") else f"/{path}"
+
+
+def invalidate_paths(paths: Iterable[str]) -> None:
+    """Submit a CloudFront invalidation for the given paths.
+
+    No-ops when ``CLOUDFRONT_DISTRIBUTION_ID`` is unset (dev / staging
+    without a CDN). Errors from boto3 are logged and swallowed: an
+    invalidation failure must not break the surrounding write.
+    """
+    distribution_id = settings.CLOUDFRONT_DISTRIBUTION_ID
+    if not distribution_id:
+        return
+
+    unique_paths = sorted({_normalize(p) for p in paths if p})
+    if not unique_paths:
+        return
+
+    client = _get_client()
+    for i in range(0, len(unique_paths), _MAX_BATCH):
+        chunk = unique_paths[i : i + _MAX_BATCH]
+        try:
+            client.create_invalidation(
+                DistributionId=distribution_id,
+                InvalidationBatch={
+                    "Paths": {
+                        "Quantity": len(chunk),
+                        "Items": chunk,
+                    },
+                    "CallerReference": str(uuid.uuid4()),
+                },
+            )
+        except (BotoCoreError, ClientError):
+            logger.exception(
+                "CloudFront invalidation failed for paths=%s", chunk
+            )

--- a/wiki/lib/ratelimiter.py
+++ b/wiki/lib/ratelimiter.py
@@ -11,6 +11,11 @@ ratelimit_upload = ratelimit(
     key="user_or_ip", rate="20/m", method=["POST"], block=True
 )
 ratelimit_search = ratelimit(key="user_or_ip", rate="30/m", block=True)
+# View tallies are JS-fired from page loads — multiple tabs / prefetches
+# from a single IP are normal, so the limit is generous.
+ratelimit_view_count = ratelimit(
+    key="ip", rate="120/m", method=["POST"], block=True
+)
 # Caps how fast a single user can create or move pages. Directory-scoped
 # slugs let multiple pages share a name across dirs, so mass-creating
 # colliding slugs could force expensive synchronous link-rewrites on

--- a/wiki/lib/tests_cache_headers.py
+++ b/wiki/lib/tests_cache_headers.py
@@ -199,6 +199,36 @@ def test_anonymous_root_response_has_public_cache_control(client):
 
 
 @pytest.mark.django_db
+def test_stale_sessionid_cookie_yields_private_no_store(client):
+    """Regression: cache middleware must run AFTER SessionMiddleware on
+    the response chain.
+
+    If an anonymous request arrives with a ``sessionid`` cookie that
+    doesn't match a real session, Django's ``SessionMiddleware`` emits
+    a delete-sessionid ``Set-Cookie`` on the response. That Set-Cookie
+    is per-visitor state — caching the response would replay the
+    delete-cookie (and the HTML around it) to other anonymous visitors.
+
+    For the cache middleware to see that Set-Cookie, its response phase
+    must run LAST, which means it must sit at the TOP of MIDDLEWARE.
+    Before this fix, it sat below ``SessionMiddleware``, so the delete
+    cookie was attached AFTER the cache middleware had already stamped
+    ``public, s-maxage=2592000``. CloudFront would then cache it.
+    """
+    client.cookies["sessionid"] = "stale-fake-session-key-aaaaaa"
+    response = client.get("/")
+    # Sanity check: SessionMiddleware did emit a delete-cookie.
+    assert "sessionid" in response.cookies, (
+        "test setup assumption broken: SessionMiddleware did not emit a "
+        "delete-sessionid cookie for a stale incoming sessionid"
+    )
+    assert response.headers.get("Cache-Control") == PRIVATE_CACHE_CONTROL, (
+        f"Cacheable response with a Set-Cookie attached! Got: "
+        f"{response.headers.get('Cache-Control')}"
+    )
+
+
+@pytest.mark.django_db
 def test_messages_framework_does_not_poison_cache(client, page):
     """End-to-end leak test:
 

--- a/wiki/lib/tests_cache_headers.py
+++ b/wiki/lib/tests_cache_headers.py
@@ -1,0 +1,240 @@
+"""Tests for the CDN cache-header decorator + middleware pair.
+
+The unit tests for behavior must run the request through the middleware
+chain, not just the decorator alone — the decorator is a marker, the
+real logic lives in ``AnonymousCacheHeadersMiddleware``.
+"""
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse, HttpResponseRedirect
+from django.test import RequestFactory
+
+from wiki.lib.cache_headers import (
+    ANON_CACHE_CONTROL,
+    PRIVATE_CACHE_CONTROL,
+    AnonymousCacheHeadersMiddleware,
+    cache_for_anonymous,
+)
+
+
+@cache_for_anonymous
+def _ok_view(request):
+    return HttpResponse("ok")
+
+
+@cache_for_anonymous
+def _redirect_view(request):
+    return HttpResponseRedirect("/elsewhere/")
+
+
+@cache_for_anonymous
+def _preset_view(request):
+    response = HttpResponse("ok")
+    response["Cache-Control"] = "public, max-age=99"
+    return response
+
+
+@cache_for_anonymous
+def _vary_already_view(request):
+    response = HttpResponse("ok")
+    response["Vary"] = "Accept-Encoding"
+    return response
+
+
+@cache_for_anonymous
+def _cookie_setting_view(request):
+    response = HttpResponse("ok")
+    response.set_cookie("messages", "your comment was submitted")
+    return response
+
+
+def _undecorated_ok_view(request):
+    return HttpResponse("ok")
+
+
+def _run(view, request):
+    """Run the view through ``AnonymousCacheHeadersMiddleware``."""
+    middleware = AnonymousCacheHeadersMiddleware(view)
+    return middleware(request)
+
+
+def _anon_request(method="GET"):
+    rf = RequestFactory()
+    request = getattr(rf, method.lower())("/")
+    request.user = AnonymousUser()
+    return request
+
+
+def _auth_request(method="GET"):
+    rf = RequestFactory()
+    request = getattr(rf, method.lower())("/")
+
+    class _U:
+        is_authenticated = True
+
+    request.user = _U()
+    return request
+
+
+def test_anonymous_get_gets_public_cache_control():
+    response = _run(_ok_view, _anon_request())
+    assert response["Cache-Control"] == ANON_CACHE_CONTROL
+    assert "Cookie" in response["Vary"]
+
+
+def test_authenticated_request_gets_private_cache_control():
+    response = _run(_ok_view, _auth_request())
+    assert response["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert "Cookie" in response["Vary"]
+
+
+def test_post_response_left_alone():
+    """Non-GET responses aren't CDN-cacheable, so the middleware passes
+    them through untouched — no Cache-Control, no Vary."""
+    for request in (_anon_request("POST"), _auth_request("POST")):
+        response = _run(_ok_view, request)
+        assert "Cache-Control" not in response.headers
+        assert "Vary" not in response.headers
+
+
+def test_anonymous_redirect_left_alone():
+    """A 302 from a marked view is non-2xx — middleware must NOT stamp a
+    public TTL on a redirect."""
+    response = _run(_redirect_view, _anon_request())
+    assert "Cache-Control" not in response.headers
+
+
+def test_existing_cache_control_not_overridden():
+    response = _run(_preset_view, _anon_request())
+    assert response["Cache-Control"] == "public, max-age=99"
+
+
+def test_vary_appends_cookie_without_clobbering():
+    response = _run(_vary_already_view, _anon_request())
+    parts = [p.strip() for p in response["Vary"].split(",")]
+    assert "Accept-Encoding" in parts
+    assert "Cookie" in parts
+
+
+def test_vary_does_not_duplicate_cookie():
+    @cache_for_anonymous
+    def view(request):
+        response = HttpResponse("ok")
+        response["Vary"] = "Cookie, Accept-Encoding"
+        return response
+
+    response = _run(view, _anon_request())
+    parts = [p.strip().lower() for p in response["Vary"].split(",")]
+    assert parts.count("cookie") == 1
+
+
+def test_response_with_set_cookie_is_not_cached():
+    """Defense against flash-message leaks.
+
+    If a marked view (or a downstream middleware like Django messages)
+    sets a cookie on the response, that cookie carries per-visitor
+    state. Caching it and replaying it to other anonymous visitors
+    would leak the user's flash. The middleware drops to ``private,
+    no-store`` whenever any cookie is on the response.
+    """
+    response = _run(_cookie_setting_view, _anon_request())
+    assert response["Cache-Control"] == PRIVATE_CACHE_CONTROL
+
+
+def test_undecorated_view_left_alone():
+    """Views not marked with ``cache_for_anonymous`` get no headers from
+    the middleware, regardless of method or auth state."""
+    for request in (_anon_request(), _auth_request(), _anon_request("POST")):
+        response = _run(_undecorated_ok_view, request)
+        assert "Cache-Control" not in response.headers
+        assert "Vary" not in response.headers
+
+
+# --- Integration tests via the test client (real middleware chain) ---
+
+
+@pytest.mark.django_db
+def test_anonymous_root_response_has_no_set_cookie(client):
+    """Cacheable responses must never emit Set-Cookie. Regression for
+    csrf_token in template, session writes, Waffle flag rollout."""
+    response = client.get("/")
+    assert "Set-Cookie" not in response.headers, (
+        f"Unexpected Set-Cookie on /: {response.headers.get('Set-Cookie')}"
+    )
+
+
+@pytest.mark.django_db
+def test_anonymous_llms_txt_has_no_set_cookie(client):
+    response = client.get("/llms.txt")
+    assert "Set-Cookie" not in response.headers
+
+
+@pytest.mark.django_db
+def test_anonymous_robots_txt_has_no_set_cookie(client):
+    response = client.get("/robots.txt")
+    assert "Set-Cookie" not in response.headers
+
+
+@pytest.mark.django_db
+def test_anonymous_sitemap_has_no_set_cookie(client):
+    response = client.get("/sitemap.xml")
+    assert "Set-Cookie" not in response.headers
+
+
+@pytest.mark.django_db
+def test_anonymous_page_view_endpoint_has_no_set_cookie(client, page):
+    response = client.post(
+        "/api/page-view/",
+        data='{"page_id": ' + str(page.id) + "}",
+        content_type="application/json",
+    )
+    assert "Set-Cookie" not in response.headers
+
+
+@pytest.mark.django_db
+def test_anonymous_root_response_has_public_cache_control(client):
+    response = client.get("/")
+    assert response.headers.get("Cache-Control") == ANON_CACHE_CONTROL
+
+
+@pytest.mark.django_db
+def test_messages_framework_does_not_poison_cache(client, page):
+    """End-to-end leak test:
+
+    Anonymous user submits a comment via ``/c/<page>/feedback/`` →
+    ``messages.success`` adds a flash → 302 to ``/c/<page>`` →
+    browser follows with the ``messages`` cookie → page renders
+    "Your comment has been submitted." into HTML → MessageMiddleware
+    deletes the cookie via Set-Cookie. The response *must* end up with
+    ``Cache-Control: private, no-store`` so CloudFront doesn't cache
+    the leaked flash.
+    """
+    # Submit a comment as anonymous.
+    response = client.post(
+        f"/c/{page.content_path}/feedback/",
+        {
+            "submit_comment": "1",
+            "message": "Test comment",
+            "name": "Anon",
+            "email": "a@b.com",
+        },
+        follow=False,
+    )
+    assert response.status_code == 302
+    # The redirect must have set the messages cookie.
+    assert "messages" in response.cookies, (
+        "page_feedback POST must produce a messages cookie for this test"
+    )
+
+    # Follow the redirect — the response should NOT be cacheable.
+    landing = client.get(response.headers["Location"])
+    assert landing.status_code == 200
+    body = landing.content.decode()
+    assert "comment has been submitted" in body, (
+        "test setup didn't actually trigger the flash render"
+    )
+    assert landing.headers.get("Cache-Control") == PRIVATE_CACHE_CONTROL, (
+        f"Cacheable response with leaked flash! Got: "
+        f"{landing.headers.get('Cache-Control')}"
+    )

--- a/wiki/lib/tests_cloudfront.py
+++ b/wiki/lib/tests_cloudfront.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from django.test import override_settings
+
+from wiki.lib.cloudfront import invalidate_paths
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="")
+@patch("wiki.lib.cloudfront._get_client")
+def test_noop_when_distribution_unset(mock_client):
+    invalidate_paths(["/c/foo"])
+    mock_client.assert_not_called()
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_noop_when_paths_empty(mock_client):
+    invalidate_paths([])
+    mock_client.assert_not_called()
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_normalizes_and_dedupes_paths(mock_client):
+    invalidate_paths(["foo", "/bar", "/bar", ""])
+    mock_client.return_value.create_invalidation.assert_called_once()
+    call = mock_client.return_value.create_invalidation.call_args
+    assert call.kwargs["DistributionId"] == "EXAMPLE123"
+    items = call.kwargs["InvalidationBatch"]["Paths"]["Items"]
+    assert items == ["/bar", "/foo"]
+    assert call.kwargs["InvalidationBatch"]["Paths"]["Quantity"] == 2
+    # CallerReference must be present and non-empty for AWS
+    assert call.kwargs["InvalidationBatch"]["CallerReference"]
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_swallows_boto_errors(mock_client, caplog):
+    mock_client.return_value.create_invalidation.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+        "CreateInvalidation",
+    )
+    # Must not raise
+    invalidate_paths(["/c/foo"])
+    assert "CloudFront invalidation failed" in caplog.text
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_calls_with_correct_distribution(mock_client):
+    invalidate_paths(["/sitemap.xml"])
+    call = mock_client.return_value.create_invalidation.call_args
+    assert call.kwargs["DistributionId"] == "EXAMPLE123"
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_unique_caller_reference_per_call(mock_client):
+    invalidate_paths(["/a"])
+    invalidate_paths(["/b"])
+    refs = [
+        c.kwargs["InvalidationBatch"]["CallerReference"]
+        for c in mock_client.return_value.create_invalidation.call_args_list
+    ]
+    assert len(refs) == 2
+    assert refs[0] != refs[1]
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_strips_query_strings_and_fragments(mock_client):
+    """CloudFront keys exclude query strings; sending them wastes a slot."""
+    invalidate_paths(["/c/foo?utm=x", "/c/bar#frag"])
+    items = mock_client.return_value.create_invalidation.call_args.kwargs[
+        "InvalidationBatch"
+    ]["Paths"]["Items"]
+    assert items == ["/c/bar", "/c/foo"]
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.lib.cloudfront._get_client")
+def test_chunks_paths_above_aws_limit(mock_client):
+    """AWS caps a batch at 3000 paths; the helper must chunk."""
+    paths = [f"/p/{i}" for i in range(3500)]
+    invalidate_paths(paths)
+    calls = mock_client.return_value.create_invalidation.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["InvalidationBatch"]["Paths"]["Quantity"] == 3000
+    assert calls[1].kwargs["InvalidationBatch"]["Paths"]["Quantity"] == 500

--- a/wiki/lib/views.py
+++ b/wiki/lib/views.py
@@ -7,7 +7,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 
 from wiki.directories.models import Directory
-from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.inheritance import resolve_all_directory_settings
 from wiki.lib.seo import extract_description
 from wiki.lib.sitemap import (
@@ -23,7 +22,6 @@ def ratelimited(request, exception=None):
     return HttpResponse(html, status=429)
 
 
-@cache_for_anonymous
 def robots_txt(request):
     """Serve robots.txt with crawl directives."""
     sitemap_url = f"{settings.BASE_URL}{reverse('django.contrib.sitemaps.views.sitemap')}"
@@ -129,7 +127,6 @@ def _llms_txt_entry(page, base_url):
     return entry
 
 
-@cache_for_anonymous
 def llms_txt(request):
     """Serve llms.txt — an index of public wiki pages for LLM crawlers.
 

--- a/wiki/lib/views.py
+++ b/wiki/lib/views.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 
 from wiki.directories.models import Directory
+from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.inheritance import resolve_all_directory_settings
 from wiki.lib.seo import extract_description
 from wiki.lib.sitemap import (
@@ -22,6 +23,7 @@ def ratelimited(request, exception=None):
     return HttpResponse(html, status=429)
 
 
+@cache_for_anonymous
 def robots_txt(request):
     """Serve robots.txt with crawl directives."""
     sitemap_url = f"{settings.BASE_URL}{reverse('django.contrib.sitemaps.views.sitemap')}"
@@ -127,6 +129,7 @@ def _llms_txt_entry(page, base_url):
     return entry
 
 
+@cache_for_anonymous
 def llms_txt(request):
     """Serve llms.txt — an index of public wiki pages for LLM crawlers.
 

--- a/wiki/pages/apps.py
+++ b/wiki/pages/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class PagesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "wiki.pages"
+
+    def ready(self):
+        from wiki.pages import signals  # noqa: F401

--- a/wiki/pages/management/commands/invalidate_cdn.py
+++ b/wiki/pages/management/commands/invalidate_cdn.py
@@ -35,9 +35,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, paths, dry_run, **options):
         if dry_run:
-            target = (
-                settings.CLOUDFRONT_DISTRIBUTION_ID or "(unset)"
-            )
+            target = settings.CLOUDFRONT_DISTRIBUTION_ID or "(unset)"
             self.stdout.write(
                 f"Would invalidate {paths} on distribution {target}"
             )
@@ -51,7 +49,9 @@ class Command(BaseCommand):
 
         try:
             invalidate_paths(paths)
-        except Exception as exc:  # pragma: no cover — invalidate_paths swallows boto errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover — invalidate_paths swallows boto errors
             self.stderr.write(f"Invalidation failed: {exc}")
             sys.exit(1)
 

--- a/wiki/pages/management/commands/invalidate_cdn.py
+++ b/wiki/pages/management/commands/invalidate_cdn.py
@@ -1,12 +1,12 @@
-"""Invalidate CloudFront paths after a deploy or by request.
-
-Used by ``.github/workflows/deploy.yml`` after a successful deploy so
-templates/static-asset/Python changes can't serve stale HTML out of
-the CDN. Also useful for ad-hoc invalidations from a shell.
+"""Invalidate CloudFront paths from a shell.
 
 Defaults to wiping every cached path (``/*``). The free monthly quota
-is 1000 invalidation paths, and ``/*`` counts as one — so a daily
-deploy uses ~30 of those a month.
+is 1000 invalidation paths, and ``/*`` counts as one.
+
+Note: post-deploy invalidation is handled directly in
+``.github/workflows/deploy.yml`` via the AWS CLI, since the deploy
+job doesn't have a Python runtime — the workflow doesn't call this
+command. This command is for ad-hoc invalidations.
 """
 
 import sys

--- a/wiki/pages/management/commands/invalidate_cdn.py
+++ b/wiki/pages/management/commands/invalidate_cdn.py
@@ -1,0 +1,58 @@
+"""Invalidate CloudFront paths after a deploy or by request.
+
+Used by ``.github/workflows/deploy.yml`` after a successful deploy so
+templates/static-asset/Python changes can't serve stale HTML out of
+the CDN. Also useful for ad-hoc invalidations from a shell.
+
+Defaults to wiping every cached path (``/*``). The free monthly quota
+is 1000 invalidation paths, and ``/*`` counts as one — so a daily
+deploy uses ~30 of those a month.
+"""
+
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from wiki.lib.cloudfront import invalidate_paths
+
+
+class Command(BaseCommand):
+    help = "Submit a CloudFront invalidation."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "paths",
+            nargs="*",
+            default=["/*"],
+            help="Paths to invalidate. Defaults to ['/*'].",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would be invalidated without calling AWS.",
+        )
+
+    def handle(self, *args, paths, dry_run, **options):
+        if dry_run:
+            target = (
+                settings.CLOUDFRONT_DISTRIBUTION_ID or "(unset)"
+            )
+            self.stdout.write(
+                f"Would invalidate {paths} on distribution {target}"
+            )
+            return
+
+        if not settings.CLOUDFRONT_DISTRIBUTION_ID:
+            self.stdout.write(
+                "CLOUDFRONT_DISTRIBUTION_ID is unset — skipping invalidation."
+            )
+            return
+
+        try:
+            invalidate_paths(paths)
+        except Exception as exc:  # pragma: no cover — invalidate_paths swallows boto errors
+            self.stderr.write(f"Invalidation failed: {exc}")
+            sys.exit(1)
+
+        self.stdout.write(self.style.SUCCESS(f"Invalidated {paths}"))

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -1292,6 +1292,42 @@ shows the page title, who made the change, when, and the change
 message. The feed is paginated (50 per page) and can be filtered
 to a specific user by clicking their name.
 
+### CDN caching
+
+Public pages are served through a CloudFront CDN to anyone who
+isn't signed in. CDN-cached responses live for up to 30 days, but
+the cache is **automatically invalidated** whenever content changes:
+
+- Editing, creating, deleting, moving, or renaming a page or
+  directory invalidates the affected URLs.
+- Each successful deploy issues a site-wide invalidation, in case
+  templates or rendering logic changed in ways that don't show up
+  as page edits.
+
+**For signed-in users**, the CDN is bypassed entirely — every
+request goes straight to the origin. So the page you see when
+you're logged in is always fresh.
+
+**For anonymous viewers**, edits propagate within ~30 seconds plus
+the time it takes CloudFront to apply the invalidation (usually
+under a minute, occasionally several minutes). If you need to
+verify how an edit looks to the public, sign out (or open an
+incognito window) — the next request you make will fetch the
+post-edit version once the invalidation lands.
+
+If you ever need to force a manual invalidation (e.g. you suspect
+the cache is stuck), run:
+
+```
+python manage.py invalidate_cdn          # whole site
+python manage.py invalidate_cdn /c/foo   # specific paths
+```
+
+The view counter shown at the bottom of each page is **not**
+served from the CDN cache — it's fetched fresh by JavaScript on
+each load, so the number stays accurate even when the surrounding
+HTML is cached.
+
 ### Best practices for admins
 
 - **Use groups** for team-based access rather than granting

--- a/wiki/pages/signals.py
+++ b/wiki/pages/signals.py
@@ -55,9 +55,12 @@ def capture_old_path(sender, instance, **kwargs):
         instance._old_content_path = None
         instance._old_directory = None
         return
-    old = Page.all_objects.filter(pk=instance.pk).only(
-        "slug", "directory_id"
-    ).select_related("directory").first()
+    old = (
+        Page.all_objects.filter(pk=instance.pk)
+        .only("slug", "directory_id")
+        .select_related("directory")
+        .first()
+    )
     if old is None:
         instance._old_content_path = None
         instance._old_directory = None

--- a/wiki/pages/signals.py
+++ b/wiki/pages/signals.py
@@ -1,0 +1,85 @@
+"""CDN cache invalidation when pages change.
+
+A ``post_save`` on ``Page`` invalidates the page's URL plus its parent
+directory listing(s). When a slug or directory change makes the page's
+URL move, the *old* URL is invalidated as well so its cached HTML
+(which would otherwise become a redirect destination's stale duplicate)
+gets evicted.
+
+We don't hook ``post_delete`` because pages soft-delete via
+``save(update_fields=[...])`` — that path goes through ``post_save``.
+Hard delete is admin-only and accepted as not-invalidated.
+
+Invalidations fire via ``transaction.on_commit`` so a rolled-back save
+doesn't burn a CloudFront invalidation slot on a write that didn't
+actually happen.
+"""
+
+from django.db import transaction
+from django.db.models.signals import post_save, pre_save
+from django.dispatch import receiver
+
+from wiki.lib.cloudfront import invalidate_paths
+
+from .models import Page
+
+
+def _parent_listing_paths(directory):
+    """Return URLs of the listing(s) that contain pages in this directory.
+
+    Django routes both ``/c/foo`` and ``/c/foo/`` to the directory view, so
+    CloudFront caches them as separate keys — we have to invalidate both.
+    """
+    if directory and directory.path:
+        return [f"/c/{directory.path}", f"/c/{directory.path}/"]
+    return ["/"]
+
+
+def _page_url_variants(content_path):
+    """Return both slash-forms of a page URL.
+
+    A page lives at ``/c/<path>``; some links/sitemaps emit it that way,
+    others append a slash. Cache both.
+    """
+    return [f"/c/{content_path}", f"/c/{content_path}/"]
+
+
+@receiver(pre_save, sender=Page)
+def capture_old_path(sender, instance, **kwargs):
+    """Stash pre-save URL state so post_save can invalidate the old URL.
+
+    Uses ``all_objects`` so this also captures the prior path of pages
+    that are about to be soft-deleted or restored.
+    """
+    if not instance.pk:
+        instance._old_content_path = None
+        instance._old_directory = None
+        return
+    old = Page.all_objects.filter(pk=instance.pk).only(
+        "slug", "directory_id"
+    ).select_related("directory").first()
+    if old is None:
+        instance._old_content_path = None
+        instance._old_directory = None
+        return
+    instance._old_content_path = old.content_path
+    instance._old_directory = old.directory
+
+
+@receiver(post_save, sender=Page)
+def invalidate_on_page_save(sender, instance, **kwargs):
+    paths = set(_page_url_variants(instance.content_path))
+    paths.update(_parent_listing_paths(instance.directory))
+    old_path = getattr(instance, "_old_content_path", None)
+    if old_path is None:
+        # New page — no prior URL or parent listing to evict.
+        transaction.on_commit(lambda: invalidate_paths(paths))
+        return
+    if old_path != instance.content_path:
+        # Slug or directory moved — old URL must also drop out of the cache.
+        paths.update(_page_url_variants(old_path))
+    old_directory = getattr(instance, "_old_directory", None)
+    if old_directory != instance.directory:
+        # Directory changed — old parent's listing showed this page.
+        paths.update(_parent_listing_paths(old_directory))
+    transaction.on_commit(lambda: invalidate_paths(paths))

--- a/wiki/pages/signals.py
+++ b/wiki/pages/signals.py
@@ -18,6 +18,7 @@ actually happen.
 from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+from django.urls import reverse
 
 from wiki.lib.cloudfront import invalidate_paths
 
@@ -31,8 +32,9 @@ def _parent_listing_paths(directory):
     CloudFront caches them as separate keys — we have to invalidate both.
     """
     if directory and directory.path:
-        return [f"/c/{directory.path}", f"/c/{directory.path}/"]
-    return ["/"]
+        base = reverse("resolve_path", kwargs={"path": directory.path})
+        return [base, f"{base}/"]
+    return [reverse("root")]
 
 
 def _page_url_variants(content_path):
@@ -41,7 +43,8 @@ def _page_url_variants(content_path):
     A page lives at ``/c/<path>``; some links/sitemaps emit it that way,
     others append a slash. Cache both.
     """
-    return [f"/c/{content_path}", f"/c/{content_path}/"]
+    base = reverse("resolve_path", kwargs={"path": content_path})
+    return [base, f"{base}/"]
 
 
 @receiver(pre_save, sender=Page)

--- a/wiki/pages/templates/pages/detail.html
+++ b/wiki/pages/templates/pages/detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static wiki_tags %}
+{% load humanize static wiki_tags %}
 
 {% block header %}
 {% if page.directory and page.directory.path %}
@@ -111,7 +111,7 @@
 
     <div class="page-meta">
       <div class="flex items-center justify-between">
-        <span>{{ page.view_count }} view{{ page.view_count|pluralize }}</span>
+        <span id="page-view-count">{{ page.view_count|intcomma }} view{{ page.view_count|pluralize }}</span>
         {% if user.is_authenticated %}
         <a href="{% url 'page_history' path=page.content_path %}" class="hover:underline">Last updated {{ page.updated_at|timesince }} ago</a>
         {% else %}
@@ -190,4 +190,11 @@
 {% block footer_scripts %}
 <script src="{% static 'js/highlight.min.js' %}"></script>
 <script src="{% static 'js/code-blocks.js' %}"></script>
+<script type="application/json" id="view-tally-config">
+{
+  "pageId": {{ page.id }},
+  "url": "{% url 'record_page_view' %}"
+}
+</script>
+<script src="{% static 'js/view-tally.js' %}" defer></script>
 {% endblock %}

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -229,10 +229,16 @@ class TestPageDetail:
         r = client.get(private_page.get_absolute_url())
         assert r.status_code == 200
 
-    def test_records_page_view_tally(self, client, page):
-        assert PageViewTally.objects.count() == 0
+    def test_get_does_not_record_tally(self, client, page):
+        # Tally creation moved to JS-fired POST so views still count
+        # when the page is served from a CDN cache.
         client.get(page.get_absolute_url())
-        assert PageViewTally.objects.count() == 1
+        assert PageViewTally.objects.count() == 0
+
+    def test_detail_includes_view_tally_config(self, client, page):
+        r = client.get(page.get_absolute_url())
+        assert b'id="view-tally-config"' in r.content
+        assert b'id="page-view-count"' in r.content
 
     def test_breadcrumbs_on_page(self, client, page):
         r = client.get(page.get_absolute_url())
@@ -675,6 +681,69 @@ class TestPreviewEndpoint:
         would leak the existence of private pages via URL paths."""
         r = client.post(reverse("page_preview"), {"content": "test"})
         assert r.status_code == 302  # redirected to login
+
+
+class TestRecordPageView:
+    """JS-fired endpoint that tallies page views for CDN-cached pages."""
+
+    def _post(self, client, body):
+        return client.post(
+            reverse("record_page_view"),
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    def test_creates_tally_and_returns_count(self, client, page):
+        page.view_count = 42
+        page.save(update_fields=["view_count"])
+        assert PageViewTally.objects.count() == 0
+        r = self._post(client, {"page_id": page.id})
+        assert r.status_code == 200
+        assert r.json() == {"count": 42}
+        assert PageViewTally.objects.filter(page=page).count() == 1
+
+    def test_works_for_anonymous_user(self, client, page):
+        # CDN-served pages will mostly be hit by anon users.
+        r = self._post(client, {"page_id": page.id})
+        assert r.status_code == 200
+        assert PageViewTally.objects.filter(page=page).count() == 1
+
+    def test_unknown_page_returns_404(self, client, db):
+        r = self._post(client, {"page_id": 99_999})
+        assert r.status_code == 404
+        assert PageViewTally.objects.count() == 0
+
+    def test_private_page_rejected_for_non_viewer(self, client, private_page):
+        # Anonymous can't view; treat like a 404 to avoid leaking existence.
+        r = self._post(client, {"page_id": private_page.id})
+        assert r.status_code == 404
+        assert PageViewTally.objects.count() == 0
+
+    def test_private_page_tallied_for_owner(self, client, user, private_page):
+        client.force_login(user)
+        r = self._post(client, {"page_id": private_page.id})
+        assert r.status_code == 200
+        assert PageViewTally.objects.filter(page=private_page).count() == 1
+
+    def test_invalid_payload_returns_400(self, client, db):
+        r = client.post(
+            reverse("record_page_view"),
+            data="not json",
+            content_type="application/json",
+        )
+        assert r.status_code == 400
+
+    def test_missing_page_id_returns_400(self, client, db):
+        r = self._post(client, {})
+        assert r.status_code == 400
+
+    def test_non_integer_page_id_returns_400(self, client, db):
+        r = self._post(client, {"page_id": "abc"})
+        assert r.status_code == 400
+
+    def test_get_not_allowed(self, client, db):
+        r = client.get(reverse("record_page_view"))
+        assert r.status_code == 405
 
 
 class TestFileUpload:

--- a/wiki/pages/tests_cdn.py
+++ b/wiki/pages/tests_cdn.py
@@ -1,0 +1,155 @@
+"""Tests for CDN invalidation when pages change."""
+
+from unittest.mock import patch
+
+import pytest
+from django.db import transaction
+
+
+@pytest.fixture
+def mock_invalidate():
+    with patch("wiki.pages.signals.invalidate_paths") as m:
+        yield m
+
+
+@pytest.mark.django_db(transaction=True)
+def test_create_page_invalidates_url_and_parent(
+    mock_invalidate, user, sub_directory
+):
+    from wiki.pages.models import Page
+
+    p = Page.objects.create(
+        title="New",
+        content="x",
+        directory=sub_directory,
+        owner=user,
+        created_by=user,
+        updated_by=user,
+    )
+    paths = mock_invalidate.call_args.args[0]
+    # Both slash-forms of the page URL.
+    assert p.get_absolute_url() in paths
+    assert f"{p.get_absolute_url()}/" in paths
+    # Both slash-forms of the parent directory listing.
+    assert "/c/engineering" in paths
+    assert "/c/engineering/" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_root_page_invalidates_root_listing(mock_invalidate, user):
+    from wiki.pages.models import Page
+
+    Page.objects.create(
+        title="Root Page",
+        content="x",
+        owner=user,
+        created_by=user,
+        updated_by=user,
+    )
+    paths = mock_invalidate.call_args.args[0]
+    assert "/" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_slug_change_invalidates_old_url(mock_invalidate, page):
+    page.title = "Renamed Page"
+    page.save()  # title change rebuilds the slug
+    paths = mock_invalidate.call_args.args[0]
+    # Old URL — both slash-forms.
+    assert "/c/getting-started" in paths
+    assert "/c/getting-started/" in paths
+    # New URL — both slash-forms.
+    assert page.get_absolute_url() in paths
+    assert f"{page.get_absolute_url()}/" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_directory_move_invalidates_both_listings(
+    mock_invalidate, page, sub_directory
+):
+    page.directory = sub_directory
+    page.save()
+    paths = mock_invalidate.call_args.args[0]
+    # Old (root) parent listing.
+    assert "/" in paths
+    # New parent listing — both slash-forms.
+    assert "/c/engineering" in paths
+    assert "/c/engineering/" in paths
+    # Old URL — both slash-forms.
+    assert "/c/getting-started" in paths
+    assert "/c/getting-started/" in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_soft_delete_invalidates(mock_invalidate, page, user):
+    mock_invalidate.reset_mock()
+    page.soft_delete(user)
+    assert mock_invalidate.called
+    paths = mock_invalidate.call_args.args[0]
+    assert page.get_absolute_url() in paths
+
+
+@pytest.mark.django_db(transaction=True)
+def test_rolled_back_save_does_not_invalidate(
+    mock_invalidate, user, sub_directory
+):
+    """transaction.on_commit must hold the invalidation until commit."""
+    from wiki.pages.models import Page
+
+    try:
+        with transaction.atomic():
+            Page.objects.create(
+                title="Doomed",
+                content="x",
+                directory=sub_directory,
+                owner=user,
+                created_by=user,
+                updated_by=user,
+            )
+            raise RuntimeError("rollback")
+    except RuntimeError:
+        pass
+    mock_invalidate.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_atomic_save_defers_invalidation_until_commit(
+    mock_invalidate, user, sub_directory
+):
+    """The success-path counterpart of test_rolled_back_save_does_not_invalidate.
+
+    Asserts that ``invalidate_paths`` is NOT called inside the atomic block,
+    but IS called after the block exits cleanly. Prevents a regression that
+    moves invalidation out of ``transaction.on_commit``.
+    """
+    from wiki.pages.models import Page
+
+    with transaction.atomic():
+        Page.objects.create(
+            title="Saved",
+            content="x",
+            directory=sub_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+        )
+        # Inside the transaction, invalidation must NOT have fired.
+        mock_invalidate.assert_not_called()
+
+    # After commit, it fires.
+    mock_invalidate.assert_called_once()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_op_save_skips_old_path(mock_invalidate, page):
+    """Saving without a slug or directory change should not include an old URL."""
+    mock_invalidate.reset_mock()
+    page.content = "Updated body, same path."
+    page.save()
+    paths = mock_invalidate.call_args.args[0]
+    # Same path → URL variants + parent listing only.
+    assert paths == {
+        page.get_absolute_url(),
+        f"{page.get_absolute_url()}/",
+        "/",
+    }

--- a/wiki/pages/tests_cdn.py
+++ b/wiki/pages/tests_cdn.py
@@ -4,6 +4,9 @@ from unittest.mock import patch
 
 import pytest
 from django.db import transaction
+from django.urls import reverse
+
+from wiki.pages.models import Page
 
 
 @pytest.fixture
@@ -16,8 +19,6 @@ def mock_invalidate():
 def test_create_page_invalidates_url_and_parent(
     mock_invalidate, user, sub_directory
 ):
-    from wiki.pages.models import Page
-
     p = Page.objects.create(
         title="New",
         content="x",
@@ -31,14 +32,12 @@ def test_create_page_invalidates_url_and_parent(
     assert p.get_absolute_url() in paths
     assert f"{p.get_absolute_url()}/" in paths
     # Both slash-forms of the parent directory listing.
-    assert "/c/engineering" in paths
-    assert "/c/engineering/" in paths
+    assert sub_directory.get_absolute_url() in paths
+    assert f"{sub_directory.get_absolute_url()}/" in paths
 
 
 @pytest.mark.django_db(transaction=True)
 def test_root_page_invalidates_root_listing(mock_invalidate, user):
-    from wiki.pages.models import Page
-
     Page.objects.create(
         title="Root Page",
         content="x",
@@ -47,17 +46,18 @@ def test_root_page_invalidates_root_listing(mock_invalidate, user):
         updated_by=user,
     )
     paths = mock_invalidate.call_args.args[0]
-    assert "/" in paths
+    assert reverse("root") in paths
 
 
 @pytest.mark.django_db(transaction=True)
 def test_slug_change_invalidates_old_url(mock_invalidate, page):
+    old_url = page.get_absolute_url()
     page.title = "Renamed Page"
     page.save()  # title change rebuilds the slug
     paths = mock_invalidate.call_args.args[0]
     # Old URL — both slash-forms.
-    assert "/c/getting-started" in paths
-    assert "/c/getting-started/" in paths
+    assert old_url in paths
+    assert f"{old_url}/" in paths
     # New URL — both slash-forms.
     assert page.get_absolute_url() in paths
     assert f"{page.get_absolute_url()}/" in paths
@@ -67,17 +67,18 @@ def test_slug_change_invalidates_old_url(mock_invalidate, page):
 def test_directory_move_invalidates_both_listings(
     mock_invalidate, page, sub_directory
 ):
+    old_url = page.get_absolute_url()
     page.directory = sub_directory
     page.save()
     paths = mock_invalidate.call_args.args[0]
     # Old (root) parent listing.
-    assert "/" in paths
+    assert reverse("root") in paths
     # New parent listing — both slash-forms.
-    assert "/c/engineering" in paths
-    assert "/c/engineering/" in paths
+    assert sub_directory.get_absolute_url() in paths
+    assert f"{sub_directory.get_absolute_url()}/" in paths
     # Old URL — both slash-forms.
-    assert "/c/getting-started" in paths
-    assert "/c/getting-started/" in paths
+    assert old_url in paths
+    assert f"{old_url}/" in paths
 
 
 @pytest.mark.django_db(transaction=True)
@@ -94,8 +95,6 @@ def test_rolled_back_save_does_not_invalidate(
     mock_invalidate, user, sub_directory
 ):
     """transaction.on_commit must hold the invalidation until commit."""
-    from wiki.pages.models import Page
-
     try:
         with transaction.atomic():
             Page.objects.create(
@@ -122,8 +121,6 @@ def test_atomic_save_defers_invalidation_until_commit(
     but IS called after the block exits cleanly. Prevents a regression that
     moves invalidation out of ``transaction.on_commit``.
     """
-    from wiki.pages.models import Page
-
     with transaction.atomic():
         Page.objects.create(
             title="Saved",
@@ -151,5 +148,5 @@ def test_no_op_save_skips_old_path(mock_invalidate, page):
     assert paths == {
         page.get_absolute_url(),
         f"{page.get_absolute_url()}/",
-        "/",
+        reverse("root"),
     }

--- a/wiki/pages/tests_invalidate_cdn_command.py
+++ b/wiki/pages/tests_invalidate_cdn_command.py
@@ -1,0 +1,41 @@
+"""Tests for the invalidate_cdn management command."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import override_settings
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.pages.management.commands.invalidate_cdn.invalidate_paths")
+def test_default_paths(mock_invalidate):
+    out = StringIO()
+    call_command("invalidate_cdn", stdout=out)
+    mock_invalidate.assert_called_once_with(["/*"])
+    assert "Invalidated" in out.getvalue()
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.pages.management.commands.invalidate_cdn.invalidate_paths")
+def test_custom_paths(mock_invalidate):
+    call_command("invalidate_cdn", "/c/foo", "/sitemap.xml")
+    mock_invalidate.assert_called_once_with(["/c/foo", "/sitemap.xml"])
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="EXAMPLE123")
+@patch("wiki.pages.management.commands.invalidate_cdn.invalidate_paths")
+def test_dry_run_does_not_invalidate(mock_invalidate):
+    out = StringIO()
+    call_command("invalidate_cdn", "--dry-run", stdout=out)
+    mock_invalidate.assert_not_called()
+    assert "Would invalidate" in out.getvalue()
+
+
+@override_settings(CLOUDFRONT_DISTRIBUTION_ID="")
+@patch("wiki.pages.management.commands.invalidate_cdn.invalidate_paths")
+def test_unset_distribution_skips_cleanly(mock_invalidate):
+    out = StringIO()
+    call_command("invalidate_cdn", stdout=out)
+    mock_invalidate.assert_not_called()
+    assert "skipping invalidation" in out.getvalue()

--- a/wiki/pages/urls_api.py
+++ b/wiki/pages/urls_api.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("upload/presign/", views.presign_upload, name="presign_upload"),
     path("upload/confirm/", views.confirm_upload, name="confirm_upload"),
     path("page-search/", views.page_search_htmx, name="page_search"),
+    path("page-view/", views.record_page_view, name="record_page_view"),
     path(
         "dir-search/",
         dir_views.directory_search_htmx,

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -16,6 +16,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.text import get_valid_filename
+from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
@@ -960,6 +961,7 @@ def page_permissions(request, path):
     )
 
 
+@never_cache
 def page_backlinks(request, path):
     """Show pages that link to this page."""
     page = get_page_from_path(path)

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -21,6 +21,7 @@ from django.views.decorators.http import require_POST
 
 from wiki.comments.models import PageComment
 from wiki.directories.models import Directory, DirectoryPermission
+from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.data_source import fetch_page_data, substitute_data_variables
 from wiki.lib.edit_lock import (
     acquire_lock_for_page,
@@ -295,6 +296,7 @@ def _parse_directory_titles(post_data):
     return {k: v for k, v in titles.items() if isinstance(v, str) and v}
 
 
+@cache_for_anonymous
 def resolve_path(request, path):
     """Unified catch-all: resolve a path as page or directory.
 
@@ -958,6 +960,7 @@ def page_permissions(request, path):
     )
 
 
+@cache_for_anonymous
 def page_backlinks(request, path):
     """Show pages that link to this page."""
     page = get_page_from_path(path)
@@ -1525,6 +1528,7 @@ def toggle_pin(request, path):
     return JsonResponse({"is_pinned": page.is_pinned})
 
 
+@cache_for_anonymous
 def page_raw_markdown(request, path):
     """Return raw markdown content for a page (respects permissions)."""
     page = page_at_path(path)

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -960,7 +960,6 @@ def page_permissions(request, path):
     )
 
 
-@cache_for_anonymous
 def page_backlinks(request, path):
     """Show pages that link to this page."""
     page = get_page_from_path(path)

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -16,6 +16,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.text import get_valid_filename
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from wiki.comments.models import PageComment
@@ -46,6 +47,7 @@ from wiki.lib.ratelimiter import (
     ratelimit_page_write,
     ratelimit_search,
     ratelimit_upload,
+    ratelimit_view_count,
 )
 from wiki.lib.seo import (
     build_article_jsonld,
@@ -422,9 +424,6 @@ def _render_page_detail(request, page):
     """Render the page detail view (shared by resolve_path and page_detail)."""
     if not can_view_page(request.user, page):
         raise Http404
-
-    # Record page view tally
-    PageViewTally.objects.create(page=page)
 
     content = page.content
     if page.data_source_url:
@@ -1158,6 +1157,34 @@ def check_page_permissions(request):
 
 # Keep old name as alias for backwards compatibility
 check_mention_permissions = check_page_permissions
+
+
+@csrf_exempt
+@require_POST
+@ratelimit_view_count
+def record_page_view(request):
+    """Record a page-view tally and return the page's current view count.
+
+    Called from JS so views are tallied even when the page itself is served
+    from a CDN cache. The endpoint is csrf_exempt because cached HTML carries
+    a stale CSRF token; it's safe because the only side effect is appending a
+    tally row. ``Page.view_count`` is treated as the source of truth — it
+    converges via the periodic ``sync_page_view_counts`` task, so a small
+    amount of fuzziness in the returned value is expected and fine.
+    """
+    try:
+        data = json.loads(request.body)
+        page_id = int(data["page_id"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return JsonResponse({"error": "Invalid payload"}, status=400)
+
+    page = Page.objects.filter(id=page_id).first()
+    # Same response for missing and forbidden — don't leak existence.
+    if not page or not can_view_page(request.user, page):
+        return JsonResponse({"error": "Not found"}, status=404)
+
+    PageViewTally.objects.create(page=page)
+    return JsonResponse({"count": page.view_count})
 
 
 @require_POST

--- a/wiki/proposals/views.py
+++ b/wiki/proposals/views.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 
 from wiki.comments.forms import CommentForm
@@ -20,6 +21,7 @@ from .models import ChangeProposal
 from .tasks import notify_owner_of_proposal, notify_proposer_of_decision
 
 
+@never_cache
 def page_feedback(request, path):
     """Unified feedback page: comment or propose changes."""
     page = get_page_from_path(path)

--- a/wiki/settings/__init__.py
+++ b/wiki/settings/__init__.py
@@ -5,5 +5,6 @@ from .project.logging import *
 from .project.security import *
 from .project.testing import *
 from .third_party.aws import *
+from .third_party.cloudfront import *
 from .third_party.sentry import *
 from .third_party.waffle import *

--- a/wiki/settings/django.py
+++ b/wiki/settings/django.py
@@ -103,13 +103,19 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE = [
+    # Must sit at the TOP of MIDDLEWARE so its response phase runs LAST
+    # — i.e. after every other middleware that may attach a Set-Cookie
+    # to the response. Concretely: SessionMiddleware (which can emit a
+    # delete-sessionid Set-Cookie when an anonymous request arrives
+    # with a stale cookie), AuthenticationMiddleware (listed for
+    # completeness — it doesn't emit cookies but populates request.user
+    # which the cache middleware reads in its response phase),
+    # CsrfViewMiddleware, MessageMiddleware, and WaffleMiddleware. The
+    # cache middleware needs to see the final set of cookies to decide
+    # whether the response is safe to cache at the CDN.
+    "wiki.lib.cache_headers.AnonymousCacheHeadersMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    # Must sit above any middleware that may attach a Set-Cookie to a
-    # response (CsrfViewMiddleware, MessageMiddleware, WaffleMiddleware).
-    # Its response phase runs last — it needs to see the final cookie
-    # set to decide whether the response is safe to cache.
-    "wiki.lib.cache_headers.AnonymousCacheHeadersMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "wiki.lib.middleware.SEOHeadersMiddleware",
     "csp.middleware.CSPMiddleware",

--- a/wiki/settings/django.py
+++ b/wiki/settings/django.py
@@ -105,6 +105,11 @@ TEMPLATES = [
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # Must sit above any middleware that may attach a Set-Cookie to a
+    # response (CsrfViewMiddleware, MessageMiddleware, WaffleMiddleware).
+    # Its response phase runs last — it needs to see the final cookie
+    # set to decide whether the response is safe to cache.
+    "wiki.lib.cache_headers.AnonymousCacheHeadersMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "wiki.lib.middleware.SEOHeadersMiddleware",
     "csp.middleware.CSPMiddleware",

--- a/wiki/settings/third_party/cloudfront.py
+++ b/wiki/settings/third_party/cloudfront.py
@@ -1,0 +1,8 @@
+import environ
+
+env = environ.FileAwareEnv()
+
+# CloudFront distribution that fronts the wiki. Empty in dev / staging
+# without a CDN, in which case `wiki.lib.cloudfront.invalidate_paths`
+# becomes a no-op.
+CLOUDFRONT_DISTRIBUTION_ID = env("CLOUDFRONT_DISTRIBUTION_ID", default="")

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -4,7 +4,6 @@ from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 
 from wiki.directories.views import root_view
-from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.monitoring import health_check, heartbeat, sentry_fail
 from wiki.lib.sitemap import DirectorySitemap, PageSitemap
 from wiki.lib.views import llms_txt, robots_txt
@@ -25,7 +24,7 @@ urlpatterns = [
     path("llms.txt", llms_txt, name="llms_txt"),
     path(
         "sitemap.xml",
-        cache_for_anonymous(sitemap),
+        sitemap,
         {"sitemaps": sitemaps},
         name="django.contrib.sitemaps.views.sitemap",
     ),

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -4,6 +4,7 @@ from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 
 from wiki.directories.views import root_view
+from wiki.lib.cache_headers import cache_for_anonymous
 from wiki.lib.monitoring import health_check, heartbeat, sentry_fail
 from wiki.lib.sitemap import DirectorySitemap, PageSitemap
 from wiki.lib.views import llms_txt, robots_txt
@@ -24,7 +25,7 @@ urlpatterns = [
     path("llms.txt", llms_txt, name="llms_txt"),
     path(
         "sitemap.xml",
-        sitemap,
+        cache_for_anonymous(sitemap),
         {"sitemaps": sitemaps},
         name="django.contrib.sitemaps.views.sitemap",
     ),


### PR DESCRIPTION
## Fixes
Fixes the non-infra parts of #81. The Pulumi/CloudFront-config piece is tracked separately — see "Required Pulumi-side changes" below.

## Summary
Anonymous GETs of public content are now CDN-cacheable. Specifically:

- `/` (root listing)
- `/c/<path>` (the catch-all that resolves to either a page or a directory)
- `/c/<path>.md` (raw markdown of a page — used by llms.txt links)

Authenticated users bypass via `sessionid`. Cached HTML lives 30 days at the CDN with a 30-second browser TTL.

Non-content endpoints (`/sitemap.xml`, `/llms.txt`, `/robots.txt`) and page-meta endpoints (backlinks, history, diff) are intentionally **not** cached — low traffic, not worth the cache complexity.

Eight commits, in order of dependency:

1. **csrf_token leak fix** (`fc2c787`) — Gates `hx-headers` in `base.html` behind `{% if user.is_authenticated %}`. Without this, every anonymous response carried `Set-Cookie: csrftoken=...`, which would either poison the public cache or fragment it badly.
2. **CloudFront helper** (`f14e453`) — `invalidate_paths()` with no-op-when-unset, query-string stripping, 3000-path AWS-limit chunking, and error swallowing so a CDN outage can't break a save.
3. **Cache headers** (`6ef8c31`) — `cache_for_anonymous` decorator marks read views; `AnonymousCacheHeadersMiddleware` (top of MIDDLEWARE so its response phase runs *last*) writes `public, max-age=30, s-maxage=2592000` for anonymous 2xx GETs, `private, no-store` for authenticated requests, and **drops to `private, no-store` whenever any `Set-Cookie` is on the response** (Django messages, CSRF token, Waffle rollout cookies). This was a real leak: anonymous comment submission → `messages.success` → 302 → page render with the flash → previously got cached and replayed to other anonymous visitors. End-to-end test in `tests_cache_headers.py` exercises that path.
4. **Invalidation signals** (`fbf93a8`) — `post_save` on `Page` and `Directory` invalidates the affected URL(s) plus parent listing(s), via `transaction.on_commit` so rolled-back saves don't burn slots. Both slash-forms (`/c/foo` and `/c/foo/`) are emitted because Django routes them to the same view but CloudFront keys them separately. Directory renames blow `/c/<old>/*` and `/c/<new>/*` wildcards plus the directory's own URL (wildcards don't match the no-slash form).
5. **Deploy invalidation** (`83454c2`) — New `invalidate-cdn` job in `deploy.yml` issues `/*`. Failure is non-fatal. Distribution ID is passed via env var, not interpolated into the shell. `manage.py invalidate_cdn` provides the same capability for ad-hoc use.
6. **Help page** (`2b82295`) — CDN section added to the existing Admin Guide.
7. **Web-only deploy gate** (`f558abd`) — `invalidate-cdn` runs after `deploy-web` succeeds, regardless of daemon outcome. The daemon doesn't serve traffic and `skip-daemon-deploy` is a real workflow input.
8. **Scope reduction** (`c661d8f`) — Drops `@cache_for_anonymous` from `/sitemap.xml`, `/llms.txt`, `/robots.txt`, page backlinks, and directory history/diff. CDN now only fronts content surfaces.

## Required Pulumi-side changes (must land alongside this PR)
- [ ] CloudFront cache behavior covers the content paths (`/`, `/c/*`), respects origin `Cache-Control`. Non-content endpoints can pass through.
- [ ] Cookie-bypass keyed on `sessionid` only — **not** `csrftoken`.
- [ ] Cache key includes all query strings (`?sort=...` differentiates listings — failing this allows cache poisoning).
- [ ] Response policy strips `Set-Cookie` from cached responses (defense in depth alongside the middleware-level Set-Cookie check).
- [ ] New GitHub secret: `CLOUDFRONT_DISTRIBUTION_ID`. Without it the deploy job is a no-op (it short-circuits cleanly).

## Reviews completed before opening
- Antagonistic code review (general agent) — addressed: trailing-slash invalidations, missing old-parent on directory move, wildcard-vs-no-slash, query/fragment stripping in `_normalize`, 3000-path chunking, Vary patching on non-GET, positive `transaction.on_commit` regression test.
- Security review (general agent) — addressed: flash-message leak via cached HTML (the middleware-ordering fix above), shell injection in deploy.yml, CloudFront client region pinning.

## Known limitations (deferred)
- A page slug collision triggers `_qualify_bare_links_on_collision`, which recursively saves linker pages; each fires its own invalidation. Rare in practice; not worth batching now.
- Static IAM keys in `deploy.yml` (pre-existing). Migrating to OIDC is a separate change.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

**Extra steps for this deploy:**
1. Add `CLOUDFRONT_DISTRIBUTION_ID` to the repo's GitHub Actions secrets.
2. Land the Pulumi-side changes (checklist above) before or alongside this PR's deploy. Without them the cache will either underperform or — in the worst case (cookie-bypass not configured) — leak signed-in HTML to anonymous viewers.
3. After deploy, run `manage.py seed_help_pages` so the new Admin Guide section lands in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)