### PR TITLE
Generate AI alt text for image uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ DB_SSL_MODE=prefer
 
 # Sentry
 # SENTRY_DSN=
+
+# Anthropic (AI alt text for image uploads; disabled when unset)
+# ANTHROPIC_API_KEY=
+# ANTHROPIC_OCR_MODEL=claude-opus-4-8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 license = "AGPL-3.0-only"
 dependencies = [
   "Django>=6.0,<6.1",
+  "anthropic>=0.116.0",
   "boto3",
   "daphne",
   "django-cotton",

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,34 @@ revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.116.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396", size = 949149, upload-time = "2026-07-02T19:08:10.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256", size = 956896, upload-time = "2026-07-02T19:08:08.756Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +295,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -450,6 +487,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -521,6 +567,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -533,6 +592,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
     { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
     { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -584,6 +658,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
 ]
 
 [[package]]
@@ -896,6 +992,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1127,6 +1264,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1224,6 +1370,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -1382,6 +1540,7 @@ name = "wiki"
 version = "1"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django" },
@@ -1420,6 +1579,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.116.0" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -60,9 +60,9 @@ var initMarkdownEditor = (function() {
     }
 
     // Image types the server may describe with AI after the bytes land.
-    // Mirrors SUPPORTED_IMAGE_TYPES in wiki/pages/ocr.py; drift only
-    // affects which status message shows, not behavior.
-    var AI_ALT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    // Rendered into editor-config by the ai_image_types template tag, so
+    // wiki/pages/ocr.py's SUPPORTED_IMAGE_TYPES stays the single source.
+    var AI_ALT_TYPES = config.aiAltTypes || [];
 
     // After the bytes are sent, the server still has work to do before it
     // returns the markdown — a few seconds of AI description for images,
@@ -164,14 +164,18 @@ var initMarkdownEditor = (function() {
       xhr.open('POST', config.urls.fileUpload);
       xhr.setRequestHeader('X-CSRFToken', csrfToken);
 
+      // Browsers skip xhr.upload events entirely when the transfer is
+      // near-instant (the normal case for this same-machine dev path),
+      // so percentages only appear for uploads slow enough to watch...
       xhr.upload.addEventListener('progress', function(e) {
         if (!e.lengthComputable) return;
-        updatePlaceholderProgress(cm, ph, file.name, Math.round(e.loaded / e.total * 100));
+        var pct = Math.round(e.loaded / e.total * 100);
+        if (pct < 100) updatePlaceholderProgress(cm, ph, file.name, pct);
       });
 
-      // Fires when the byte transfer completes, before the response —
-      // which may still wait on AI alt text. Unlike a 100% progress
-      // tick, this is guaranteed even on fast localhost uploads.
+      // ...and the processing status is shown right after send() below
+      // rather than from an upload event. If progress events did fire,
+      // this flips the text back once the bytes are done.
       xhr.upload.addEventListener('load', function() {
         showProcessingStatus(cm, ph, file);
       });
@@ -195,6 +199,9 @@ var initMarkdownEditor = (function() {
       var fd = new FormData();
       fd.append('file', file);
       xhr.send(fd);
+      // Same-machine transfer is effectively instant; the wait the user
+      // actually experiences is the server's AI pass, so show it now.
+      showProcessingStatus(cm, ph, file);
     }
 
     var MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -25,49 +25,51 @@ var initMarkdownEditor = (function() {
     // ── File upload (defined early so toolbar action can reference it) ──
     var editor; // forward declaration
 
-    // Shared helpers for placeholder management
+    // Shared helpers for placeholder management. One spinner animates for
+    // the placeholder's whole life — paste/upload, S3 transfer, and the
+    // server's AI pass — while each phase just swaps the message beside it.
+    var SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+    function renderPlaceholder(cm, ph) {
+      var line = cm.getLine(ph.line);
+      if (line === undefined) return; // line was deleted; nothing to draw on
+      cm.replaceRange(SPINNER_FRAMES[ph.frame] + ' ' + ph.text,
+        { line: ph.line, ch: 0 },
+        { line: ph.line, ch: line.length }
+      );
+    }
+
     function insertPlaceholder(cm, filename) {
       var cursor = cm.getCursor();
-      var text = '⏳ Uploading ' + filename + '...';
-      cm.replaceRange(text + '\n', cursor);
-      var line = cursor.line;
-      var dots = 0;
-      var interval = setInterval(function() {
-        dots = (dots + 1) % 4;
-        var t = '⏳ Uploading ' + filename + '.'.repeat(dots + 1);
-        cm.replaceRange(t,
-          { line: line, ch: 0 },
-          { line: line, ch: cm.getLine(line).length }
-        );
-      }, 400);
-      return { line: line, interval: interval };
+      var ph = {
+        line: cursor.line,
+        frame: 0,
+        text: 'Uploading ' + filename + '…'
+      };
+      cm.replaceRange(SPINNER_FRAMES[0] + ' ' + ph.text + '\n', cursor);
+      ph.interval = setInterval(function() {
+        ph.frame = (ph.frame + 1) % SPINNER_FRAMES.length;
+        renderPlaceholder(cm, ph);
+      }, 120);
+      return ph;
     }
 
     function updatePlaceholderProgress(cm, ph, filename, pct) {
-      var text = '⏳ Uploading ' + filename + ' (' + pct + '%)';
-      cm.replaceRange(text,
-        { line: ph.line, ch: 0 },
-        { line: ph.line, ch: cm.getLine(ph.line).length }
-      );
+      ph.text = 'Uploading ' + filename + ' (' + pct + '%)';
+      renderPlaceholder(cm, ph);
     }
 
     // Image types the server may describe with AI after the bytes land.
     var AI_ALT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
-    function setPlaceholderStatus(cm, ph, text) {
-      // Stop the animated dots so the status message sticks.
-      clearInterval(ph.interval);
-      cm.replaceRange(text,
-        { line: ph.line, ch: 0 },
-        { line: ph.line, ch: cm.getLine(ph.line).length }
-      );
-    }
-
-    // After the bytes are sent, the server may still spend a few seconds
-    // generating alt text for images — tell the user what the wait is.
-    function showReadingStatus(cm, ph, file) {
-      if (AI_ALT_TYPES.indexOf(file.type) === -1) return;
-      setPlaceholderStatus(cm, ph, '🔍 Reading ' + file.name + '…');
+    // After the bytes are sent, the server still has work to do before it
+    // returns the markdown — a few seconds of AI description for images,
+    // a quick finalization for everything else.
+    function showProcessingStatus(cm, ph, file) {
+      ph.text = (AI_ALT_TYPES.indexOf(file.type) !== -1)
+        ? 'Reading ' + file.name + '…'
+        : 'Finishing ' + file.name + '…';
+      renderPlaceholder(cm, ph);
     }
 
     function replacePlaceholder(cm, ph, markdown) {
@@ -125,7 +127,7 @@ var initMarkdownEditor = (function() {
           }
 
           // Step 3: Confirm with Django
-          showReadingStatus(cm, ph, file);
+          showProcessingStatus(cm, ph, file);
           fetch(config.urls.confirmUpload, {
             method: 'POST',
             headers: { 'X-CSRFToken': csrfToken, 'Content-Type': 'application/json' },
@@ -163,9 +165,12 @@ var initMarkdownEditor = (function() {
       xhr.upload.addEventListener('progress', function(e) {
         if (!e.lengthComputable) return;
         var pct = Math.round(e.loaded / e.total * 100);
-        updatePlaceholderProgress(cm, ph, file.name, pct);
-        // Bytes are sent; the response may still wait on AI alt text.
-        if (pct >= 100) showReadingStatus(cm, ph, file);
+        if (pct >= 100) {
+          // Bytes are sent; the response may still wait on AI alt text.
+          showProcessingStatus(cm, ph, file);
+        } else {
+          updatePlaceholderProgress(cm, ph, file.name, pct);
+        }
       });
 
       xhr.addEventListener('load', function() {

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -51,6 +51,25 @@ var initMarkdownEditor = (function() {
       );
     }
 
+    // Image types the server may describe with AI after the bytes land.
+    var AI_ALT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+    function setPlaceholderStatus(cm, ph, text) {
+      // Stop the animated dots so the status message sticks.
+      clearInterval(ph.interval);
+      cm.replaceRange(text,
+        { line: ph.line, ch: 0 },
+        { line: ph.line, ch: cm.getLine(ph.line).length }
+      );
+    }
+
+    // After the bytes are sent, the server may still spend a few seconds
+    // generating alt text for images — tell the user what the wait is.
+    function showReadingStatus(cm, ph, file) {
+      if (AI_ALT_TYPES.indexOf(file.type) === -1) return;
+      setPlaceholderStatus(cm, ph, '🔍 Reading ' + file.name + '…');
+    }
+
     function replacePlaceholder(cm, ph, markdown) {
       clearInterval(ph.interval);
       cm.replaceRange(markdown,
@@ -106,6 +125,7 @@ var initMarkdownEditor = (function() {
           }
 
           // Step 3: Confirm with Django
+          showReadingStatus(cm, ph, file);
           fetch(config.urls.confirmUpload, {
             method: 'POST',
             headers: { 'X-CSRFToken': csrfToken, 'Content-Type': 'application/json' },
@@ -142,7 +162,10 @@ var initMarkdownEditor = (function() {
 
       xhr.upload.addEventListener('progress', function(e) {
         if (!e.lengthComputable) return;
-        updatePlaceholderProgress(cm, ph, file.name, Math.round(e.loaded / e.total * 100));
+        var pct = Math.round(e.loaded / e.total * 100);
+        updatePlaceholderProgress(cm, ph, file.name, pct);
+        // Bytes are sent; the response may still wait on AI alt text.
+        if (pct >= 100) showReadingStatus(cm, ph, file);
       });
 
       xhr.addEventListener('load', function() {

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -67,7 +67,7 @@ var initMarkdownEditor = (function() {
     // a quick finalization for everything else.
     function showProcessingStatus(cm, ph, file) {
       ph.text = (AI_ALT_TYPES.indexOf(file.type) !== -1)
-        ? 'Reading ' + file.name + '…'
+        ? 'Generating image description…'
         : 'Finishing ' + file.name + '…';
       renderPlaceholder(cm, ph);
     }

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -60,6 +60,8 @@ var initMarkdownEditor = (function() {
     }
 
     // Image types the server may describe with AI after the bytes land.
+    // Mirrors SUPPORTED_IMAGE_TYPES in wiki/pages/ocr.py; drift only
+    // affects which status message shows, not behavior.
     var AI_ALT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
     // After the bytes are sent, the server still has work to do before it
@@ -164,13 +166,14 @@ var initMarkdownEditor = (function() {
 
       xhr.upload.addEventListener('progress', function(e) {
         if (!e.lengthComputable) return;
-        var pct = Math.round(e.loaded / e.total * 100);
-        if (pct >= 100) {
-          // Bytes are sent; the response may still wait on AI alt text.
-          showProcessingStatus(cm, ph, file);
-        } else {
-          updatePlaceholderProgress(cm, ph, file.name, pct);
-        }
+        updatePlaceholderProgress(cm, ph, file.name, Math.round(e.loaded / e.total * 100));
+      });
+
+      // Fires when the byte transfer completes, before the response —
+      // which may still wait on AI alt text. Unlike a 100% progress
+      // tick, this is guaranteed even on fast localhost uploads.
+      xhr.upload.addEventListener('load', function() {
+        showProcessingStatus(cm, ph, file);
       });
 
       xhr.addEventListener('load', function() {

--- a/wiki/conftest.py
+++ b/wiki/conftest.py
@@ -8,6 +8,17 @@ from wiki.pages.models import Page, PageRevision
 from wiki.users.models import SystemConfig, UserProfile
 
 
+@pytest.fixture(autouse=True)
+def _no_anthropic_api(settings):
+    """Keep tests off the real Anthropic API.
+
+    A developer's ``.env.dev`` may carry a real ANTHROPIC_API_KEY for
+    manual testing; blank it so unmocked upload tests never make live
+    calls. Tests that exercise the OCR path set their own key.
+    """
+    settings.ANTHROPIC_API_KEY = ""
+
+
 @pytest.fixture
 def user(db):
     """A regular @free.law user with profile."""

--- a/wiki/directories/templates/directories/form.html
+++ b/wiki/directories/templates/directories/form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static wiki_tags %}
+{% load static upload_tags wiki_tags %}
 
 {% block title %}{% if creating %}New Subdirectory{% else %}Edit Directory: {{ directory.title }}{% endif %} - FLP Wiki{% endblock %}
 
@@ -114,6 +114,7 @@
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",
+  "aiAltTypes": {% ai_image_types %},
   "directUpload": {% if not DEBUG %}true{% else %}false{% endif %},
   "urls": {
     "presignUpload": "{% url 'presign_upload' %}",

--- a/wiki/pages/ocr.py
+++ b/wiki/pages/ocr.py
@@ -17,7 +17,8 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-# Image types the Anthropic API accepts as input.
+# Image types the Anthropic API accepts as input. Mirrored by
+# AI_ALT_TYPES in wiki/assets/static-global/js/markdown-editor.js.
 SUPPORTED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",
@@ -108,7 +109,9 @@ def describe_image(image_bytes, content_type):
     text = next((b.text for b in response.content if b.type == "text"), "")
     try:
         alt_text = json.loads(text)["alt_text"].strip()
-    except (json.JSONDecodeError, KeyError, AttributeError):
+    except (json.JSONDecodeError, KeyError, AttributeError, TypeError):
+        # TypeError covers valid JSON that isn't an object (e.g. a bare
+        # list or number) — the schema forbids it, but don't bet on that.
         logger.warning("Alt text response was not valid JSON: %r", text[:200])
         return None
     return alt_text or None

--- a/wiki/pages/ocr.py
+++ b/wiki/pages/ocr.py
@@ -17,8 +17,9 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-# Image types the Anthropic API accepts as input. Mirrored by
-# AI_ALT_TYPES in wiki/assets/static-global/js/markdown-editor.js.
+# Image types the Anthropic API accepts as input. The editor reads this
+# list from editor-config via the ai_image_types template tag to decide
+# which uploads get the "Generating image description" status.
 SUPPORTED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",

--- a/wiki/pages/ocr.py
+++ b/wiki/pages/ocr.py
@@ -1,0 +1,114 @@
+"""Generate alt text for uploaded images via the Anthropic API.
+
+Called synchronously from the upload views so the markdown snippet
+returned to the editor already carries a useful description instead of
+the filename. Failures of any kind (no API key, unsupported type,
+oversized image, API errors, timeouts) return ``None`` and the caller
+falls back to the current filename-as-alt behavior — an upload must
+never fail or block on the AI call.
+"""
+
+import base64
+import json
+import logging
+
+import anthropic
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# Image types the Anthropic API accepts as input.
+SUPPORTED_IMAGE_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+}
+
+# The API caps images at 5 MB; stay under it with margin for base64.
+MAX_IMAGE_BYTES = int(4.5 * 1024 * 1024)
+
+# The call runs inside the upload request, so keep it bounded: one
+# attempt, and give up well before the browser or proxy would.
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+_PROMPT = (
+    "Write alt text for this image, uploaded to an organizational wiki. "
+    "One concise sentence (under 125 characters) describing what the "
+    "image shows, suitable for screen readers. Include important visible "
+    "text such as headings, labels, or error messages so the description "
+    "is also useful for search. Don't start with 'Image of' or "
+    "'Screenshot of' unless the medium matters."
+)
+
+_OUTPUT_SCHEMA = {
+    "type": "json_schema",
+    "schema": {
+        "type": "object",
+        "properties": {"alt_text": {"type": "string"}},
+        "required": ["alt_text"],
+        "additionalProperties": False,
+    },
+}
+
+
+def describe_image(image_bytes, content_type):
+    """Return AI-generated alt text for an image, or None to skip.
+
+    None means "use the fallback" — the feature is disabled, the image
+    can't be sent to the API, or the call failed.
+    """
+    if not settings.ANTHROPIC_API_KEY:
+        return None
+    if content_type not in SUPPORTED_IMAGE_TYPES:
+        return None
+    if len(image_bytes) > MAX_IMAGE_BYTES:
+        return None
+
+    client = anthropic.Anthropic(
+        api_key=settings.ANTHROPIC_API_KEY,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+        max_retries=0,
+    )
+    try:
+        response = client.messages.create(
+            model=settings.ANTHROPIC_OCR_MODEL,
+            max_tokens=1024,
+            output_config={"effort": "low", "format": _OUTPUT_SCHEMA},
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": content_type,
+                                "data": base64.standard_b64encode(
+                                    image_bytes
+                                ).decode("ascii"),
+                            },
+                        },
+                        {"type": "text", "text": _PROMPT},
+                    ],
+                }
+            ],
+        )
+    except anthropic.APIError:
+        logger.warning("Alt text generation failed", exc_info=True)
+        return None
+
+    if response.stop_reason != "end_turn":
+        # Refusal or truncation — structured output isn't guaranteed.
+        logger.warning(
+            "Alt text generation stopped early: %s", response.stop_reason
+        )
+        return None
+
+    text = next((b.text for b in response.content if b.type == "text"), "")
+    try:
+        alt_text = json.loads(text)["alt_text"].strip()
+    except (json.JSONDecodeError, KeyError, AttributeError):
+        logger.warning("Alt text response was not valid JSON: %r", text[:200])
+        return None
+    return alt_text or None

--- a/wiki/pages/templates/pages/form.html
+++ b/wiki/pages/templates/pages/form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static wiki_tags %}
+{% load static upload_tags wiki_tags %}
 
 {% block title %}{% if editing %}Edit - {{ page.title|strip_backticks }} - FLP Wiki{% else %}New Page - FLP Wiki{% endif %}{% endblock %}
 
@@ -200,6 +200,7 @@
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",
+  "aiAltTypes": {% ai_image_types %},
   "directUpload": {% if not DEBUG %}true{% else %}false{% endif %},
   "urls": {
     "presignUpload": "{% url 'presign_upload' %}",

--- a/wiki/pages/templatetags/upload_tags.py
+++ b/wiki/pages/templatetags/upload_tags.py
@@ -1,0 +1,20 @@
+"""Template tags for the file-upload editor config."""
+
+from django import template
+from django.utils.safestring import mark_safe
+
+from wiki.lib.safe_json import dump_json_for_script
+from wiki.pages.ocr import SUPPORTED_IMAGE_TYPES
+
+register = template.Library()
+
+
+@register.simple_tag
+def ai_image_types():
+    """JSON array of image MIME types the server describes with AI.
+
+    Rendered into the editor-config block so the editor's upload status
+    text stays in sync with ``SUPPORTED_IMAGE_TYPES`` — the single
+    source of truth for which uploads get an alt-text pass.
+    """
+    return mark_safe(dump_json_for_script(sorted(SUPPORTED_IMAGE_TYPES)))

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -4,11 +4,15 @@ import io
 import json
 from datetime import timedelta
 
+import anthropic
+import httpx
 import pytest
 import time_machine
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.sessions.models import Session
 from django.core import mail
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.test import Client
@@ -33,6 +37,7 @@ from wiki.pages.models import (
     SlugRedirect,
     ZeroResultSearch,
 )
+from wiki.pages.ocr import describe_image
 from wiki.pages.tasks import (
     OPTIMIZE_BATCH_SIZE,
     optimize_images,
@@ -1000,6 +1005,264 @@ def _mock_s3_client():
                 pass
 
     return MockS3Client()
+
+
+# ── AI alt text for image uploads ─────────────────────────────
+
+
+def _fail_if_called(*args, **kwargs):
+    raise AssertionError("should not have been called")
+
+
+class TestUploadAltText:
+    """The upload endpoints put AI-generated alt text in the markdown."""
+
+    def test_image_upload_uses_ai_alt_text(self, client, user):
+        client.force_login(user)
+        img = SimpleUploadedFile(
+            "chart.png", _make_png(), content_type="image/png"
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "wiki.pages.views.describe_image",
+                lambda image_bytes, content_type: "A bar chart of signups",
+            )
+            r = client.post(reverse("file_upload"), {"file": img})
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![A bar chart of signups](")
+
+    def test_falls_back_to_filename_when_skipped(self, client, user):
+        client.force_login(user)
+        img = SimpleUploadedFile(
+            "chart.png", _make_png(), content_type="image/png"
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "wiki.pages.views.describe_image",
+                lambda image_bytes, content_type: None,
+            )
+            r = client.post(reverse("file_upload"), {"file": img})
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![chart.png](")
+
+    def test_alt_text_is_sanitized_for_markdown(self, client, user):
+        client.force_login(user)
+        img = SimpleUploadedFile(
+            "chart.png", _make_png(), content_type="image/png"
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "wiki.pages.views.describe_image",
+                lambda image_bytes, content_type: "A [chart]\nwith   lines",
+            )
+            r = client.post(reverse("file_upload"), {"file": img})
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![A chart with lines](")
+
+    def test_non_image_skips_ai_call(self, client, user):
+        client.force_login(user)
+        doc = SimpleUploadedFile(
+            "notes.txt", b"hello", content_type="text/plain"
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.views.describe_image", _fail_if_called)
+            r = client.post(reverse("file_upload"), {"file": doc})
+        assert r.status_code == 200
+
+    def test_oversized_image_skips_ai_call(self, client, user):
+        client.force_login(user)
+        img = SimpleUploadedFile(
+            "big.png", _make_png(), content_type="image/png"
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.views.MAX_IMAGE_BYTES", 10)
+            mp.setattr("wiki.pages.views.describe_image", _fail_if_called)
+            r = client.post(reverse("file_upload"), {"file": img})
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![big.png](")
+
+    def test_ai_call_receives_file_bytes(self, client, user):
+        client.force_login(user)
+        png_bytes = _make_png()
+        img = SimpleUploadedFile(
+            "chart.png", png_bytes, content_type="image/png"
+        )
+        calls = []
+
+        def record(image_bytes, content_type):
+            calls.append((image_bytes, content_type))
+            return "A chart"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.views.describe_image", record)
+            client.post(reverse("file_upload"), {"file": img})
+        assert calls == [(png_bytes, "image/png")]
+
+    def test_confirm_upload_uses_ai_alt_text(self, client, user, settings):
+        """The S3 confirm flow reads the file back and describes it."""
+        settings.AWS_PRIVATE_STORAGE_BUCKET_NAME = "test-bucket"
+        client.force_login(user)
+        s3_key = default_storage.save(
+            "uploads/2026/07/abc_diagram.png", ContentFile(_make_png())
+        )
+        pending = PendingUpload.objects.create(
+            s3_key=s3_key,
+            original_filename="diagram.png",
+            content_type="image/png",
+            expected_size=1024,
+            uploaded_by=user,
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "wiki.pages.views.get_s3_client", lambda: _mock_s3_client()
+            )
+            mp.setattr(
+                "wiki.pages.views.describe_image",
+                lambda image_bytes, content_type: "An architecture diagram",
+            )
+            r = client.post(
+                reverse("confirm_upload"),
+                json.dumps({"pending_id": str(pending.id)}),
+                content_type="application/json",
+            )
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![An architecture diagram](")
+
+    def test_unreadable_file_falls_back(self, client, user, settings):
+        """A file that can't be read back must not break the upload."""
+        settings.AWS_PRIVATE_STORAGE_BUCKET_NAME = "test-bucket"
+        client.force_login(user)
+        pending = PendingUpload.objects.create(
+            s3_key="uploads/2026/07/does-not-exist.png",
+            original_filename="photo.png",
+            content_type="image/png",
+            expected_size=1024,
+            uploaded_by=user,
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "wiki.pages.views.get_s3_client", lambda: _mock_s3_client()
+            )
+            mp.setattr("wiki.pages.views.describe_image", _fail_if_called)
+            r = client.post(
+                reverse("confirm_upload"),
+                json.dumps({"pending_id": str(pending.id)}),
+                content_type="application/json",
+            )
+        assert r.status_code == 200
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![photo.png](")
+
+
+class _FakeBlock:
+    type = "text"
+
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeResponse:
+    def __init__(self, text, stop_reason="end_turn"):
+        self.stop_reason = stop_reason
+        self.content = [_FakeBlock(text)]
+
+
+class _FakeAnthropic:
+    """Stands in for anthropic.Anthropic; records the create() kwargs."""
+
+    last_create_kwargs = None
+
+    def __init__(self, response=None, error=None):
+        self._response = response
+        self._error = error
+
+    def __call__(self, **client_kwargs):
+        # Mimic the anthropic.Anthropic(...) constructor.
+        return self
+
+    @property
+    def messages(self):
+        return self
+
+    def create(self, **kwargs):
+        _FakeAnthropic.last_create_kwargs = kwargs
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+class TestDescribeImage:
+    """Unit tests for the Anthropic call in wiki/pages/ocr.py."""
+
+    def test_no_api_key_skips_without_api_call(self, settings):
+        settings.ANTHROPIC_API_KEY = ""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", _fail_if_called)
+            assert describe_image(b"bytes", "image/png") is None
+
+    def test_unsupported_type_skips_without_api_call(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", _fail_if_called)
+            assert describe_image(b"<svg/>", "image/svg+xml") is None
+
+    def test_oversized_image_skips_without_api_call(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", _fail_if_called)
+            mp.setattr("wiki.pages.ocr.MAX_IMAGE_BYTES", 10)
+            assert describe_image(b"x" * 11, "image/png") is None
+
+    def test_happy_path_returns_alt_text(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_OCR_MODEL = "test-model"
+        fake = _FakeAnthropic(
+            response=_FakeResponse(json.dumps({"alt_text": " A red square "}))
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") == "A red square"
+
+        kwargs = _FakeAnthropic.last_create_kwargs
+        assert kwargs["model"] == "test-model"
+        image_block = kwargs["messages"][0]["content"][0]
+        assert image_block["type"] == "image"
+        assert image_block["source"]["media_type"] == "image/png"
+
+    def test_api_error_returns_none(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        error = anthropic.APIConnectionError(
+            request=httpx.Request("POST", "https://api.anthropic.com")
+        )
+        fake = _FakeAnthropic(error=error)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") is None
+
+    def test_refusal_returns_none(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        fake = _FakeAnthropic(
+            response=_FakeResponse("", stop_reason="refusal")
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") is None
+
+    def test_invalid_json_returns_none(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        fake = _FakeAnthropic(response=_FakeResponse("not json"))
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") is None
+
+    def test_empty_alt_text_returns_none(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        fake = _FakeAnthropic(
+            response=_FakeResponse(json.dumps({"alt_text": "  "}))
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") is None
 
 
 class TestPageSearchAutocomplete:

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -1059,6 +1059,23 @@ class TestUploadAltText:
         data = json.loads(r.content)
         assert data["markdown"].startswith("![A chart with lines](")
 
+    def test_describe_image_exception_falls_back(self, client, user):
+        """A bug in the AI path must not turn a good upload into a 500."""
+        client.force_login(user)
+        img = SimpleUploadedFile(
+            "chart.png", _make_png(), content_type="image/png"
+        )
+
+        def boom(image_bytes, content_type):
+            raise RuntimeError("unexpected AI failure")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.views.describe_image", boom)
+            r = client.post(reverse("file_upload"), {"file": img})
+        assert r.status_code == 200
+        data = json.loads(r.content)
+        assert data["markdown"].startswith("![chart.png](")
+
     def test_non_image_skips_ai_call(self, client, user):
         client.force_login(user)
         doc = SimpleUploadedFile(
@@ -1113,9 +1130,7 @@ class TestUploadAltText:
             uploaded_by=user,
         )
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "wiki.pages.views.get_s3_client", lambda: _mock_s3_client()
-            )
+            mp.setattr("wiki.pages.views.get_s3_client", _mock_s3_client)
             mp.setattr(
                 "wiki.pages.views.describe_image",
                 lambda image_bytes, content_type: "An architecture diagram",
@@ -1140,9 +1155,7 @@ class TestUploadAltText:
             uploaded_by=user,
         )
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "wiki.pages.views.get_s3_client", lambda: _mock_s3_client()
-            )
+            mp.setattr("wiki.pages.views.get_s3_client", _mock_s3_client)
             mp.setattr("wiki.pages.views.describe_image", _fail_if_called)
             r = client.post(
                 reverse("confirm_upload"),
@@ -1251,6 +1264,14 @@ class TestDescribeImage:
     def test_invalid_json_returns_none(self, settings):
         settings.ANTHROPIC_API_KEY = "test-key"
         fake = _FakeAnthropic(response=_FakeResponse("not json"))
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
+            assert describe_image(b"png-bytes", "image/png") is None
+
+    def test_non_object_json_returns_none(self, settings):
+        """Valid JSON that isn't an object must not raise TypeError."""
+        settings.ANTHROPIC_API_KEY = "test-key"
+        fake = _FakeAnthropic(response=_FakeResponse("[]"))
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("wiki.pages.ocr.anthropic.Anthropic", fake)
             assert describe_image(b"png-bytes", "image/png") is None

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import re
 from datetime import timedelta
 
 import anthropic
@@ -37,7 +38,7 @@ from wiki.pages.models import (
     SlugRedirect,
     ZeroResultSearch,
 )
-from wiki.pages.ocr import describe_image
+from wiki.pages.ocr import SUPPORTED_IMAGE_TYPES, describe_image
 from wiki.pages.tasks import (
     OPTIMIZE_BATCH_SIZE,
     optimize_images,
@@ -1075,6 +1076,20 @@ class TestUploadAltText:
         assert r.status_code == 200
         data = json.loads(r.content)
         assert data["markdown"].startswith("![chart.png](")
+
+    def test_editor_config_carries_ai_image_types(self, client, user):
+        """The editor learns which types get AI alt text from the server."""
+        client.force_login(user)
+        content = client.get(reverse("page_create")).content.decode()
+        match = re.search(
+            r'<script type="application/json" id="editor-config">\s*(\{.*?\})'
+            r"\s*</script>",
+            content,
+            re.DOTALL,
+        )
+        assert match, "editor-config block missing"
+        editor_config = json.loads(match.group(1))
+        assert editor_config["aiAltTypes"] == sorted(SUPPORTED_IMAGE_TYPES)
 
     def test_non_image_skips_ai_call(self, client, user):
         client.force_login(user)

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import uuid
 from datetime import datetime
@@ -81,6 +82,13 @@ from .models import (
     PendingUpload,
     SlugRedirect,
 )
+from .ocr import (
+    MAX_IMAGE_BYTES,
+    SUPPORTED_IMAGE_TYPES,
+    describe_image,
+)
+
+logger = logging.getLogger(__name__)
 
 FILE_REF_RE = re.compile(r"/files/(\d+)/")
 
@@ -1339,7 +1347,13 @@ def file_upload_htmx(request):
         content_type=uploaded_file.content_type or "",
     )
 
-    return JsonResponse({"markdown": _file_upload_markdown(upload)})
+    return JsonResponse(
+        {
+            "markdown": _file_upload_markdown(
+                upload, alt_text=_generate_alt_text(upload)
+            )
+        }
+    )
 
 
 @require_POST
@@ -1446,10 +1460,45 @@ def confirm_upload(request):
         upload.save()
         pending.delete()
 
-    return JsonResponse({"markdown": _file_upload_markdown(upload)})
+    return JsonResponse(
+        {
+            "markdown": _file_upload_markdown(
+                upload, alt_text=_generate_alt_text(upload)
+            )
+        }
+    )
 
 
-def _file_upload_markdown(upload):
+def _generate_alt_text(upload):
+    """Return AI alt text for an image upload, or None for the fallback.
+
+    Reads the file back from storage (local disk in dev, S3 in prod), so
+    check size/type first to avoid pulling a 1 GB video into memory just
+    to skip it. Never raises: the upload already succeeded, and a broken
+    AI call must not turn it into an error.
+    """
+    if upload.content_type not in SUPPORTED_IMAGE_TYPES:
+        return None
+    try:
+        if upload.file.size > MAX_IMAGE_BYTES:
+            return None
+        with upload.file.open("rb") as f:
+            image_bytes = f.read()
+    except Exception:
+        logger.warning(
+            "Could not read upload %s for alt text", upload.id, exc_info=True
+        )
+        return None
+    return describe_image(image_bytes, upload.content_type)
+
+
+def _sanitize_alt_text(alt_text):
+    """Make model-generated alt text safe inside ``![...]()`` markdown."""
+    alt_text = re.sub(r"\s+", " ", alt_text).strip()
+    return alt_text.replace("[", "").replace("]", "")
+
+
+def _file_upload_markdown(upload, alt_text=None):
     """Return markdown syntax for a FileUpload."""
     file_url = reverse(
         "file_serve",
@@ -1459,7 +1508,8 @@ def _file_upload_markdown(upload):
         },
     )
     if upload.content_type and upload.content_type.startswith("image/"):
-        return f"![{upload.original_filename}]({file_url})"
+        alt = _sanitize_alt_text(alt_text) if alt_text else ""
+        return f"![{alt or upload.original_filename}]({file_url})"
     return f"[{upload.original_filename}]({file_url})"
 
 

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -1484,12 +1484,14 @@ def _generate_alt_text(upload):
             return None
         with upload.file.open("rb") as f:
             image_bytes = f.read()
+        return describe_image(image_bytes, upload.content_type)
     except Exception:
         logger.warning(
-            "Could not read upload %s for alt text", upload.id, exc_info=True
+            "Alt text generation failed for upload %s",
+            upload.id,
+            exc_info=True,
         )
         return None
-    return describe_image(image_bytes, upload.content_type)
 
 
 def _sanitize_alt_text(alt_text):

--- a/wiki/proposals/templates/proposals/feedback.html
+++ b/wiki/proposals/templates/proposals/feedback.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static upload_tags %}
 
 {% block title %}Feedback for "{{ page.title }}" - FLP Wiki{% endblock %}
 
@@ -105,6 +105,7 @@
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",
+  "aiAltTypes": {% ai_image_types %},
   "directUpload": {% if not DEBUG %}true{% else %}false{% endif %},
   "urls": {
     "presignUpload": "{% url 'presign_upload' %}",

--- a/wiki/settings/__init__.py
+++ b/wiki/settings/__init__.py
@@ -4,6 +4,7 @@ from .project.email import *
 from .project.logging import *
 from .project.security import *
 from .project.testing import *
+from .third_party.anthropic import *
 from .third_party.aws import *
 from .third_party.cloudfront import *
 from .third_party.sentry import *

--- a/wiki/settings/third_party/anthropic.py
+++ b/wiki/settings/third_party/anthropic.py
@@ -1,5 +1,8 @@
 import environ
 
+# Keeps the settings assembly's `import *` from also dragging in `env`.
+__all__ = ["ANTHROPIC_API_KEY", "ANTHROPIC_OCR_MODEL"]
+
 env = environ.FileAwareEnv()
 
 # API key for the Anthropic API, used to generate alt text for image

--- a/wiki/settings/third_party/anthropic.py
+++ b/wiki/settings/third_party/anthropic.py
@@ -1,0 +1,11 @@
+import environ
+
+env = environ.FileAwareEnv()
+
+# API key for the Anthropic API, used to generate alt text for image
+# uploads. When unset, uploads skip the AI call and fall back to the
+# filename as alt text.
+ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
+
+# Vision-capable model used to describe uploaded images.
+ANTHROPIC_OCR_MODEL = env("ANTHROPIC_OCR_MODEL", default="claude-opus-4-8")


### PR DESCRIPTION
## Fixes
Fixes: #88

## Summary
When an image is uploaded in the editor, the server now describes it with the Anthropic API **synchronously, during the upload request**, so the markdown snippet inserted into the editor is `![<AI description>](url)` instead of `![filename](url)`. Because the description lands in the page markdown, it's automatically indexed by the existing content search vector — text visible only in images becomes findable with no search-side changes.

Approach and notable decisions:

- **New `wiki/pages/ocr.py`** makes one `messages.create()` vision call (base64 image + prompt) using the official `anthropic` SDK, with structured outputs (a one-field JSON schema) so the response is guaranteed parseable. The prompt asks for one concise screen-reader sentence that includes important visible text (headings, labels, error messages) so it's useful for search too.
- **Strictly best-effort**: no `ANTHROPIC_API_KEY` (the default), unsupported type (only jpeg/png/gif/webp), image over ~4.5 MB (the API's 5 MB limit), timeout, or any API error → the upload proceeds exactly as before, with the filename as alt. One attempt, no retries, 30s cap, `effort: low` — the call sits in the upload request path so it's kept bounded.
- Both upload flows are covered: the dev path (`file_upload_htmx`) and the S3 path (`confirm_upload`, which reads the object back from storage).
- **Editor UX**: after the byte transfer finishes, the upload placeholder switches from the progress percentage to `🔍 Reading <name>…` while the server does the AI call (image types only).
- Model-generated alt is sanitized for markdown (whitespace collapsed, `[`/`]` stripped).
- New settings: `ANTHROPIC_API_KEY` and `ANTHROPIC_OCR_MODEL` (default `claude-opus-4-8`).
- A conftest autouse fixture blanks `ANTHROPIC_API_KEY` in tests so the suite can never hit the live API even if a dev has a key in `.env.dev`.

Gotchas / compromises:

- Historical uploads are not backfilled (per discussion on the issue) — only new uploads get descriptions.
- I couldn't exercise the live API from my environment (no key available); the integration is covered by unit tests with a faked client. Worth one manual test with a real key: add `ANTHROPIC_API_KEY` to `.env.dev`, restart, upload a screenshot, and check the inserted markdown.
- The `anthropic` package is a new dependency, so the Docker image needs a rebuild wherever this deploys (`uv.lock` is updated).

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

1. To deploy, set `ANTHROPIC_API_KEY` in the production environment (feature is silently disabled without it). `ANTHROPIC_OCR_MODEL` optionally overrides the default `claude-opus-4-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-generated accessibility alt text for supported image uploads, including direct-to-storage confirmation flows.
  * Enhanced the upload editor experience with improved in-place processing status and percentage progress.
* **Bug Fixes**
  * Robust fallback to filename-based alt text when AI is disabled, unsupported/oversized, unreadable, or when AI returns invalid/empty results; generated text is sanitized for markdown.
* **Documentation**
  * Updated the example environment configuration with optional Anthropic settings for image description.
* **Tests**
  * Added coverage for OCR/alt-text generation and upload endpoints, with safeguards to prevent real external API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->