### PR TITLE
Carry ?next= through the magic link sign-in flow

### DIFF
--- a/wiki/assets/templates/cotton/header.html
+++ b/wiki/assets/templates/cotton/header.html
@@ -132,7 +132,7 @@
           </button>
         </form>
       {% else %}
-        <a href="{% url 'login' %}" rel="nofollow" class="btn-outline text-sm py-1.5">Sign in</a>
+        <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}" rel="nofollow" class="btn-outline text-sm py-1.5">Sign in</a>
       {% endif %}
     </nav>
   </div>

--- a/wiki/users/tasks.py
+++ b/wiki/users/tasks.py
@@ -1,4 +1,5 @@
 import sys
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -92,16 +93,20 @@ def notify_email_access_granted(email):
     )
 
 
-def send_magic_link_email(email, raw_token):
+def send_magic_link_email(email, raw_token, next_url=""):
     """Send the magic link sign-in email.
 
     Called synchronously. Fast via SES in prod, instant via
     console backend in dev.
+
+    ``next_url`` (a same-host path, already validated by the caller) rides
+    along on the verify link so the user lands back on the page they
+    originally requested after signing in.
     """
-    verify_url = (
-        f"{settings.BASE_URL}{reverse('verify')}"
-        f"?token={raw_token}&email={email}"
-    )
+    params = {"token": raw_token, "email": email}
+    if next_url:
+        params["next"] = next_url
+    verify_url = f"{settings.BASE_URL}{reverse('verify')}?{urlencode(params)}"
 
     body = (
         f"Click the link below to sign in:\n\n"

--- a/wiki/users/templates/users/login.html
+++ b/wiki/users/templates/users/login.html
@@ -13,6 +13,9 @@
   <div class="card">
     <form method="post">
       {% csrf_token %}
+      {% if next_url %}
+      <input type="hidden" name="next" value="{{ next_url }}">
+      {% endif %}
       <div class="space-y-4">
         <div>
           <label for="id_email" class="block text-sm font-medium mb-1.5">Email</label>

--- a/wiki/users/tests.py
+++ b/wiki/users/tests.py
@@ -202,6 +202,24 @@ class TestNextRedirect:
         assert r.status_code == 302
         assert r.url == "/c/some-page/"
 
+    def test_verify_ignores_bare_pattern_name_next(self, client, db):
+        # SECURITY: a schemeless, hostless string like "admin_list" passes
+        # url_has_allowed_host_and_scheme but redirect() would reverse() it
+        # as a URL pattern name (or 500 on NoReverseMatch). Only real paths
+        # (leading slash) may pass through.
+        client.post(reverse("login"), {"email": "alice@free.law"})
+        token = re.search(r"token=([^&]+)", mail.outbox[0].body).group(1)
+        r = client.get(
+            reverse("verify"),
+            {
+                "token": token,
+                "email": "alice@free.law",
+                "next": "admin_list",
+            },
+        )
+        assert r.status_code == 302
+        assert r.url == reverse("root")
+
     def test_verify_ignores_offsite_next(self, client, db):
         # SECURITY: the verify link is attacker-composable, so an off-host
         # next must fall back to root instead of redirecting away.

--- a/wiki/users/tests.py
+++ b/wiki/users/tests.py
@@ -147,6 +147,96 @@ class TestMagicLinkFlow:
         assert r.status_code == 302
 
 
+class TestNextRedirect:
+    """The ?next= target must survive the whole magic link round trip."""
+
+    def _magic_link_query(self):
+        """Parse the verify URL's query string out of the sent email."""
+        m = re.search(r"\?(\S+)", mail.outbox[0].body)
+        return m.group(1)
+
+    def test_login_page_renders_hidden_next_field(self, client, db):
+        r = client.get(reverse("login"), {"next": "/c/some-page/"})
+        assert b'name="next" value="/c/some-page/"' in r.content
+
+    def test_login_page_drops_offsite_next(self, client, db):
+        # SECURITY: an off-host next must not propagate (open redirect).
+        r = client.get(reverse("login"), {"next": "https://evil.example.com/"})
+        assert b'name="next"' not in r.content
+
+    def test_next_carried_into_magic_link(self, client, db):
+        client.post(
+            reverse("login"),
+            {"email": "alice@free.law", "next": "/c/some-page/"},
+        )
+        assert "next=%2Fc%2Fsome-page%2F" in self._magic_link_query()
+
+    def test_offsite_next_dropped_from_magic_link(self, client, db):
+        client.post(
+            reverse("login"),
+            {"email": "alice@free.law", "next": "https://evil.example.com/"},
+        )
+        assert "next=" not in self._magic_link_query()
+
+    def test_post_redirect_preserves_next(self, client, db):
+        r = client.post(
+            reverse("login"),
+            {"email": "alice@free.law", "next": "/c/some-page/"},
+        )
+        assert r.url == reverse("login") + "?next=%2Fc%2Fsome-page%2F"
+
+    def test_verify_redirects_to_next(self, client, db):
+        client.post(
+            reverse("login"),
+            {"email": "alice@free.law", "next": "/c/some-page/"},
+        )
+        token = re.search(r"token=([^&]+)", mail.outbox[0].body).group(1)
+        r = client.get(
+            reverse("verify"),
+            {
+                "token": token,
+                "email": "alice@free.law",
+                "next": "/c/some-page/",
+            },
+        )
+        assert r.status_code == 302
+        assert r.url == "/c/some-page/"
+
+    def test_verify_ignores_offsite_next(self, client, db):
+        # SECURITY: the verify link is attacker-composable, so an off-host
+        # next must fall back to root instead of redirecting away.
+        client.post(reverse("login"), {"email": "alice@free.law"})
+        token = re.search(r"token=([^&]+)", mail.outbox[0].body).group(1)
+        r = client.get(
+            reverse("verify"),
+            {
+                "token": token,
+                "email": "alice@free.law",
+                "next": "https://evil.example.com/",
+            },
+        )
+        assert r.status_code == 302
+        assert r.url == reverse("root")
+
+    def test_authenticated_user_follows_next_from_login(self, client, user):
+        client.force_login(user)
+        r = client.get(reverse("login"), {"next": "/c/some-page/"})
+        assert r.status_code == 302
+        assert r.url == "/c/some-page/"
+
+    def test_login_required_page_links_next_through_form(self, client, db):
+        # End to end: a protected page bounces to login?next=..., and that
+        # value must come back out of the rendered form.
+        settings_url = reverse("user_settings")
+        r = client.get(settings_url)
+        assert r.status_code == 302
+        login_url = r.url
+        assert "?next=" in login_url
+        r = client.get(login_url)
+        expected = f'name="next" value="{settings_url}"'
+        assert expected.encode() in r.content
+
+
 class TestLogout:
     def test_logout_via_post(self, client, user):
         client.force_login(user)

--- a/wiki/users/views.py
+++ b/wiki/users/views.py
@@ -1,4 +1,5 @@
 import secrets
+from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth import login, logout
@@ -8,6 +9,8 @@ from django.db import transaction
 from django.db.models import Q
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.cache import cache_control
 
 from wiki.lib.access import is_email_allowed, is_internal_user
@@ -39,12 +42,26 @@ from wiki.users.tasks import (
 )
 
 
+def _safe_next_url(request, url):
+    """Return ``url`` if it's a safe same-host redirect target, else ""."""
+    if url and url_has_allowed_host_and_scheme(
+        url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return url
+    return ""
+
+
 # SECURITY: rate limit login POSTs to prevent magic link email spam.
 @ratelimit_login
 def login_view(request):
     """Show login form and send magic link email."""
+    next_url = _safe_next_url(
+        request, request.POST.get("next") or request.GET.get("next")
+    )
     if request.user.is_authenticated:
-        return redirect("root")
+        return redirect(next_url or "root")
 
     form = LoginForm(request.POST or None)
     if request.method == "POST" and form.is_valid():
@@ -81,16 +98,23 @@ def login_view(request):
                 raw_token = secrets.token_urlsafe(32)
                 profile.set_magic_token(raw_token)
                 profile.save()
-                send_magic_link_email(email, raw_token)
+                send_magic_link_email(email, raw_token, next_url=next_url)
 
         messages.success(
             request,
             "If that address is allowed to sign in, we've emailed a "
             "sign-in link. It expires in 15 minutes.",
         )
-        return redirect("login")
+        # Keep ?next= on the post-submit page so a retry (e.g. after a
+        # typo'd address) still lands the user on their original page.
+        login_url = reverse("login")
+        if next_url:
+            login_url += "?" + urlencode({"next": next_url})
+        return redirect(login_url)
 
-    return render(request, "users/login.html", {"form": form})
+    return render(
+        request, "users/login.html", {"form": form, "next_url": next_url}
+    )
 
 
 def verify_view(request):
@@ -138,7 +162,10 @@ def verify_view(request):
             backend="django.contrib.auth.backends.ModelBackend",
         )
         messages.success(request, "You're now signed in.")
-        return redirect("root")
+        # The link's next param is attacker-influenced (anyone can compose
+        # a verify URL), so only follow it to a same-host destination.
+        next_url = _safe_next_url(request, request.GET.get("next"))
+        return redirect(next_url or "root")
     else:
         messages.error(request, "This sign-in link has expired or is invalid.")
         return redirect("login")

--- a/wiki/users/views.py
+++ b/wiki/users/views.py
@@ -43,11 +43,19 @@ from wiki.users.tasks import (
 
 
 def _safe_next_url(request, url):
-    """Return ``url`` if it's a safe same-host redirect target, else ""."""
-    if url and url_has_allowed_host_and_scheme(
-        url,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
+    """Return ``url`` if it's a safe same-host redirect target, else "".
+
+    The leading-slash check keeps bare strings (e.g. "admin_list") out of
+    ``redirect()``, which would otherwise reverse() them as pattern names.
+    """
+    if (
+        url
+        and url.startswith("/")
+        and url_has_allowed_host_and_scheme(
+            url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        )
     ):
         return url
     return ""


### PR DESCRIPTION
## Fixes
Fixes: #126

## Summary
Clicking a link to a protected wiki page while signed out redirects to the login form with `?next=`, but that destination was dropped on the floor: after redeeming the magic link you always landed on the wiki root and had to hunt down the page you wanted.

This threads `next` through the entire chain:

1. **Login form** renders a hidden `next` input (populated from the querystring `login_required` already appends).
2. **Login POST** passes it to `send_magic_link_email()`, which adds it as a query param on the verify URL in the email. The post-submit redirect also keeps `?next=` so a retry after a typo'd address still works.
3. **`verify_view`** redirects to `next` after a successful sign-in, falling back to root.
4. The **header's "Sign in" link** now passes the current page as `next` too, matching what the 404 page already did (its `?next=` was previously ignored).

**Security:** the value is validated with Django's `url_has_allowed_host_and_scheme()` both when the email is sent and again at redemption — the verify link is attacker-composable, so an off-host or protocol-relative `next` is dropped and the user lands on root. Covered by tests and verified by hand against the running dev server (including offsite and `//host` probes).

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)