### PR TITLE
Add rel=nofollow to robots.txt-blocked links on crawlable pages

### DIFF
--- a/wiki/assets/templates/404.html
+++ b/wiki/assets/templates/404.html
@@ -22,7 +22,7 @@
     If you're FLP staff, sign in with your email &mdash; no password needed.
   </p>
   <div class="mt-6 flex flex-col items-center gap-3">
-    <a href="{% url 'login' %}?next={{ request.path }}" class="btn-primary inline-flex text-lg px-8 py-3">
+    <a href="{% url 'login' %}?next={{ request.path }}" rel="nofollow" class="btn-primary inline-flex text-lg px-8 py-3">
       Sign In to Find Out
     </a>
     <a href="{% url 'root' %}" class="text-sm text-gray-400 dark:text-gray-500 underline">

--- a/wiki/assets/templates/cotton/header.html
+++ b/wiki/assets/templates/cotton/header.html
@@ -132,7 +132,7 @@
           </button>
         </form>
       {% else %}
-        <a href="{% url 'login' %}" class="btn-outline text-sm py-1.5">Sign in</a>
+        <a href="{% url 'login' %}" rel="nofollow" class="btn-outline text-sm py-1.5">Sign in</a>
       {% endif %}
     </nav>
   </div>

--- a/wiki/pages/templates/pages/detail.html
+++ b/wiki/pages/templates/pages/detail.html
@@ -58,7 +58,7 @@
         {% if can_edit %}
           <a href="{% url 'page_edit' path=page.content_path %}" class="btn-outline text-sm">Edit</a>
         {% else %}
-          <a href="{% url 'page_feedback' path=page.content_path %}" class="btn-outline text-sm">Feedback</a>
+          <a href="{% url 'page_feedback' path=page.content_path %}" rel="nofollow" class="btn-outline text-sm">Feedback</a>
         {% endif %}
         <div class="relative" x-data="dropdown">
           {% if pending_proposal_count or pending_comment_count %}<span class="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full z-10"></span>{% endif %}
@@ -93,7 +93,7 @@
             <a href="{% url 'page_feedback' path=page.content_path %}" class="dropdown-item">Propose Change</a>
             <a href="{% url 'page_history' path=page.content_path %}" class="dropdown-item">History</a>
             {% endif %}
-            <a href="{% url 'page_backlinks' path=page.content_path %}" class="dropdown-item">What links here</a>
+            <a href="{% url 'page_backlinks' path=page.content_path %}" rel="nofollow" class="dropdown-item">What links here</a>
             <button x-data="copyMarkdown" @click="copy" class="dropdown-item" x-text="label"></button>
             {% if can_delete %}
               <a href="{% url 'page_delete' path=page.content_path %}" class="dropdown-item-danger">Delete</a>
@@ -122,7 +122,7 @@
       <div class="mt-3 flex items-center gap-1.5 flex-wrap">
         {% if people.creator %}
         <span class="mr-0.5 text-gray-400 dark:text-gray-500">Creator:</span>
-        <a href="{% url 'recent_changes_user' username=people.creator|username_local %}" class="badge-green hover:opacity-80">
+        <a href="{% url 'recent_changes_user' username=people.creator|username_local %}" rel="nofollow" class="badge-green hover:opacity-80">
           {% if people.creator.profile.gravatar_url %}
           <img src="{{ people.creator.profile.gravatar_url }}" alt="" class="w-4 h-4 rounded-full">
           {% endif %}
@@ -132,7 +132,7 @@
         {% if people.admins %}
         <span class="ml-2 mr-0.5 text-gray-400 dark:text-gray-500">Admins:</span>
         {% for admin in people.admins %}
-        <a href="{% url 'recent_changes_user' username=admin|username_local %}" class="badge-purple hover:opacity-80">
+        <a href="{% url 'recent_changes_user' username=admin|username_local %}" rel="nofollow" class="badge-purple hover:opacity-80">
           {% if admin.profile.gravatar_url %}
           <img src="{{ admin.profile.gravatar_url }}" alt="" class="w-4 h-4 rounded-full">
           {% endif %}
@@ -143,7 +143,7 @@
         {% if people.editors %}
         <span class="ml-2 mr-0.5 text-gray-400 dark:text-gray-500">Editors:</span>
         {% for editor in people.editors %}
-        <a href="{% url 'recent_changes_user' username=editor|username_local %}" class="badge-blue hover:opacity-80">
+        <a href="{% url 'recent_changes_user' username=editor|username_local %}" rel="nofollow" class="badge-blue hover:opacity-80">
           {% if editor.profile.gravatar_url %}
           <img src="{{ editor.profile.gravatar_url }}" alt="" class="w-4 h-4 rounded-full">
           {% endif %}


### PR DESCRIPTION
## Fixes

Fixes: #83 (the \"Blocked by robots.txt\" / \"Not found\" rows)

## Summary

Google Search Console flags pages whose only inbound links are robots.txt-disallowed without `rel=\"nofollow\"`. Audited the templates rendered to anonymous crawlers (root, `/c/<path>/`, 404) and found seven `<a>` tags that hit Disallow patterns without `nofollow`:

- `assets/templates/cotton/header.html` — Sign in (`/u/login/`)
- `assets/templates/404.html` — \"Sign In to Find Out\" (`/u/login/`)
- `pages/templates/pages/detail.html` — Feedback button (`/c/*/feedback/`), \"What links here\" (`/c/*/backlinks/`), creator/admins/editors badges (`/activity/<user>/`)

All of these are action/activity URLs we don't want indexed regardless, so adding `nofollow` is the right fix (vs. removing the Disallow rules).

The directory-detail action links are all gated by `{% if user.is_authenticated %}` / `{% if can_edit %}`, so crawlers don't see them — no edit needed there.

### Adjacent (not in this PR)

`wiki/lib/markdown.py:594-597` deliberately skips action URLs in the user-content nofollow pass, on the assumption that robots.txt is enough. That's the same assumption Google is now pushing back on. Worth a follow-up if a user writes a markdown link like `[edit me](/c/foo/edit/)` in page content.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

Template-only change; no code paths or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)