### PR TITLE
Fix anonymous preview + add Preview tab to proposal review (#107, #110)

### DIFF
--- a/wiki/assets/static-global/js/alpine-components.js
+++ b/wiki/assets/static-global/js/alpine-components.js
@@ -600,4 +600,23 @@ document.addEventListener('alpine:init', () => {
       return this.showDeny ? 'Cancel' : 'Deny Proposal'
     },
   }))
+
+  // Diff / Preview tab toggle on the proposal review page.
+  Alpine.data('proposalPreview', () => ({
+    view: 'diff',
+    showDiff() { this.view = 'diff' },
+    showPreview() { this.view = 'preview' },
+    get isDiff() { return this.view === 'diff' },
+    get isPreview() { return this.view === 'preview' },
+    get diffTabClass() {
+      return this.view === 'diff'
+        ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+        : 'border-transparent text-gray-500 dark:text-gray-400'
+    },
+    get previewTabClass() {
+      return this.view === 'preview'
+        ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+        : 'border-transparent text-gray-500 dark:text-gray-400'
+    },
+  }))
 })

--- a/wiki/lib/ratelimiter.py
+++ b/wiki/lib/ratelimiter.py
@@ -16,6 +16,11 @@ ratelimit_search = ratelimit(key="user_or_ip", rate="30/m", block=True)
 ratelimit_view_count = ratelimit(
     key="ip", rate="120/m", method=["POST"], block=True
 )
+# Markdown preview is unauthenticated (anonymous users propose changes and
+# preview them) and rendering is CPU-bound, so cap how fast it can be hit.
+ratelimit_preview = ratelimit(
+    key="user_or_ip", rate="30/m", method=["POST"], block=True
+)
 # Caps how fast a single user can create or move pages. Directory-scoped
 # slugs let multiple pages share a name across dirs, so mass-creating
 # colliding slugs could force expensive synchronous link-rewrites on

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -676,11 +676,14 @@ class TestPreviewEndpoint:
         assert r.status_code == 200
         assert b"<h2" in r.content
 
-    def test_preview_requires_login(self, client, db):
-        """Anon access is rejected — rendering resolves #dir/slug and
-        would leak the existence of private pages via URL paths."""
-        r = client.post(reverse("page_preview"), {"content": "test"})
-        assert r.status_code == 302  # redirected to login
+    def test_preview_allows_anonymous(self, client, db):
+        """Anon access renders the preview (issue #107): the proposal form is
+        open to guests, so its Preview tab must be too. Rendering happens as
+        the anonymous viewer, which resolves only public pages, so nothing
+        private leaks (see TestPreviewDoesNotLeakInternalTitles)."""
+        r = client.post(reverse("page_preview"), {"content": "## Hello"})
+        assert r.status_code == 200
+        assert b"<h2" in r.content
 
 
 class TestRecordPageView:

--- a/wiki/pages/tests_access.py
+++ b/wiki/pages/tests_access.py
@@ -74,6 +74,18 @@ class TestPreviewDoesNotLeakInternalTitles:
         assert internal.title not in body
         assert internal.get_absolute_url() not in body
 
