### PR TITLE
Pin full-text search config to english

### DIFF
--- a/wiki/pages/migrations/0021_rebuild_search_vectors_english.py
+++ b/wiki/pages/migrations/0021_rebuild_search_vectors_english.py
@@ -1,0 +1,32 @@
+"""Rebuild search vectors with an explicit english config.
+
+Vectors were previously built with the server's default_text_search_config,
+which varies by environment (e.g. "simple" on some CI/production images and
+no stemming as a result). Now that SearchVector/SearchQuery pin
+config="english", rebuild stored vectors so they match at query time.
+"""
+
+from django.contrib.postgres.search import SearchVector
+from django.db import migrations
+
+SEARCH_CONFIG = "english"
+
+
+def rebuild_search_vectors(apps, schema_editor):
+    Page = apps.get_model("pages", "Page")
+    Page.objects.update(
+        search_vector=SearchVector("title", weight="A", config=SEARCH_CONFIG)
+        + SearchVector("content", weight="B", config=SEARCH_CONFIG)
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pages", "0020_zeroresultsearch"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rebuild_search_vectors, migrations.RunPython.noop
+        ),
+    ]

--- a/wiki/pages/models.py
+++ b/wiki/pages/models.py
@@ -8,6 +8,11 @@ from django.utils.text import slugify
 
 from wiki.lib.path_utils import page_path_conflicts_with_directory
 
+# Explicit text search config so stemming works ("demos" matches "demo")
+# regardless of the Postgres server's default_text_search_config, which
+# varies with the build's locale (e.g. "simple" on some CI images).
+SEARCH_CONFIG = "english"
+
 
 class ActivePageManager(models.Manager):
     """Default manager — excludes soft-deleted pages."""
@@ -294,8 +299,10 @@ class Page(models.Model):
     def _update_search_vector(self):
         """Update the search_vector for this page in the DB."""
         Page.all_objects.filter(pk=self.pk).update(
-            search_vector=SearchVector("title", weight="A")
-            + SearchVector("content", weight="B")
+            search_vector=SearchVector(
+                "title", weight="A", config=SEARCH_CONFIG
+            )
+            + SearchVector("content", weight="B", config=SEARCH_CONFIG)
         )
 
     @property

--- a/wiki/pages/search.py
+++ b/wiki/pages/search.py
@@ -20,7 +20,7 @@ from wiki.lib.inheritance import (
 )
 from wiki.lib.permissions import viewable_pages_q
 
-from .models import Page
+from .models import SEARCH_CONFIG, Page
 
 SORT_OPTIONS = [
     ("relevance", "Relevance"),
@@ -40,9 +40,13 @@ def _build_search_query(parsed):
     """
     queries = []
     if parsed.text:
-        queries.append(SearchQuery(parsed.text, search_type="plain"))
+        queries.append(
+            SearchQuery(parsed.text, search_type="plain", config=SEARCH_CONFIG)
+        )
     for phrase in parsed.phrases:
-        queries.append(SearchQuery(phrase, search_type="phrase"))
+        queries.append(
+            SearchQuery(phrase, search_type="phrase", config=SEARCH_CONFIG)
+        )
 
     if not queries:
         return None
@@ -141,6 +145,7 @@ def search_pages(parsed, user=None, sort="relevance"):
             headline=SearchHeadline(
                 "content",
                 query,
+                config=SEARCH_CONFIG,
                 start_sel="<mark>",
                 stop_sel="</mark>",
                 max_words=60,

--- a/wiki/pages/tasks.py
+++ b/wiki/pages/tasks.py
@@ -12,7 +12,7 @@ from django.db.models import F, Sum
 from django.utils import timezone
 from PIL import Image
 
-from .models import FileUpload, Page, PageViewTally
+from .models import SEARCH_CONFIG, FileUpload, Page, PageViewTally
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ def update_search_vectors():
     Returns the number of pages updated.
     """
     count = Page.objects.update(
-        search_vector=SearchVector("title", weight="A")
-        + SearchVector("content", weight="B")
+        search_vector=SearchVector("title", weight="A", config=SEARCH_CONFIG)
+        + SearchVector("content", weight="B", config=SEARCH_CONFIG)
     )
     return count
 

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -11,6 +11,7 @@ from django.contrib.sessions.models import Session
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
+from django.db import connection
 from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
@@ -2892,6 +2893,47 @@ class TestSearchView:
         r = client.get(f"{reverse('search')}?q=badgeterm")
         # Building icon for internal (staff) visibility.
         assert b'title="Staff"' in r.content
+
+
+class TestSearchStemming:
+    """Stemming must work regardless of the server's
+    default_text_search_config, which varies by environment (issue #123)."""
+
+    def test_stemming_survives_simple_server_default(self, client, user):
+        # SET LOCAL reverts when the test's wrapping transaction rolls
+        # back, so other tests are unaffected.
+        with connection.cursor() as cursor:
+            cursor.execute("SET LOCAL default_text_search_config = 'simple'")
+        Page.objects.create(
+            title="Recorded Demos",
+            content="A collection of demos we have recorded.",
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility=Page.Visibility.PUBLIC,
+        )
+        client.force_login(user)
+        r = client.get(f"{reverse('search')}?q=demo")
+        assert r.status_code == 200
+        assert "Recorded Demos" in r.content.decode()
+
+    def test_phrase_stemming_survives_simple_server_default(
+        self, client, user
+    ):
+        with connection.cursor() as cursor:
+            cursor.execute("SET LOCAL default_text_search_config = 'simple'")
+        Page.objects.create(
+            title="Training Sessions",
+            content="We give recorded demos to new employees.",
+            owner=user,
+            created_by=user,
+            updated_by=user,
+            visibility=Page.Visibility.PUBLIC,
+        )
+        client.force_login(user)
+        r = client.get(f'{reverse("search")}?q="recorded demo"')
+        assert r.status_code == 200
+        assert "Training Sessions" in r.content.decode()
 
 
 class TestSearchVisibilityNormalization:


### PR DESCRIPTION
## Fixes
Fixes: #123

## Summary
Full-text search relied on the Postgres server's `default_text_search_config`, which varies with the image's build locale — `pg_catalog.english` on locale-aware local Postgres, but often `simple` on CI-built images. With `simple` there is no stemming, so a search for "demo" wouldn't match a page containing "demos".

Rather than trying to control the server setting in every environment, this pins `config="english"` explicitly at every call site, which makes search behavior independent of the server default:

- `SearchVector` in `Page._update_search_vector()` and the `update_search_vectors` cron task
- `SearchQuery` (both plain and phrase) in `search_pages()`
- `SearchHeadline` for result snippets

A data migration rebuilds all stored search vectors so indexed vectors match query-time parsing (any vectors built while the default was `simple` would otherwise stay unstemmed).

The regression tests force the session's `default_text_search_config` to `simple` before indexing and searching, so they fail without the fix even on a locale-aware local Postgres.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

No special steps — the data migration runs as part of the standard deploy and rebuilds all search vectors (single `UPDATE`, fast at current page counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now uses a consistent English text-processing setup, improving stemming and result matching across the app.
  * Search snippets and phrase queries now follow the same behavior as standard search results.

* **Bug Fixes**
  * Search results are no longer affected by the database server’s default text-search locale.
  * Existing page search data is rebuilt to match the updated search behavior.

* **Tests**
  * Added coverage to verify stemming and quoted searches still work when the server default is set differently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->