### PR TITLE
Fix multi-line Django comment rendering on page form

### DIFF
--- a/wiki/pages/templates/pages/form.html
+++ b/wiki/pages/templates/pages/form.html
@@ -21,9 +21,9 @@
         data-inherited-visibility="{{ inherit_meta.visibility.value|default:'' }}">
     {% csrf_token %}
 
-    {# Location picker — only when the user may set/change the page's
+    {% comment %} Location picker — only when the user may set/change the page's
        directory (creation, or editing as an administrator). Reparenting can
-       change an inherit-visibility page's effective visibility. #}
+       change an inherit-visibility page's effective visibility. {% endcomment %}
     {% if show_location_picker %}
     <div>
       <label class="block text-sm font-medium mb-1">Location</label>


### PR DESCRIPTION
## Fixes
This fixes the stray template comment text that rendered at the top of the New Page form.

## Summary
Django's `{# #}` inline comment syntax only works on a single line. The location-picker comment in `wiki/pages/templates/pages/form.html` spanned three lines, so the closing `#}` was never recognized and the comment text was emitted into the rendered HTML — showing up at the top of the New Page form.

Switched it to a `{% comment %}{% endcomment %}` block, which is the correct way to write multi-line comments in Django templates. The other `{# #}` comments in the file are all single-line and were unaffected.

## Deployment

**This PR should:**
- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`