### PR TITLE
Normalize search visibility to effective values

### DIFF
--- a/wiki/lib/inheritance.py
+++ b/wiki/lib/inheritance.py
@@ -74,6 +74,21 @@ def _resolve_directory_value(directory, field_name):
     return _FIELD_DEFAULTS[field_name], directory
 
 
+def effective_value_from_map(raw_value, directory_id, resolved, field_name):
+    """Resolve a raw field value using a resolve_all_directory_settings map.
+
+    Returns ``raw_value`` when it's explicit; for "inherit", returns the
+    owning directory's effective value from ``resolved``, falling back to
+    the field default when there's no directory to inherit from.
+    """
+    if raw_value != "inherit":
+        return raw_value
+    entry = resolved.get(directory_id)
+    if entry is None:
+        return _FIELD_DEFAULTS[field_name]
+    return entry[0]
+
+
 def resolve_all_directory_settings(field_name):
     """Bulk resolve all directories for a single field.
 

--- a/wiki/lib/inheritance.py
+++ b/wiki/lib/inheritance.py
@@ -74,6 +74,11 @@ def _resolve_directory_value(directory, field_name):
     return _FIELD_DEFAULTS[field_name], directory
 
 
+def field_default(field_name):
+    """Return the fallback default used when inheritance can't resolve."""
+    return _FIELD_DEFAULTS[field_name]
+
+
 def effective_value_from_map(raw_value, directory_id, resolved, field_name):
     """Resolve a raw field value using a resolve_all_directory_settings map.
 

--- a/wiki/pages/search.py
+++ b/wiki/pages/search.py
@@ -70,17 +70,19 @@ def _apply_filters(qs, parsed):
         qs = qs.filter(owner_q)
 
     if parsed.visibility:
-        # Include both explicit and inherited matches
+        # Filter on effective visibility: explicit matches plus pages that
+        # inherit the value from their directory. "inherit" itself is never
+        # an effective visibility, so filtering on it matches nothing.
         resolved = resolve_all_directory_settings("visibility")
         matching_dir_ids = {
             dir_id
             for dir_id, (eff_value, _, _) in resolved.items()
             if eff_value == parsed.visibility
         }
-        qs = qs.filter(
-            Q(visibility=parsed.visibility)
-            | Q(visibility="inherit", directory_id__in=matching_dir_ids)
-        )
+        vis_q = Q(visibility="inherit", directory_id__in=matching_dir_ids)
+        if parsed.visibility != "inherit":
+            vis_q |= Q(visibility=parsed.visibility)
+        qs = qs.filter(vis_q)
 
     if parsed.before_date:
         qs = qs.filter(updated_at__date__lte=parsed.before_date)

--- a/wiki/pages/search.py
+++ b/wiki/pages/search.py
@@ -14,7 +14,10 @@ from django.contrib.postgres.search import (
 )
 from django.db.models import F, Q, Value
 
-from wiki.lib.inheritance import resolve_all_directory_settings
+from wiki.lib.inheritance import (
+    field_default,
+    resolve_all_directory_settings,
+)
 from wiki.lib.permissions import viewable_pages_q
 
 from .models import Page
@@ -80,6 +83,12 @@ def _apply_filters(qs, parsed):
             if eff_value == parsed.visibility
         }
         vis_q = Q(visibility="inherit", directory_id__in=matching_dir_ids)
+        if parsed.visibility == field_default("visibility"):
+            # Directory-less inherit pages have no parent to resolve from
+            # and fall back to the field default — mirror viewable_pages_q
+            # and effective_value_from_map so the facet count and the
+            # filtered results agree.
+            vis_q |= Q(visibility="inherit", directory__isnull=True)
         if parsed.visibility != "inherit":
             vis_q |= Q(visibility=parsed.visibility)
         qs = qs.filter(vis_q)

--- a/wiki/pages/templates/pages/search.html
+++ b/wiki/pages/templates/pages/search.html
@@ -189,7 +189,7 @@
               <h3 class="text-base font-medium text-gray-900 dark:text-gray-100 group-hover:text-primary-700 dark:group-hover:text-primary-400 transition-colors">
                 {{ page.title }}
               </h3>
-              <c-visibility-badge visibility="{{ page.visibility }}" />
+              <c-visibility-badge visibility="{{ page.effective_visibility }}" />
               <c-domain-access-badges :domains="page.access_domains" />
             </div>
             {% if page.headline %}

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -2964,6 +2964,32 @@ class TestSearchVisibilityNormalization:
         r = client.get(f"{reverse('search')}?q=effvisterm is:inherit")
         assert r.context["total_count"] == 0
 
+    def test_directoryless_inherit_page_counts_and_filters_as_public(
+        self, client, user
+    ):
+        """A page with no directory and visibility="inherit" resolves to
+        the field default (public). The Public facet count and the Public
+        filter must agree on it (PR #125 review)."""
+        Page.objects.create(
+            title="Orphaned Inherit Page",
+            content="effvisterm content",
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility=Page.Visibility.INHERIT,
+        )
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm")
+        facet_values = {
+            f["visibility"]: f["count"]
+            for f in r.context["facets"]["visibility"]
+        }
+        assert facet_values == {"public": 1}
+
+        r = client.get(f"{reverse('search')}?q=effvisterm&visibility=public")
+        assert r.context["total_count"] == 1
+        assert "Orphaned Inherit Page" in r.content.decode()
+
     def test_inherited_private_page_shows_lock_icon(
         self, client, user, inherited_private_page
     ):

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -2894,6 +2894,86 @@ class TestSearchView:
         assert b'title="Staff"' in r.content
 
 
+class TestSearchVisibilityNormalization:
+    """Search treats visibility as effective values: pages set to "inherit"
+    resolve to their directory's visibility in facets, filters, and result
+    badges — "inherit" is never surfaced as a visibility."""
+
+    @pytest.fixture
+    def inherited_private_page(self, user, private_directory):
+        return Page.objects.create(
+            title="Inherited Private Page",
+            content="effvisterm content",
+            directory=private_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility=Page.Visibility.INHERIT,
+        )
+
+    @pytest.fixture
+    def explicit_public_page(self, user, root_directory):
+        return Page.objects.create(
+            title="Explicit Public Page",
+            content="effvisterm content",
+            directory=root_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility=Page.Visibility.PUBLIC,
+        )
+
+    def test_facets_resolve_inherit_to_effective_visibility(
+        self, client, user, inherited_private_page, explicit_public_page
+    ):
+        """The visibility facet should count inheriting pages under their
+        directory's effective visibility, never offer "inherit"."""
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm")
+        facet_values = {
+            f["visibility"]: f["count"]
+            for f in r.context["facets"]["visibility"]
+        }
+        assert "inherit" not in facet_values
+        assert facet_values == {"public": 1, "private": 1}
+
+    def test_private_filter_includes_inherited_private(
+        self, client, user, inherited_private_page, explicit_public_page
+    ):
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm&visibility=private")
+        content = r.content.decode()
+        assert "Inherited Private Page" in content
+        assert "Explicit Public Page" not in content
+
+    def test_public_filter_excludes_inherited_private(
+        self, client, user, inherited_private_page, explicit_public_page
+    ):
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm&visibility=public")
+        content = r.content.decode()
+        assert "Explicit Public Page" in content
+        assert "Inherited Private Page" not in content
+
+    def test_inherit_filter_matches_nothing(
+        self, client, user, inherited_private_page, explicit_public_page
+    ):
+        """ "inherit" is not an effective visibility, so filtering on it
+        should return no results rather than a mix of public and private."""
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm is:inherit")
+        assert r.context["total_count"] == 0
+
+    def test_inherited_private_page_shows_lock_icon(
+        self, client, user, inherited_private_page
+    ):
+        """Result badges should reflect effective visibility, so a page
+        inheriting "private" gets the lock icon."""
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=effvisterm")
+        assert b'title="Private"' in r.content
+
+
 class TestZeroResultSearch:
     """No-result searches are tallied anonymously by query + audience."""
 

--- a/wiki/pages/views_search.py
+++ b/wiki/pages/views_search.py
@@ -10,6 +10,10 @@ from django.utils import timezone
 
 from wiki.directories.models import Directory
 from wiki.lib.access import is_internal_user
+from wiki.lib.inheritance import (
+    effective_value_from_map,
+    resolve_all_directory_settings,
+)
 from wiki.lib.permissions import annotate_access_domains
 from wiki.lib.ratelimiter import ratelimit_search
 
@@ -28,20 +32,40 @@ def _parse_url_date(value):
         return None
 
 
-def _compute_facets(qs):
-    """Compute directory and visibility facets from the queryset."""
+def _compute_facets(qs, resolved_visibility):
+    """Compute directory and visibility facets from the queryset.
+
+    Visibility counts use effective values — pages set to "inherit" count
+    toward their directory's resolved visibility, so the facet only ever
+    offers real visibilities (public/internal/private), never "inherit".
+    """
     directory_facets = (
         qs.exclude(directory__isnull=True)
         .values("directory__path", "directory__title")
         .annotate(count=Count("id"))
         .order_by("-count")[:10]
     )
-    visibility_facets = (
-        qs.values("visibility").annotate(count=Count("id")).order_by("-count")
-    )
+    visibility_counts = {}
+    rows = qs.values("visibility", "directory_id").annotate(count=Count("id"))
+    for row in rows:
+        effective = effective_value_from_map(
+            row["visibility"],
+            row["directory_id"],
+            resolved_visibility,
+            "visibility",
+        )
+        visibility_counts[effective] = (
+            visibility_counts.get(effective, 0) + row["count"]
+        )
+    visibility_facets = [
+        {"visibility": value, "count": count}
+        for value, count in sorted(
+            visibility_counts.items(), key=lambda item: -item[1]
+        )
+    ]
     return {
         "directories": list(directory_facets),
-        "visibility": list(visibility_facets),
+        "visibility": visibility_facets,
     }
 
 
@@ -199,7 +223,8 @@ def search_view(request):
         _record_zero_result_search(search_query_text, request.user)
 
     # Compute facets from the full queryset (before pagination)
-    facets = _compute_facets(qs)
+    resolved_visibility = resolve_all_directory_settings("visibility")
+    facets = _compute_facets(qs, resolved_visibility)
 
     paginator = Paginator(qs, settings.SEARCH_RESULTS_PER_PAGE)
     try:
@@ -207,6 +232,16 @@ def search_view(request):
     except (ValueError, TypeError):
         page_num = 1
     page_obj = paginator.get_page(page_num)
+
+    # Resolve inherited visibility so result badges reflect the effective
+    # value, not the raw "inherit" setting.
+    for result in page_obj.object_list:
+        result.effective_visibility = effective_value_from_map(
+            result.visibility,
+            result.directory_id,
+            resolved_visibility,
+            "visibility",
+        )
 
     # Staff-only: annotate this page of results with the outside domains that
     # can reach each result, for the access badges.


### PR DESCRIPTION
## Fixes
Fixes: #124

## Summary
Pages whose visibility is set to `inherit` were surfaced in search as a distinct "Inherit" visibility. The facet sidebar offered it as a filter, and clicking it returned a mixture of public and private pages, since "inherit" isn't a real visibility — it's a pointer at the directory's setting.

This PR normalizes search to *effective* visibility everywhere:

- **Facets**: `_compute_facets()` now groups counts by `(visibility, directory_id)` and resolves `inherit` rows to the directory's effective value via the existing `resolve_all_directory_settings()` bulk map, so the sidebar only ever offers Public/Staff/Private.
- **Filtering**: the `is:`/`visibility=` filter already resolved inheritance for real values, but `is:inherit` matched every raw-inherit page regardless of effective visibility. It now matches nothing.
- **Result badges**: results are annotated with `effective_visibility`, so a page inheriting "private" shows the lock icon (previously inherit pages showed no badge at all).
- Added a small shared helper, `effective_value_from_map()`, to `wiki/lib/inheritance.py` for resolving a raw value against the bulk directory map, used by both the facets and the badge annotation.

No new UI components — the change only affects which values appear in the existing facet list and badges, so no screenshots.

Tested with a new `TestSearchVisibilityNormalization` class (facets, both filter directions, `is:inherit`, badge icon); full suite passes (1087 tests).

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)