### PR TITLE
Clarify that directory grants reach all descendants (incl. private)

### DIFF
--- a/wiki/directories/templates/directories/permissions.html
+++ b/wiki/directories/templates/directories/permissions.html
@@ -10,16 +10,24 @@
     <a href="{{ directory.get_absolute_url }}" class="btn-outline text-sm">Back</a>
   </div>
 
-  <div class="flex items-center justify-between mb-6">
-    <p class="text-sm text-gray-500 dark:text-gray-400">
-      Directory permissions are inherited by all pages and subdirectories within.
+  <div class="rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 mb-4 text-sm text-amber-800 dark:text-amber-200">
+    <p class="font-medium">Grants here apply to everything inside this directory.</p>
+    <p class="mt-1">
+      Anyone you grant — a user, group, or whole domain — can reach
+      <strong>every page and subdirectory within</strong>, including
+      <strong>private</strong> ones and anything added here <strong>later</strong>.
+      This can't be turned off for a specific sub-path, so grant access on the
+      narrowest directory that should be shared rather than a broad parent.
     </p>
+  </div>
+
+  <div class="flex items-center justify-end mb-6">
     {% if directory.path %}
-      <a href="{% url 'directory_apply_permissions' path=directory.path %}" class="btn-outline text-sm whitespace-nowrap ml-4">
+      <a href="{% url 'directory_apply_permissions' path=directory.path %}" class="btn-outline text-sm whitespace-nowrap">
         Apply to children
       </a>
     {% else %}
-      <a href="{% url 'directory_apply_permissions_root' %}" class="btn-outline text-sm whitespace-nowrap ml-4">
+      <a href="{% url 'directory_apply_permissions_root' %}" class="btn-outline text-sm whitespace-nowrap">
         Apply to children
       </a>
     {% endif %}

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -549,10 +549,21 @@ within it and to child directories. For example, if a user
 "Engineering" directory, they can edit any page in that
 directory and its subdirectories.
 
-Access to a parent directory also implies access to its child
-directories. So if you grant someone View on "Engineering",
-they can also see "Engineering / DevOps" (unless that child
-directory is private and they have no grant on it specifically).
+> [!IMPORTANT]
+> A grant on a directory reaches **everything inside it,
+> regardless of visibility** — including **private** pages and
+> subdirectories, and anything added there **in the future**.
+> A grant means "let this user/group/domain in," and that can't
+> be switched off for a specific page or subdirectory underneath.
+> Marking a child **private** does **not** hide it from someone
+> who has a grant on a parent.
+>
+> So grant access on the **narrowest** directory that should be
+> shared — not a broad parent — and remember that anything later
+> filed under a shared directory becomes visible to everyone it's
+> shared with. To keep a pocket of content out, put it **outside**
+> the shared directory rather than relying on its visibility
+> setting.
 
 ### Applying permissions recursively
 


### PR DESCRIPTION
## Fixes
<!-- No tracked issue. -->
Follow-up to #111 (now merged). The new allowlist/grant model lets you grant a **whole domain** access to a directory, and grants **inherit down to every descendant** — but the UI and help text undersold what that means. This makes the consequence obvious so admins don't accidentally over-share.

## Summary
Granting a user/group/**domain** on a directory exposes **everything beneath it, regardless of visibility** — including **private** pages and anything added there later — and inheritance can't be switched off for a specific sub-path. Two doc/UI clarifications:

- **Directory permissions page** (`directories/permissions.html`): replaced the muted one-line "inherited by all pages and subdirectories" note with a prominent amber callout spelling out the full consequence (private content included, future content included, grant the narrowest directory).
- **In-app help** (`seed_help_pages.py`): the inheritance section had an **actively misleading** line claiming a private child is protected from a parent grant *"unless that child directory is private"* — it isn't; explicit grants pierce visibility. Replaced it with an `[!IMPORTANT]` callout describing the real behavior, plus the guidance to keep sensitive content **outside** a shared directory rather than relying on its visibility setting.

No logic changes — this is purely the wording/UI that explains existing behavior.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

1. Re-run `python manage.py seed_help_pages` so the corrected help text replaces the old (misleading) version in the live help pages. The template change ships with the normal web deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
