### PR TITLE
Honor fenced code block language marker for highlight.js

### DIFF
--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -725,6 +725,12 @@ def render_markdown(content, viewer=None):
         content,
         extras=[
             "fenced-code-blocks",
+            # Emit the fence's language as a `language-<lang>` class on the
+            # <code> element (and skip markdown2's own Pygments pass) so the
+            # client-side highlight.js honors the requested language instead
+            # of auto-detecting. A bare ```` ``` ```` fence gets no class and
+            # still auto-detects; ```` ```plaintext ```` disables highlighting.
+            "highlightjs-lang",
             "tables",
             "header-ids",
             "toc",

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -1130,6 +1130,23 @@ class TestMarkdownRendering:
         html = str(render_markdown(md))
         assert "print" in html
 
+    def test_fenced_code_block_language_class(self):
+        """The fence's language is emitted as a class so highlight.js
+        honors it instead of auto-detecting (issue #89)."""
+        html = str(render_markdown("```python\nprint('hello')\n```"))
+        assert 'class="python language-python"' in html
+
+    def test_fenced_code_block_plaintext_disables_highlighting(self):
+        """```plaintext``` carries language-plaintext so highlight.js
+        renders it without syntax highlighting (issue #89)."""
+        html = str(render_markdown("```plaintext\nfooo\n```"))
+        assert 'class="plaintext language-plaintext"' in html
+
+    def test_fenced_code_block_without_language_has_no_class(self):
+        """A bare fence gets no language class (highlight.js auto-detects)."""
+        html = str(render_markdown("```\nfooo\n```"))
+        assert "<code>" in html
+
     def test_tables(self):
         md = "| A | B |\n|---|---|\n| 1 | 2 |"
         html = str(render_markdown(md))


### PR DESCRIPTION
## Fixes
Fixes #89

## Summary
A triple-backtick language marker (e.g. ` ```plaintext `) was being ignored — highlight.js auto-detected the language anyway, so a `plaintext` block could be rendered as `ini`.

**Root cause:** `render_markdown` used markdown2's `fenced-code-blocks` extra *without* `highlightjs-lang`. Without it, markdown2 emits a `<code>` element with **no language class** (and runs its own Pygments pass for recognized languages). The client-side highlight.js (`code-blocks.js`) then ran `hljs.highlightElement()` on every block and, finding no language class, fell back to **auto-detection**.

**Fix:** Added the `highlightjs-lang` extra so markdown2:
- emits `<code class="<lang> language-<lang>">`, letting highlight.js honor the requested language, and
- skips its own Pygments pass entirely, leaving all highlighting to the vendored highlight.js (which is what the `.hljs` GitHub theme in `highlight.css` targets anyway).

Behavior now:
- ` ```plaintext ` → `language-plaintext` → rendered **without** highlighting (the reported case)
- ` ```python ` → `language-python` → highlighted as Python
- bare ` ``` ` → no class → auto-detects (unchanged)

The `language-*` class survives nh3 sanitization (`code` already allows `class`), so it works in both the page detail view and the live editor preview. Added three tests covering the explicit-language, plaintext-disable, and no-language cases.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No special deploy steps. The change is server-rendered HTML, so note the CDN may serve stale pages until cache expiry (existing pages re-render on next save / cache miss).