### PR TITLE
Include the requesting user in user-search autocomplete results

### DIFF
--- a/wiki/assets/static-global/js/username-autocomplete.js
+++ b/wiki/assets/static-global/js/username-autocomplete.js
@@ -10,7 +10,9 @@
   var dropdown = document.getElementById('username-dropdown');
   if (!input || !dropdown) return;
 
-  var userSearchUrl = JSON.parse(document.getElementById('username-autocomplete-config').textContent).userSearchUrl;
+  var config = JSON.parse(document.getElementById('username-autocomplete-config').textContent);
+  var userSearchUrl = config.userSearchUrl;
+  var includeSelf = config.includeSelf ? '&include_self=1' : '';
 
   var timer = null;
 
@@ -18,7 +20,7 @@
     if (query.length < 1) { dropdown.classList.add('hidden'); return; }
     clearTimeout(timer);
     timer = setTimeout(function() {
-      fetch(userSearchUrl + '?q=' + encodeURIComponent(query))
+      fetch(userSearchUrl + '?q=' + encodeURIComponent(query) + includeSelf)
         .then(function(r) { return r.json(); })
         .then(function(results) {
           if (!results.length) { dropdown.classList.add('hidden'); return; }

--- a/wiki/groups/templates/groups/detail.html
+++ b/wiki/groups/templates/groups/detail.html
@@ -75,7 +75,7 @@
 
 {% block footer_scripts %}
 <script type="application/json" id="username-autocomplete-config">
-{"userSearchUrl": "{% url 'user_search' %}"}
+{"userSearchUrl": "{% url 'user_search' %}", "includeSelf": true}
 </script>
 <script src="{% static 'js/username-autocomplete.js' %}"></script>
 {% endblock %}

--- a/wiki/groups/tests.py
+++ b/wiki/groups/tests.py
@@ -79,6 +79,18 @@ class TestGroupDetail:
         assert r.status_code == 302
         assert group.user_set.filter(pk=other_user.pk).exists()
 
+    def test_add_self(self, client, user, group):
+        """A manager can add themselves to a group (#130)."""
+        user.is_staff = True
+        user.save()
+        client.force_login(user)
+        r = client.post(
+            reverse("group_add_member", kwargs={"pk": group.pk}),
+            {"username": user.profile.handle},
+        )
+        assert r.status_code == 302
+        assert group.user_set.filter(pk=user.pk).exists()
+
     def test_add_nonexistent_user(self, client, user, group):
         user.is_staff = True
         user.save()

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -1901,10 +1901,17 @@ class TestUserSearchAPI:
         data = __import__("json").loads(r.content)
         assert data == []
 
-    def test_user_search_includes_self(self, client, user):
-        """You can find yourself, e.g. to add yourself to a group (#130)."""
+    def test_user_search_excludes_self(self, client, user):
         client.force_login(user)
         r = client.get(f"{reverse('user_search')}?q=alice")
+        data = json.loads(r.content)
+        usernames = [u["username"] for u in data]
+        assert "alice" not in usernames
+
+    def test_user_search_include_self_param(self, client, user):
+        """include_self=1 returns yourself, e.g. for group membership (#130)."""
+        client.force_login(user)
+        r = client.get(f"{reverse('user_search')}?q=alice&include_self=1")
         data = json.loads(r.content)
         usernames = [u["username"] for u in data]
         assert "alice" in usernames

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -1601,12 +1601,13 @@ class TestUserSearchAPI:
         data = __import__("json").loads(r.content)
         assert data == []
 
-    def test_user_search_excludes_self(self, client, user):
+    def test_user_search_includes_self(self, client, user):
+        """You can find yourself, e.g. to add yourself to a group (#130)."""
         client.force_login(user)
         r = client.get(f"{reverse('user_search')}?q=alice")
         data = json.loads(r.content)
         usernames = [u["username"] for u in data]
-        assert "alice" not in usernames
+        assert "alice" in usernames
 
 
 class TestPagePermissions:

--- a/wiki/users/views.py
+++ b/wiki/users/views.py
@@ -518,14 +518,13 @@ def user_search_htmx(request):
 
     # Match the typed @-handle (or a display name). The inner join on
     # profile means every result has a handle.
-    users = (
-        User.objects.filter(
-            Q(profile__handle__istartswith=q)
-            | Q(profile__display_name__icontains=q)
-        )
-        .exclude(pk=request.user.pk)
-        .select_related("profile")[:10]
-    )
+    # The requesting user is included: this endpoint also feeds the group
+    # member and permission-grant autocompletes, where picking yourself is
+    # legitimate (see issue #130).
+    users = User.objects.filter(
+        Q(profile__handle__istartswith=q)
+        | Q(profile__display_name__icontains=q)
+    ).select_related("profile")[:10]
 
     results = []
     for u in users:

--- a/wiki/users/views.py
+++ b/wiki/users/views.py
@@ -517,14 +517,17 @@ def user_search_htmx(request):
         return JsonResponse([], safe=False)
 
     # Match the typed @-handle (or a display name). The inner join on
-    # profile means every result has a handle.
-    # The requesting user is included: this endpoint also feeds the group
-    # member and permission-grant autocompletes, where picking yourself is
-    # legitimate (see issue #130).
+    # profile means every result has a handle. The requesting user is
+    # excluded by default (you don't @-mention yourself), but callers like
+    # the group member form pass include_self=1 since adding yourself to a
+    # group is legitimate (see issue #130).
     users = User.objects.filter(
         Q(profile__handle__istartswith=q)
         | Q(profile__display_name__icontains=q)
-    ).select_related("profile")[:10]
+    )
+    if request.GET.get("include_self") != "1":
+        users = users.exclude(pk=request.user.pk)
+    users = users.select_related("profile")[:10]
 
     results = []
     for u in users:


### PR DESCRIPTION
## Fixes
Fixes: #130

## Summary
The `user_search` JSON endpoint excluded the requesting user unconditionally. That's the right default for @-mention autocomplete, but the same endpoint feeds the group "Add Member" autocomplete, where adding yourself is legitimate — so you could never find yourself to add yourself to a group.

This keeps the self-exclusion as the default and adds an `include_self=1` opt-in query param. Only the group detail page passes it (via the `username-autocomplete.js` config block), so @-mention and permission autocompletes are unchanged. The `group_add_member` view itself never blocked self-adds — the bug was purely in the autocomplete — but there's a regression test at that level too, plus endpoint tests covering both the default exclusion and the opt-in.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [X] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include the currently signed-in user in user search/autocomplete results via `include_self=1`.
  * Staff users can now add themselves to a group directly from the group member management flow.

* **Bug Fixes**
  * Fixed user search so the requester is only excluded by default, but is included when `include_self=1` is provided.

* **Tests**
  * Added coverage for adding a user to their own group and for the new `include_self=1` behavior in user search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->