### PR TITLE
Notify subscribers when pages are created and deleted

### DIFF
--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -586,6 +586,12 @@ def page_create(request, path=""):
             )
 
         _process_mentions_and_grants(page, request)
+        notify_subscribers(
+            page.id,
+            request.user.id,
+            page.change_message,
+            action="created",
+        )
 
         messages.success(request, f'Page "{page.title}" created.')
         return redirect(page.get_absolute_url())
@@ -845,6 +851,14 @@ def page_delete(request, path):
             page.directory.get_absolute_url()
             if page.directory
             else reverse("root")
+        )
+        # Notify before soft-deleting: the default Page manager hides deleted
+        # pages, so notify_subscribers() couldn't re-fetch the page afterward.
+        notify_subscribers(
+            page.id,
+            request.user.id,
+            "",
+            action="deleted",
         )
         page.soft_delete(request.user)
         messages.success(request, f'Page "{title}" deleted.')

--- a/wiki/subscriptions/tasks.py
+++ b/wiki/subscriptions/tasks.py
@@ -24,7 +24,9 @@ def notify_subscribers(
     """Notify all subscribers about a page change.
 
     ``action`` is one of "created", "updated", or "deleted" and controls the
-    email wording. Called synchronously after a page is saved or deleted.
+    email wording. Called synchronously after a save, or *before* a
+    soft-delete: the default Page manager hides deleted rows, so the page
+    must still be visible when this runs (see page_delete).
     """
     page = Page.objects.get(id=page_id)
     editor = User.objects.get(id=editor_id)

--- a/wiki/subscriptions/tasks.py
+++ b/wiki/subscriptions/tasks.py
@@ -14,36 +14,53 @@ from .utils import get_subscriber_info_for_page
 
 
 def notify_subscribers(
-    page_id, editor_id, change_message, prev_rev=None, new_rev=None
+    page_id,
+    editor_id,
+    change_message,
+    prev_rev=None,
+    new_rev=None,
+    action="updated",
 ):
     """Notify all subscribers about a page change.
 
-    Called synchronously after page save.
+    ``action`` is one of "created", "updated", or "deleted" and controls the
+    email wording. Called synchronously after a page is saved or deleted.
     """
     page = Page.objects.get(id=page_id)
     editor = User.objects.get(id=editor_id)
 
     page_sub_user_ids, dir_sub_mapping = get_subscriber_info_for_page(page)
-
-    signer = Signer()
-    base = settings.BASE_URL
-    page_url = (
-        f"{base}{reverse('resolve_path', kwargs={'path': page.content_path})}"
-    )
-
-    # Build diff line if we have both revision numbers
-    diff_line = ""
-    if prev_rev is not None and new_rev is not None and prev_rev >= 1:
-        diff_path = reverse(
-            "page_diff",
-            kwargs={"path": page.content_path, "v1": prev_rev, "v2": new_rev},
-        )
-        diff_url = f"{base}{diff_path}"
-        diff_line = f"Diff: {diff_url}\n\n"
-
     all_user_ids = page_sub_user_ids | set(dir_sub_mapping.keys())
     if not all_user_ids:
         return
+
+    signer = Signer()
+    base = settings.BASE_URL
+    subject = f'[FLP Wiki] "{page.title}" was {action}'
+
+    # A "View" link to a deleted page would 404, and a diff only makes sense
+    # for an update between two revisions.
+    detail_lines = ""
+    if action != "deleted":
+        page_url = f"{base}{reverse('resolve_path', kwargs={'path': page.content_path})}"
+        detail_lines = f"View: {page_url}\n\n"
+        if (
+            action == "updated"
+            and prev_rev is not None
+            and new_rev is not None
+            and prev_rev >= 1
+        ):
+            diff_path = reverse(
+                "page_diff",
+                kwargs={
+                    "path": page.content_path,
+                    "v1": prev_rev,
+                    "v2": new_rev,
+                },
+            )
+            detail_lines += f"Diff: {base}{diff_path}\n\n"
+
+    change_line = f"Change: {change_message}\n\n" if change_message else ""
 
     users = {
         u.id: u
@@ -61,69 +78,47 @@ def notify_subscribers(
         if not can_view_page(user, page):
             continue
 
+        page_token = signer.sign(f"{uid}:{page.id}")
+        page_unsub = (
+            f"{base}{reverse('unsubscribe', kwargs={'token': page_token})}"
+        )
+        page_unsub_one_click = f"{base}{reverse('unsubscribe_one_click', kwargs={'token': page_token})}"
+
         if uid in page_sub_user_ids:
             # Direct page subscriber (page-level override takes priority)
-            token = signer.sign(f"{uid}:{page.id}")
-            unsub_landing = (
-                f"{base}{reverse('unsubscribe', kwargs={'token': token})}"
-            )
-            unsub_one_click = f"{base}{reverse('unsubscribe_one_click', kwargs={'token': token})}"
-
-            body = (
-                f"{display_name(editor)} "
-                f'updated "{page.title}".\n\n'
-                f"Change: {change_message or 'No description'}\n\n"
-                f"View: {page_url}\n\n"
-                f"{diff_line}"
-                f"Unsubscribe: {unsub_landing}"
-            )
-
-            msg = EmailMessage(
-                subject=f'[FLP Wiki] "{page.title}" was updated',
-                body=body,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                to=[user.email],
-                headers={
-                    "List-Unsubscribe": f"<{unsub_one_click}>",
-                    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-                },
-            )
-            msg.send()
-        elif uid in dir_sub_mapping:
+            footer = f"Unsubscribe: {page_unsub}"
+        else:
             # Directory-based subscriber
             directory = dir_sub_mapping[uid]
-            page_token = signer.sign(f"{uid}:{page.id}")
             dir_token = signer.sign(f"d:{uid}:{directory.id}")
-            page_unsub = (
-                f"{base}{reverse('unsubscribe', kwargs={'token': page_token})}"
-            )
             dir_unsub = (
                 f"{base}{reverse('unsubscribe', kwargs={'token': dir_token})}"
             )
-            page_unsub_one_click = f"{base}{reverse('unsubscribe_one_click', kwargs={'token': page_token})}"
-
-            body = (
-                f"{display_name(editor)} "
-                f'updated "{page.title}".\n\n'
-                f"Change: {change_message or 'No description'}\n\n"
-                f"View: {page_url}\n\n"
-                f"{diff_line}"
-                f'You received this because you\'re subscribed to "{directory.title}".\n\n'
+            footer = (
+                f"You received this because you're subscribed to "
+                f'"{directory.title}".\n\n'
                 f"Unsubscribe from this page: {page_unsub}\n"
                 f"Unsubscribe from {directory.title}: {dir_unsub}"
             )
 
-            msg = EmailMessage(
-                subject=f'[FLP Wiki] "{page.title}" was updated',
-                body=body,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                to=[user.email],
-                headers={
-                    "List-Unsubscribe": f"<{page_unsub_one_click}>",
-                    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-                },
-            )
-            msg.send()
+        body = (
+            f'{display_name(editor)} {action} "{page.title}".\n\n'
+            f"{change_line}"
+            f"{detail_lines}"
+            f"{footer}"
+        )
+
+        msg = EmailMessage(
+            subject=subject,
+            body=body,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            to=[user.email],
+            headers={
+                "List-Unsubscribe": f"<{page_unsub_one_click}>",
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+            },
+        )
+        msg.send()
 
 
 def _get_content_snippet(content, username, context_lines=2):

--- a/wiki/subscriptions/tests.py
+++ b/wiki/subscriptions/tests.py
@@ -998,6 +998,124 @@ class TestEditNotifiesSubscribers:
         assert "Dir sub test" in mail.outbox[0].body
 
 
+class TestNotifyActionWording:
+    """The action argument controls subject/body wording and links."""
+
+    def test_created_action(self, user, other_user, page):
+        PageSubscription.objects.create(user=other_user, page=page)
+        notify_subscribers(page.id, user.id, "Add new page", action="created")
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "was created" in msg.subject
+        assert "created" in msg.body
+        # A new page has a working View link but no diff.
+        assert page.get_absolute_url() in msg.body
+        assert "Diff:" not in msg.body
+
+    def test_deleted_action(self, user, other_user, page):
+        PageSubscription.objects.create(user=other_user, page=page)
+        notify_subscribers(page.id, user.id, "", action="deleted")
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "was deleted" in msg.subject
+        assert "deleted" in msg.body
+        # A deleted page would 404, so don't link to it or a diff.
+        assert "View:" not in msg.body
+        assert "Diff:" not in msg.body
+
+    def test_default_action_is_updated(self, user, other_user, page):
+        PageSubscription.objects.create(user=other_user, page=page)
+        notify_subscribers(page.id, user.id, "Change")
+        assert "was updated" in mail.outbox[0].subject
+
+
+class TestCreateNotifiesSubscribers:
+    """Integration: creating a page notifies directory subscribers."""
+
+    def test_create_notifies_directory_subscriber(
+        self, client, user, other_user, sub_directory
+    ):
+        DirectorySubscription.objects.create(
+            user=other_user, directory=sub_directory
+        )
+        client.force_login(user)
+        r = client.post(
+            reverse("page_create"),
+            {
+                "title": "Brand New Page",
+                "content": "Fresh content",
+                "visibility": "public",
+                "editability": "inherit",
+                "in_sitemap": "inherit",
+                "in_llms_txt": "inherit",
+                "change_message": "Add new page",
+                "directory_path": sub_directory.path,
+                "directory_titles": "{}",
+            },
+        )
+        assert r.status_code == 302
+        assert len(mail.outbox) == 1
+        assert other_user.email in mail.outbox[0].to
+        assert "was created" in mail.outbox[0].subject
+
+    def test_create_does_not_notify_creator(self, client, user, sub_directory):
+        """The creator is auto-subscribed but shouldn't email themselves."""
+        DirectorySubscription.objects.create(
+            user=user, directory=sub_directory
+        )
+        client.force_login(user)
+        r = client.post(
+            reverse("page_create"),
+            {
+                "title": "Solo Page",
+                "content": "Content",
+                "visibility": "public",
+                "editability": "inherit",
+                "in_sitemap": "inherit",
+                "in_llms_txt": "inherit",
+                "change_message": "Add new page",
+                "directory_path": sub_directory.path,
+                "directory_titles": "{}",
+            },
+        )
+        assert r.status_code == 302
+        assert len(mail.outbox) == 0
+
+
+class TestDeleteNotifiesSubscribers:
+    """Integration: deleting a page notifies subscribers."""
+
+    def test_delete_notifies_page_subscriber(
+        self, client, user, other_user, page
+    ):
+        PageSubscription.objects.create(user=other_user, page=page)
+        client.force_login(user)
+        r = client.post(
+            reverse("page_delete", kwargs={"path": page.content_path})
+        )
+        assert r.status_code == 302
+        assert len(mail.outbox) == 1
+        assert other_user.email in mail.outbox[0].to
+        assert "was deleted" in mail.outbox[0].subject
+
+    def test_delete_notifies_directory_subscriber(
+        self, client, user, other_user, sub_directory, page_in_directory
+    ):
+        DirectorySubscription.objects.create(
+            user=other_user, directory=sub_directory
+        )
+        client.force_login(user)
+        r = client.post(
+            reverse(
+                "page_delete",
+                kwargs={"path": page_in_directory.content_path},
+            )
+        )
+        assert r.status_code == 302
+        assert len(mail.outbox) == 1
+        assert other_user.email in mail.outbox[0].to
+
+
 # ── Template context tests ───────────────────────────────────────
 
 

--- a/wiki/subscriptions/tests.py
+++ b/wiki/subscriptions/tests.py
@@ -921,6 +921,44 @@ class TestOneClickUnsubscribe:
         ).exists()
 
 
+class TestUnsubscribeForDeletedPage:
+    """Delete notifications link to unsubscribe URLs that are clicked after
+    the page is soft-deleted, so the handlers must resolve soft-deleted
+    pages (Page.all_objects) rather than silently no-op."""
+
+    def test_one_click_unsubscribes_deleted_page(self, client, user, page):
+        PageSubscription.objects.create(user=user, page=page)
+        page.soft_delete(user)
+        signer = Signer()
+        token = signer.sign(f"{user.id}:{page.id}")
+        r = client.post(
+            reverse("unsubscribe_one_click", kwargs={"token": token})
+        )
+        assert r.status_code == 200
+        assert PageSubscription.objects.filter(
+            user=user, page=page, status=U
+        ).exists()
+
+    def test_landing_get_renders_for_deleted_page(self, client, user, page):
+        PageSubscription.objects.create(user=user, page=page)
+        page.soft_delete(user)
+        signer = Signer()
+        token = signer.sign(f"{user.id}:{page.id}")
+        r = client.get(reverse("unsubscribe", kwargs={"token": token}))
+        assert r.status_code == 200
+
+    def test_landing_post_unsubscribes_deleted_page(self, client, user, page):
+        PageSubscription.objects.create(user=user, page=page)
+        page.soft_delete(user)
+        signer = Signer()
+        token = signer.sign(f"{user.id}:{page.id}")
+        r = client.post(reverse("unsubscribe", kwargs={"token": token}))
+        assert r.status_code == 302
+        assert PageSubscription.objects.filter(
+            user=user, page=page, status=U
+        ).exists()
+
+
 # ── Integration tests ────────────────────────────────────────────
 
 

--- a/wiki/subscriptions/views.py
+++ b/wiki/subscriptions/views.py
@@ -119,7 +119,9 @@ def _unsubscribe_page(request, user_id, page_id):
     """Handle page unsubscribe from email link."""
     if request.method == "POST":
         user = User.objects.filter(id=user_id).first()
-        page = Page.objects.filter(id=page_id).first()
+        # Use all_objects: delete notifications link here, so the page is
+        # often soft-deleted by the time the recipient clicks.
+        page = Page.all_objects.filter(id=page_id).first()
         if user and page:
             PageSubscription.objects.update_or_create(
                 user=user,
@@ -129,7 +131,7 @@ def _unsubscribe_page(request, user_id, page_id):
         messages.success(request, "You've been unsubscribed.")
         return redirect("root")
 
-    page = get_object_or_404(Page, id=page_id)
+    page = get_object_or_404(Page.all_objects, id=page_id)
     return render(
         request,
         "subscriptions/unsubscribe.html",
@@ -223,7 +225,9 @@ def unsubscribe_one_click(request, token):
         return HttpResponse("Invalid token", status=400)
 
     user = User.objects.filter(id=user_id).first()
-    page = Page.objects.filter(id=page_id).first()
+    # Use all_objects: delete notifications link here, so the page is
+    # often soft-deleted by the time the recipient clicks.
+    page = Page.all_objects.filter(id=page_id).first()
     if user and page:
         PageSubscription.objects.update_or_create(
             user=user,


### PR DESCRIPTION
## Fixes
Fixes: #85

## Summary
Subscribing to a directory should mean you hear about pages being **added to** or **removed from** it, but `notify_subscribers()` was only invoked on page edits and reverts. New and deleted pages went out silently.

This PR:
- Adds an `action` argument to `notify_subscribers()` (`"created"` / `"updated"` / `"deleted"`, default `"updated"`) that controls the email subject and body wording. Deletions omit the View link (it would 404) and the diff line only appears for updates. While there, the duplicated page-subscriber vs. directory-subscriber email branches were collapsed into one shared body builder.
- Calls `notify_subscribers(..., action="created")` in `page_create` after the page and its mentions are saved.
- Calls `notify_subscribers(..., action="deleted")` in `page_delete` **before** `soft_delete()`. This ordering matters: the default `Page` manager (`ActivePageManager`) hides soft-deleted pages, and `notify_subscribers()` re-fetches the page by id — so notifying after deletion would raise `DoesNotExist`.

The existing view-permission checks, page-vs-directory override resolution, and "don't email the actor" behavior are all reused unchanged.

Adds unit tests for the new action wording/links and integration tests covering create and delete notifications for both page- and directory-level subscribers (and confirming the actor isn't emailed).

**Out of scope:** page *moves* still don't notify. A move can pull a page into or out of a subscribed directory, so that's arguably a related gap, but it's a separate change.

## Deployment

**This PR should:**
 - [x] Skip daemon deploy

No special deployment steps are required.
