### PR TITLE
Stop mid-word underscores from becoming emphasis (#106)

### DIFF
--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -539,7 +539,10 @@ _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
-_BOLD_ITALIC_RE = re.compile(r"\*{1,3}|_{1,3}")
+# Asterisk emphasis is stripped anywhere, but underscore emphasis only at word
+# edges, so intra-word underscores in identifiers (PRAY_AND_PAY, snake_case)
+# survive in plain-text extraction — matching the renderer's middle-word-em.
+_BOLD_ITALIC_RE = re.compile(r"\*{1,3}|(?<!\w)_{1,3}|_{1,3}(?!\w)")
 _STRIKETHROUGH_RE = re.compile(r"~~")
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _HR_RE = re.compile(r"^[-*_]{3,}\s*$", re.MULTILINE)
@@ -723,22 +726,28 @@ def render_markdown(content, viewer=None):
     content = resolve_wiki_links(content, viewer=viewer)
     html = markdown2.markdown(
         content,
-        extras=[
-            "fenced-code-blocks",
+        extras={
+            "fenced-code-blocks": None,
             # Emit the fence's language as a `language-<lang>` class on the
             # <code> element (and skip markdown2's own Pygments pass) so the
             # client-side highlight.js honors the requested language instead
             # of auto-detecting. A bare ```` ``` ```` fence gets no class and
             # still auto-detects; ```` ```plaintext ```` disables highlighting.
-            "highlightjs-lang",
-            "tables",
-            "header-ids",
-            "toc",
-            "strike",
-            "task_list",
-            "cuddled-lists",
-            "link-patterns",
-        ],
+            "highlightjs-lang": None,
+            "tables": None,
+            "header-ids": None,
+            "toc": None,
+            "strike": None,
+            "task_list": None,
+            "cuddled-lists": None,
+            "link-patterns": None,
+            # Disallow emphasis in the middle of words so identifiers like
+            # PRAY_AND_PAY or snake_case aren't mangled into PRAY<em>AND</em>PAY.
+            # Edge-of-word _italic_, *italic*, and **bold** still work. Known
+            # trade-off (markdown2 #679): __double-underscore bold__ no longer
+            # renders as <strong>; authors should use **bold** instead.
+            "middle-word-em": False,
+        },
         link_patterns=[(_AUTOLINK_RE, r"\1")],
     )
     toc = getattr(html, "toc_html", "")

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -62,6 +62,19 @@ class TestStripMarkdown:
         assert "italic" in result
         assert "*" not in result
 
+    def test_strips_edge_of_word_underscore_emphasis(self):
+        result = strip_markdown("This is _italic_ and __bold__ text.")
+        assert "italic" in result
+        assert "bold" in result
+        assert "_" not in result
+
+    def test_preserves_intra_word_underscores(self):
+        # Identifiers like PRAY_AND_PAY / snake_case must not be mangled (#106).
+        assert strip_markdown("The PRAY_AND_PAY constant") == (
+            "The PRAY_AND_PAY constant"
+        )
+        assert "snake_case_name" in strip_markdown("a snake_case_name field")
+
     def test_strips_strikethrough(self):
         result = strip_markdown("This is ~~deleted~~ text.")
         assert "deleted" in result
@@ -112,6 +125,37 @@ class TestRenderMarkdownAutolink:
     def test_bare_http_url(self):
         html = render_markdown("See http://example.com for info.")
         assert 'href="http://example.com"' in html
+
+
+class TestRenderMarkdownEmphasis:
+    """Underscores in the middle of words must not become emphasis (#106)."""
+
+    def test_mid_word_underscores_not_emphasized(self):
+        html = render_markdown("The PRAY_AND_PAY constant is fixed.")
+        assert "PRAY_AND_PAY" in html
+        assert "<em>" not in html
+
+    def test_snake_case_preserved(self):
+        html = render_markdown("Set the snake_case_name field.")
+        assert "snake_case_name" in html
+        assert "<em>" not in html
+
+    def test_edge_of_word_underscore_still_italic(self):
+        html = render_markdown("This is _really_ important.")
+        assert "<em>really</em>" in html
+
+    def test_double_underscore_bold_known_limitation(self):
+        # Accepted trade-off of the middle-word-em extra (markdown2 #679):
+        # __double underscore bold__ is not rendered as <strong>. Authors
+        # should use **bold** instead. Documented here so the behavior is
+        # an explicit choice, not a silent regression.
+        html = render_markdown("This is __very__ important.")
+        assert "<strong>very</strong>" not in html
+
+    def test_star_emphasis_unaffected(self):
+        html = render_markdown("Use *stars* and **double stars**.")
+        assert "<em>stars</em>" in html
+        assert "<strong>double stars</strong>" in html
 
 
 class TestExtractSlugsFromInternalUrls:


### PR DESCRIPTION
## Fixes
Fixes: #106

## Summary
Words with embedded underscores like `PRAY_AND_PAY` were rendered as `PRAY<em>AND</em>PAY` because markdown2 treats intra-word underscores as emphasis delimiters by default.

This PR enables markdown2's `middle-word-em: False` extra so underscore emphasis is only honored at word edges:

- `PRAY_AND_PAY`, `snake_case` → rendered literally (fixed)
- `_italic_`, `*italic*`, `**bold**` → still work

It also applies the same word-edge rule to `strip_markdown`, the plain-text extraction used for SEO meta descriptions and search snippets, which had the identical bug (`PRAY_AND_PAY` → `PRAYANDPAY`).

**Trade-off / gotcha:** `middle-word-em: False` triggers markdown2 upstream bug [#679](https://github.com/trentm/python-markdown2/issues/679), so `__double-underscore bold__` no longer renders as `<strong>` (it comes out as `<em>_bold_</em>`). Authors should use `**bold**` instead. This was a deliberate choice over the `code-friendly` extra (which would have disabled `_italic_` entirely). The limitation is documented in a code comment and pinned by `test_double_underscore_bold_known_limitation`. I audited the built-in seeded help pages and the `wiki-exports` docs — none use `__bold__`, and their many `snake_case`/ORM-lookup identifiers (`cluster__docket__court`, `__name__`) are either in code spans or now render correctly.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

Markdown rendering is computed at request time, so no migration or data backfill is needed; existing pages will simply render correctly on next view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)