+    def test_anonymous_preview_redacts_internal_link(self, client, user):
+        """The preview endpoint is open to anonymous users (issue #107), so a
+        logged-out previewer must not resolve an internal page's title/URL."""
+        internal = self._internal_page(user, "Confidential Roadmap")
+        r = client.post(
+            reverse("page_preview"), {"content": f"See #{internal.slug}"}
+        )
+        assert r.status_code == 200
+        body = r.content.decode()
+        assert internal.title not in body
+        assert internal.get_absolute_url() not in body
+
     def test_staff_preview_resolves_link(self, client, user):
         internal = self._internal_page(user, "Staff Roadmap")
         client.force_login(user)

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -49,6 +49,7 @@ from wiki.lib.permissions import (
 )
 from wiki.lib.ratelimiter import (
     ratelimit_page_write,
+    ratelimit_preview,
     ratelimit_search,
     ratelimit_upload,
     ratelimit_view_count,
@@ -1246,14 +1247,18 @@ def record_page_view(request):
 
 
 @require_POST
-@login_required
+@ratelimit_preview
 def page_preview_htmx(request):
     """Return rendered markdown preview for HTMX requests.
 
-    Gated on auth, and rendered *as the requesting viewer*: wiki-link
+    Open to anonymous users: the proposal form is accessible without login,
+    so its Preview tab must be too (otherwise it renders a login page — see
+    issue #107). Rendering happens *as the requesting viewer*: wiki-link
     resolution emits the target page's title and URL, so previewing must not
     resolve references to pages this user can't view — otherwise a guest
     could enumerate internal page titles/URLs by previewing ``#guessed-slug``.
+    For anonymous viewers this resolves only public pages, which they can
+    already see, so there is nothing to leak.
     """
     content = request.POST.get("content", "")
     rendered = render_markdown(content, viewer=request.user)

--- a/wiki/proposals/templates/proposals/review.html
+++ b/wiki/proposals/templates/proposals/review.html
@@ -27,16 +27,28 @@
   </div>
   {% endif %}
 
-  {% if diff_html %}
-  <div class="mb-6">
-    <h2 class="text-lg font-semibold mb-2">Diff</h2>
-    <div class="font-mono text-sm overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg p-3">
-      {{ diff_html|safe }}
+  <div x-data="proposalPreview" class="mb-6">
+    <div class="flex border-b border-gray-200 dark:border-gray-700 mb-3">
+      <button type="button" @click="showDiff" :class="diffTabClass"
+              class="px-4 py-2 text-sm font-medium border-b-2">Diff</button>
+      <button type="button" @click="showPreview" :class="previewTabClass"
+              class="px-4 py-2 text-sm font-medium border-b-2">Preview</button>
+    </div>
+
+    <div x-show="isDiff">
+      {% if diff_html %}
+      <div class="font-mono text-sm overflow-x-auto border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+        {{ diff_html|safe }}
+      </div>
+      {% else %}
+      <p class="text-gray-500 dark:text-gray-400 italic">No content changes.</p>
+      {% endif %}
+    </div>
+
+    <div x-show="isPreview" x-cloak class="wiki-content card min-h-[200px] p-4">
+      {{ proposed_html|safe }}
     </div>
   </div>
-  {% else %}
-  <p class="text-gray-500 dark:text-gray-400 mb-6 italic">No content changes.</p>
-  {% endif %}
 
   {% if proposal.status == "pending" %}
   <div x-data="proposalReview" class="space-y-4">

--- a/wiki/proposals/tests.py
+++ b/wiki/proposals/tests.py
@@ -211,6 +211,30 @@ class TestProposalReview:
         assert r.status_code == 200
         assert b"Diff" in r.content
 
+    def test_review_renders_proposed_content_preview(
+        self, client, user, other_user, page
+    ):
+        """The review page renders the proposed markdown so the reviewer can
+        preview it, not just read the raw diff (issue #110)."""
+        proposal = ChangeProposal.objects.create(
+            page=page,
+            proposed_by=other_user,
+            proposed_title=page.title,
+            proposed_content="## Proposed Heading\n\nBody text.",
+            change_message="Minor fix",
+        )
+        client.force_login(user)
+        r = client.get(
+            reverse(
+                "proposal_review",
+                kwargs={"path": page.slug, "pk": proposal.pk},
+            )
+        )
+        assert r.status_code == 200
+        assert b"Preview" in r.content
+        assert b"Proposed Heading" in r.content
+        assert b"<h2" in r.content
+
     def test_review_requires_edit_permission(self, client, other_user, page):
         proposal = ChangeProposal.objects.create(
             page=page,

--- a/wiki/proposals/views.py
+++ b/wiki/proposals/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.http import require_POST
 from wiki.comments.forms import CommentForm
 from wiki.comments.models import PageComment
 from wiki.comments.tasks import notify_owner_of_comment
+from wiki.lib.markdown import render_markdown
 from wiki.lib.page_utils import get_page_from_path
 from wiki.lib.permissions import can_edit_page, can_view_page
 from wiki.pages.diff_utils import unified_diff
@@ -142,6 +143,10 @@ def proposal_review(request, path, pk):
     proposal = get_object_or_404(ChangeProposal, pk=pk, page=page)
 
     diff_html = unified_diff(page.content, proposal.proposed_content)
+    # Render as the reviewer so wiki-link resolution respects their access.
+    proposed_html = render_markdown(
+        proposal.proposed_content, viewer=request.user
+    )
 
     return render(
         request,
@@ -150,6 +155,7 @@ def proposal_review(request, path, pk):
             "page": page,
             "proposal": proposal,
             "diff_html": diff_html,
+            "proposed_html": proposed_html,
         },
     )
 


### PR DESCRIPTION
## Fixes

Fixes: #107
Fixes: #110

## Summary

Two preview-related fixes for the proposals flow.

**#107 — Anonymous preview pane showed a login form.** The markdown preview endpoint (`page_preview_htmx`) had `@login_required` re-added at some point, so the **Preview** tab on the proposal form — which anonymous users *can* reach (Feedback > Propose Changes) — rendered a login page instead of the preview. This is a recurrence of #4.

The auth gate was unnecessary for the stated security concern: rendering already happens *as the requesting viewer*, and wiki-link resolution filters references through `can_view_page`. For an anonymous viewer only **public** pages resolve — pages they can already see — so previewing `#some-slug` can't leak internal page titles or URLs.

- Removed `@login_required` from `page_preview_htmx`.
- Added a `@ratelimit_preview` decorator (30/m by `user_or_ip`) since the now-unauthenticated endpoint does CPU-bound markdown rendering.
- Updated `test_preview_requires_login` → `test_preview_allows_anonymous`; added an anonymous-viewer redaction test confirming internal titles/URLs still don't leak.

**#110 — Proposal review page had no rendered preview.** Reviewing a proposal showed only a raw unified diff, with no way to see the proposed markdown rendered. Added a Diff/Preview tab toggle (matching the editor tabs elsewhere): Diff keeps the existing unified diff, Preview renders `proposal.proposed_content` server-side, as the reviewing viewer.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

Web-tier fix; no daemon/cronjob changes.