### PR TITLE
Add tabbed code blocks via {% tabs %} markers

### DIFF
--- a/wiki/assets/static-global/js/code-blocks.js
+++ b/wiki/assets/static-global/js/code-blocks.js
@@ -81,6 +81,10 @@
     if (code.dataset.enhanced) return;
     code.dataset.enhanced = 'true';
 
+    // Record the authored language before highlighting: hljs auto-detection
+    // adds a language-* class to bare blocks, which would fake a tab label.
+    code.dataset.lang = langOf(code);
+
     if (typeof hljs !== 'undefined') {
       hljs.highlightElement(code);
     }
@@ -121,24 +125,25 @@
 
   // ── Tabbed code groups ─────────────────────────────────────────────
 
+  var groupCount = 0;
+
   function groupPanels(group) {
     return [].slice.call(group.children).filter(function (el) {
       return el.classList.contains('code-block-wrapper');
     });
   }
 
-  function activateGroup(group, lang) {
+  function tabIndexForLang(group, lang) {
+    var tabs = group.querySelectorAll('[role="tab"]');
+    for (var i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.lang === lang) return i;
+    }
+    return -1;
+  }
+
+  function activateGroup(group, index) {
     var tabs = group.querySelectorAll('[role="tab"]');
     var panels = groupPanels(group);
-    var index = 0;
-    if (lang) {
-      for (var i = 0; i < tabs.length; i++) {
-        if (tabs[i].dataset.lang === lang) {
-          index = i;
-          break;
-        }
-      }
-    }
     tabs.forEach(function (tab, i) {
       var active = i === index;
       tab.setAttribute('aria-selected', active ? 'true' : 'false');
@@ -148,13 +153,10 @@
     });
   }
 
-  function groupHasLang(group, lang) {
-    return !!group.querySelector('[role="tab"][data-lang="' + lang + '"]');
-  }
-
   function selectLang(lang) {
     document.querySelectorAll('.code-tabs').forEach(function (group) {
-      if (groupHasLang(group, lang)) activateGroup(group, lang);
+      var index = tabIndexForLang(group, lang);
+      if (index !== -1) activateGroup(group, index);
     });
   }
 
@@ -162,26 +164,32 @@
     if (group.querySelector('.code-tabs-bar')) return;
     var panels = groupPanels(group);
     if (!panels.length) return;
+    var groupId = ++groupCount;
 
     var bar = document.createElement('div');
     bar.className = 'code-tabs-bar';
     bar.setAttribute('role', 'tablist');
     bar.setAttribute('aria-label', 'Code examples');
 
-    panels.forEach(function (panel) {
+    panels.forEach(function (panel, i) {
       var code = panel.querySelector('pre code');
-      var lang = code ? langOf(code) : '';
+      var lang = (code && code.dataset.lang) || '';
       var tab = document.createElement('button');
       tab.type = 'button';
+      tab.id = 'code-tab-' + groupId + '-' + i;
       tab.setAttribute('role', 'tab');
+      tab.setAttribute('aria-controls', 'code-tabpanel-' + groupId + '-' + i);
       tab.dataset.lang = lang;
       tab.textContent = labelFor(lang);
+      panel.id = 'code-tabpanel-' + groupId + '-' + i;
+      panel.setAttribute('role', 'tabpanel');
+      panel.setAttribute('aria-labelledby', tab.id);
       tab.addEventListener('click', function () {
         if (lang) {
           rememberLang(lang);
           selectLang(lang);
         } else {
-          activateGroup(group, lang);
+          activateGroup(group, i);
         }
       });
       bar.appendChild(tab);
@@ -202,7 +210,8 @@
     group.insertBefore(bar, group.firstChild);
 
     var remembered = storedLang();
-    activateGroup(group, remembered && groupHasLang(group, remembered) ? remembered : null);
+    var index = remembered ? tabIndexForLang(group, remembered) : -1;
+    activateGroup(group, index === -1 ? 0 : index);
   }
 
   // ── Entry point ────────────────────────────────────────────────────

--- a/wiki/assets/static-global/js/code-blocks.js
+++ b/wiki/assets/static-global/js/code-blocks.js
@@ -1,16 +1,89 @@
 /**
- * Code block enhancements: syntax highlighting + copy button.
+ * Code block enhancements: syntax highlighting, copy buttons, and tabbed
+ * code groups ({% tabs %} markup, rendered as <div class="code-tabs">).
  *
- * Loaded on page/directory detail views after highlight.js.
- * Runs after DOM is ready — wraps each <pre> in a container and
- * injects a copy button, then applies highlight.js.
+ * Loaded after highlight.js on detail views and editor forms. Runs on DOM
+ * ready for each .wiki-content container, and is exposed as
+ * window.enhanceCodeBlocks(root) so the editor preview can enhance
+ * HTML it injects after the fact.
+ *
+ * Tab selection is shared: picking a language activates it in every tab
+ * group on the page that offers it, and persists across pages via
+ * localStorage.
  */
-document.addEventListener('DOMContentLoaded', function () {
-  var blocks = document.querySelectorAll('.wiki-content pre code');
+(function () {
+  var STORAGE_KEY = 'wiki-code-tab';
 
-  blocks.forEach(function (code) {
-    // Syntax highlighting
-    hljs.highlightElement(code);
+  var LANG_LABELS = {
+    bash: 'Bash',
+    cpp: 'C++',
+    csharp: 'C#',
+    css: 'CSS',
+    curl: 'cURL',
+    go: 'Go',
+    html: 'HTML',
+    java: 'Java',
+    javascript: 'JavaScript',
+    js: 'JavaScript',
+    json: 'JSON',
+    php: 'PHP',
+    plaintext: 'Text',
+    py: 'Python',
+    python: 'Python',
+    ruby: 'Ruby',
+    rust: 'Rust',
+    sh: 'Shell',
+    shell: 'Shell',
+    sql: 'SQL',
+    ts: 'TypeScript',
+    typescript: 'TypeScript',
+    xml: 'XML',
+    yaml: 'YAML',
+    yml: 'YAML',
+  };
+
+  // ```curl fences keep their language-curl class (and cURL tab label) but
+  // highlight with bash rules.
+  if (typeof hljs !== 'undefined') {
+    hljs.registerAliases('curl', { languageName: 'bash' });
+  }
+
+  function langOf(code) {
+    var match = code.className.match(/language-([\w+-]+)/);
+    return match ? match[1].toLowerCase() : '';
+  }
+
+  function labelFor(lang) {
+    if (!lang) return 'Text';
+    if (LANG_LABELS[lang]) return LANG_LABELS[lang];
+    return lang.charAt(0).toUpperCase() + lang.slice(1);
+  }
+
+  function storedLang() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function rememberLang(lang) {
+    try {
+      localStorage.setItem(STORAGE_KEY, lang);
+    } catch (e) {
+      /* storage unavailable — selection just won't persist */
+    }
+  }
+
+  // ── Highlighting + copy button ─────────────────────────────────────
+
+  function enhanceBlock(code) {
+    if (code.dataset.enhanced) return;
+    code.dataset.enhanced = 'true';
+
+    if (typeof hljs !== 'undefined') {
+      hljs.highlightElement(code);
+    }
 
     // Wrap <pre> in a relative container for the copy button
     var pre = code.parentElement;
@@ -44,5 +117,104 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     wrapper.appendChild(btn);
+  }
+
+  // ── Tabbed code groups ─────────────────────────────────────────────
+
+  function groupPanels(group) {
+    return [].slice.call(group.children).filter(function (el) {
+      return el.classList.contains('code-block-wrapper');
+    });
+  }
+
+  function activateGroup(group, lang) {
+    var tabs = group.querySelectorAll('[role="tab"]');
+    var panels = groupPanels(group);
+    var index = 0;
+    if (lang) {
+      for (var i = 0; i < tabs.length; i++) {
+        if (tabs[i].dataset.lang === lang) {
+          index = i;
+          break;
+        }
+      }
+    }
+    tabs.forEach(function (tab, i) {
+      var active = i === index;
+      tab.setAttribute('aria-selected', active ? 'true' : 'false');
+      tab.tabIndex = active ? 0 : -1;
+      tab.classList.toggle('active', active);
+      if (panels[i]) panels[i].hidden = !active;
+    });
+  }
+
+  function groupHasLang(group, lang) {
+    return !!group.querySelector('[role="tab"][data-lang="' + lang + '"]');
+  }
+
+  function selectLang(lang) {
+    document.querySelectorAll('.code-tabs').forEach(function (group) {
+      if (groupHasLang(group, lang)) activateGroup(group, lang);
+    });
+  }
+
+  function buildTabGroup(group) {
+    if (group.querySelector('.code-tabs-bar')) return;
+    var panels = groupPanels(group);
+    if (!panels.length) return;
+
+    var bar = document.createElement('div');
+    bar.className = 'code-tabs-bar';
+    bar.setAttribute('role', 'tablist');
+    bar.setAttribute('aria-label', 'Code examples');
+
+    panels.forEach(function (panel) {
+      var code = panel.querySelector('pre code');
+      var lang = code ? langOf(code) : '';
+      var tab = document.createElement('button');
+      tab.type = 'button';
+      tab.setAttribute('role', 'tab');
+      tab.dataset.lang = lang;
+      tab.textContent = labelFor(lang);
+      tab.addEventListener('click', function () {
+        if (lang) {
+          rememberLang(lang);
+          selectLang(lang);
+        } else {
+          activateGroup(group, lang);
+        }
+      });
+      bar.appendChild(tab);
+    });
+
+    bar.addEventListener('keydown', function (e) {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      var tabs = [].slice.call(bar.querySelectorAll('[role="tab"]'));
+      var current = tabs.indexOf(document.activeElement);
+      if (current === -1) return;
+      e.preventDefault();
+      var step = e.key === 'ArrowLeft' ? -1 : 1;
+      var next = tabs[(current + step + tabs.length) % tabs.length];
+      next.focus();
+      next.click();
+    });
+
+    group.insertBefore(bar, group.firstChild);
+
+    var remembered = storedLang();
+    activateGroup(group, remembered && groupHasLang(group, remembered) ? remembered : null);
+  }
+
+  // ── Entry point ────────────────────────────────────────────────────
+
+  function enhanceCodeBlocks(root) {
+    root.querySelectorAll('pre code').forEach(enhanceBlock);
+    root.querySelectorAll('.code-tabs').forEach(buildTabGroup);
+  }
+
+  window.enhanceCodeBlocks = enhanceCodeBlocks;
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.wiki-content').forEach(enhanceCodeBlocks);
   });
-});
+})();

--- a/wiki/assets/static-global/js/markdown-editor.js
+++ b/wiki/assets/static-global/js/markdown-editor.js
@@ -347,10 +347,8 @@ var initMarkdownEditor = (function() {
           body: 'content=' + encodeURIComponent(editor.value()),
         }).then(function(r) { return r.text(); }).then(function(html) {
           previewPane.innerHTML = html;
-          if (typeof hljs !== 'undefined') {
-            previewPane.querySelectorAll('pre code').forEach(function(block) {
-              hljs.highlightElement(block);
-            });
+          if (typeof window.enhanceCodeBlocks === 'function') {
+            window.enhanceCodeBlocks(previewPane);
           }
         });
       });

--- a/wiki/assets/tailwind/input.css
+++ b/wiki/assets/tailwind/input.css
@@ -321,6 +321,28 @@
   .copy-code-btn.copied .check-icon {
     @apply block;
   }
+
+  /* === Tabbed code groups ({% tabs %} … {% endtabs %}) === */
+  .code-tabs {
+    @apply my-3;
+  }
+  .code-tabs [hidden] {
+    display: none;
+  }
+  .code-tabs-bar {
+    @apply flex flex-wrap border-b border-gray-200 dark:border-gray-700;
+  }
+  .code-tabs-bar [role='tab'] {
+    @apply px-3 py-1.5 text-sm font-medium border-b-2 border-transparent -mb-px
+           text-gray-500 hover:text-gray-700
+           dark:text-gray-400 dark:hover:text-gray-300 transition-colors;
+  }
+  .code-tabs-bar [role='tab'].active {
+    @apply border-primary-500 text-primary-600 dark:text-primary-400;
+  }
+  .code-tabs .code-block-wrapper {
+    @apply mt-2 mb-0;
+  }
 }
 
 @layer components {

--- a/wiki/assets/tailwind/input.css
+++ b/wiki/assets/tailwind/input.css
@@ -324,24 +324,30 @@
 
   /* === Tabbed code groups ({% tabs %} … {% endtabs %}) === */
   .code-tabs {
-    @apply my-3;
+    @apply my-3 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700;
   }
   .code-tabs [hidden] {
     display: none;
   }
   .code-tabs-bar {
-    @apply flex flex-wrap border-b border-gray-200 dark:border-gray-700;
+    @apply flex flex-wrap gap-1 p-1.5 bg-gray-100 dark:bg-gray-900
+           border-b border-gray-200 dark:border-gray-700;
   }
   .code-tabs-bar [role='tab'] {
-    @apply px-3 py-1.5 text-sm font-medium border-b-2 border-transparent -mb-px
-           text-gray-500 hover:text-gray-700
-           dark:text-gray-400 dark:hover:text-gray-300 transition-colors;
+    @apply px-3 py-1 text-sm font-medium rounded-md
+           text-gray-500 hover:text-gray-700 hover:bg-gray-200/60
+           dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-700/60
+           transition-colors;
   }
   .code-tabs-bar [role='tab'].active {
-    @apply border-primary-500 text-primary-600 dark:text-primary-400;
+    @apply bg-white text-gray-900 shadow-sm
+           dark:bg-gray-700 dark:text-gray-100;
   }
   .code-tabs .code-block-wrapper {
-    @apply mt-2 mb-0;
+    @apply m-0;
+  }
+  .code-tabs pre code {
+    @apply rounded-none;
   }
 }
 

--- a/wiki/directories/templates/directories/form.html
+++ b/wiki/directories/templates/directories/form.html
@@ -6,6 +6,7 @@
 {% block head %}
 <link rel="stylesheet" href="{% static 'css/font-awesome.min.css' %}">
 <link rel="stylesheet" href="{% static 'css/easymde.min.css' %}">
+<link rel="stylesheet" href="{% static 'css/highlight.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -111,6 +112,8 @@
 
 {% block footer_scripts %}
 <script src="{% static 'js/easymde.min.js' %}"></script>
+<script src="{% static 'js/highlight.min.js' %}"></script>
+<script src="{% static 'js/code-blocks.js' %}"></script>
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -43,9 +43,11 @@ _BUTTON_LINK_RE = re.compile(
 # sanitized HTML, where the markers render as bare <p> tags). Only matches
 # when nothing but <pre> blocks sits between the markers, so malformed
 # groups keep their visible markers instead of silently half-converting.
+# The tempered dot ((?!</pre>).) keeps each <pre> unit unambiguous so a
+# missing {% endtabs %} can't trigger exponential backtracking (ReDoS).
 _CODE_TABS_RE = re.compile(
     r"<p>\{%\s*tabs\s*%\}</p>\s*"
-    r"((?:<pre>.*?</pre>\s*)+)"
+    r"((?:<pre>(?:(?!</pre>).)*</pre>\s*)+)"
     r"<p>\{%\s*endtabs\s*%\}</p>",
     re.DOTALL | re.IGNORECASE,
 )

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -39,6 +39,17 @@ _BUTTON_LINK_RE = re.compile(
     r"\s*\{button(?:-(outline|danger))?\}",
 )
 
+# Matches a {% tabs %}…{% endtabs %} group of fenced code blocks (runs on
+# sanitized HTML, where the markers render as bare <p> tags). Only matches
+# when nothing but <pre> blocks sits between the markers, so malformed
+# groups keep their visible markers instead of silently half-converting.
+_CODE_TABS_RE = re.compile(
+    r"<p>\{%\s*tabs\s*%\}</p>\s*"
+    r"((?:<pre>.*?</pre>\s*)+)"
+    r"<p>\{%\s*endtabs\s*%\}</p>",
+    re.DOTALL | re.IGNORECASE,
+)
+
 _SLUG_CHARS = r"[a-z0-9]+(?:-[a-z0-9]+)*"
 
 # Captures a wiki-link target: an optional directory path, the page slug,
@@ -551,6 +562,9 @@ _ALERT_MARKER_STRIP_RE = re.compile(
     r"\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*", re.IGNORECASE
 )
 _BUTTON_SUFFIX_STRIP_RE = re.compile(r"\{button(?:-(outline|danger))?\}")
+_TABS_MARKER_STRIP_RE = re.compile(
+    r"^\{%\s*(?:end)?tabs\s*%\}\s*$", re.MULTILINE | re.IGNORECASE
+)
 _UL_RE = re.compile(r"^[\s]*[-*+]\s+", re.MULTILINE)
 _OL_RE = re.compile(r"^[\s]*\d+\.\s+", re.MULTILINE)
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -578,6 +592,7 @@ def strip_markdown(text: str) -> str:
     text = _BLOCKQUOTE_RE.sub("", text)
     text = _ALERT_MARKER_STRIP_RE.sub("", text)
     text = _BUTTON_SUFFIX_STRIP_RE.sub("", text)
+    text = _TABS_MARKER_STRIP_RE.sub("", text)
     text = _UL_RE.sub("", text)
     text = _OL_RE.sub("", text)
     text = _WHITESPACE_RE.sub(" ", text).strip()
@@ -715,6 +730,23 @@ def _convert_button_links(html):
     return _BUTTON_LINK_RE.sub(replace_button, html)
 
 
+def _convert_code_tabs(html):
+    """Convert {% tabs %}…{% endtabs %} code-fence groups to tab containers.
+
+    Wraps the enclosed <pre> blocks in <div class="code-tabs">; the tab bar
+    itself is built client-side by code-blocks.js from each block's
+    language-* class. Runs after sanitization so injected HTML is already
+    stripped. Groups containing anything other than code blocks are left
+    untouched, keeping the markers visible as an authoring hint.
+    """
+
+    def replace_tabs(match):
+        blocks = match.group(1).strip()
+        return f'<div class="code-tabs">\n{blocks}\n</div>'
+
+    return _CODE_TABS_RE.sub(replace_tabs, html)
+
+
 def render_markdown(content, viewer=None):
     """Render markdown content to HTML with wiki link resolution and TOC.
 
@@ -755,6 +787,7 @@ def render_markdown(content, viewer=None):
     processed = _add_nofollow_to_non_public_links(sanitized)
     processed = _convert_alerts(processed)
     processed = _convert_button_links(processed)
+    processed = _convert_code_tabs(processed)
     result = MarkdownResult(processed)
     result.toc_html = _sanitize(toc) if toc else ""
     return result

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -39,16 +39,14 @@ _BUTTON_LINK_RE = re.compile(
     r"\s*\{button(?:-(outline|danger))?\}",
 )
 
-# Matches a {% tabs %}…{% endtabs %} group of fenced code blocks (runs on
-# sanitized HTML, where the markers render as bare <p> tags). Only matches
-# when nothing but <pre> blocks sits between the markers, so malformed
-# groups keep their visible markers instead of silently half-converting.
-# The tempered dot ((?!</pre>).) keeps each <pre> unit unambiguous so a
-# missing {% endtabs %} can't trigger exponential backtracking (ReDoS).
+# Matches a {% tabs %}…{% endtabs %} marker pair (runs on sanitized HTML,
+# where the markers render as bare <p> tags). Deliberately just a single
+# lazy group with no nested quantifiers — regex-based validation of the
+# enclosed <pre> blocks risks exponential backtracking (CodeQL); the
+# "only code blocks between markers" rule is checked by
+# _contains_only_pre_blocks with a linear string scan instead.
 _CODE_TABS_RE = re.compile(
-    r"<p>\{%\s*tabs\s*%\}</p>\s*"
-    r"((?:<pre>(?:(?!</pre>).)*</pre>\s*)+)"
-    r"<p>\{%\s*endtabs\s*%\}</p>",
+    r"<p>\{%\s*tabs\s*%\}</p>(.*?)<p>\{%\s*endtabs\s*%\}</p>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -732,6 +730,25 @@ def _convert_button_links(html):
     return _BUTTON_LINK_RE.sub(replace_button, html)
 
 
+def _contains_only_pre_blocks(fragment):
+    """Return True when fragment is one or more <pre>…</pre> blocks.
+
+    Only whitespace may separate the blocks. A linear string scan rather
+    than a regex, so pathological inputs can't trigger backtracking.
+    """
+    rest = fragment
+    if not rest:
+        return False
+    while rest:
+        if not rest.startswith("<pre>"):
+            return False
+        end = rest.find("</pre>")
+        if end == -1:
+            return False
+        rest = rest[end + len("</pre>") :].lstrip()
+    return True
+
+
 def _convert_code_tabs(html):
     """Convert {% tabs %}…{% endtabs %} code-fence groups to tab containers.
 
@@ -744,6 +761,8 @@ def _convert_code_tabs(html):
 
     def replace_tabs(match):
         blocks = match.group(1).strip()
+        if not _contains_only_pre_blocks(blocks):
+            return match.group(0)
         return f'<div class="code-tabs">\n{blocks}\n</div>'
 
     return _CODE_TABS_RE.sub(replace_tabs, html)

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -1,5 +1,6 @@
 """Tests for markdown utilities: strip_markdown, render_markdown, internal URL extraction."""
 
+import time
 from unittest.mock import patch
 
 import pytest
@@ -725,6 +726,18 @@ class TestConvertCodeTabs:
     def test_unclosed_marker_left_untouched(self):
         html = f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}"
         assert _convert_code_tabs(html) == html
+
+    def test_unclosed_marker_with_many_blocks_is_fast(self):
+        """Regression guard against catastrophic regex backtracking.
+
+        An unclosed {% tabs %} followed by many code blocks must fail to
+        match in linear time; the pre-tempered-dot regex took exponential
+        time on this input (CodeQL alert #10).
+        """
+        html = "<p>{% tabs %}</p>" + "<pre><code>x</code></pre>" * 40
+        start = time.monotonic()
+        assert _convert_code_tabs(html) == html
+        assert time.monotonic() - start < 1.0
 
 
 class TestCodeTabsEndToEnd:

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -12,6 +12,7 @@ from wiki.lib.markdown import (
     _add_nofollow_to_non_public_links,
     _convert_alerts,
     _convert_button_links,
+    _convert_code_tabs,
     extract_all_wiki_slugs,
     extract_slugs_from_internal_urls,
     render_markdown,
@@ -653,6 +654,134 @@ class TestStripMarkdownButtons:
     def test_strips_button_danger(self):
         result = strip_markdown("[Delete](/x){button-danger}")
         assert "{button-danger}" not in result
+
+
+class TestConvertCodeTabs:
+    """{% tabs %} groups of code blocks should become tab containers."""
+
+    PYTHON_PRE = (
+        '<pre><code class="python language-python">import requests\n'
+        "</code></pre>"
+    )
+    CURL_PRE = (
+        '<pre><code class="curl language-curl">curl -L https://x\n'
+        "</code></pre>"
+    )
+
+    def test_basic_group(self):
+        html = (
+            "<p>{% tabs %}</p>\n\n"
+            f"{self.PYTHON_PRE}\n\n{self.CURL_PRE}\n\n"
+            "<p>{% endtabs %}</p>"
+        )
+        result = _convert_code_tabs(html)
+        assert '<div class="code-tabs">' in result
+        assert result.count("<pre>") == 2
+        assert "{% tabs %}" not in result
+        assert "{% endtabs %}" not in result
+
+    def test_marker_spacing_variants(self):
+        html = (
+            f"<p>{{%tabs%}}</p>\n{self.PYTHON_PRE}\n<p>{{%  endtabs  %}}</p>"
+        )
+        result = _convert_code_tabs(html)
+        assert '<div class="code-tabs">' in result
+        assert "{%" not in result
+
+    def test_single_block_converts(self):
+        html = (
+            f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}\n<p>{{% endtabs %}}</p>"
+        )
+        result = _convert_code_tabs(html)
+        assert '<div class="code-tabs">' in result
+
+    def test_multiple_groups(self):
+        group = (
+            f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}\n<p>{{% endtabs %}}</p>"
+        )
+        html = f"{group}\n<p>Between.</p>\n{group}"
+        result = _convert_code_tabs(html)
+        assert result.count('<div class="code-tabs">') == 2
+        assert "<p>Between.</p>" in result
+
+    def test_non_code_content_left_untouched(self):
+        html = (
+            "<p>{% tabs %}</p>\n"
+            "<p>Stray paragraph.</p>\n"
+            f"{self.PYTHON_PRE}\n"
+            "<p>{% endtabs %}</p>"
+        )
+        assert _convert_code_tabs(html) == html
+
+    def test_content_after_blocks_left_untouched(self):
+        html = (
+            "<p>{% tabs %}</p>\n"
+            f"{self.PYTHON_PRE}\n"
+            "<p>Stray paragraph.</p>\n"
+            "<p>{% endtabs %}</p>"
+        )
+        assert _convert_code_tabs(html) == html
+
+    def test_unclosed_marker_left_untouched(self):
+        html = f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}"
+        assert _convert_code_tabs(html) == html
+
+
+class TestCodeTabsEndToEnd:
+    """Test {% tabs %} rendering through the full render_markdown pipeline."""
+
+    def test_tabs_render(self):
+        md = (
+            "{% tabs %}\n\n"
+            "```python\nimport requests\n```\n\n"
+            "```curl\ncurl -L https://example.com\n```\n\n"
+            "{% endtabs %}\n"
+        )
+        html = render_markdown(md)
+        assert '<div class="code-tabs">' in html
+        assert "language-python" in html
+        assert "language-curl" in html
+        assert "{% tabs %}" not in html
+
+    def test_mixed_content(self):
+        md = (
+            "Intro text.\n\n"
+            "{% tabs %}\n\n```python\nx = 1\n```\n\n{% endtabs %}\n\n"
+            "Outro text.\n"
+        )
+        html = render_markdown(md)
+        assert '<div class="code-tabs">' in html
+        assert "Intro text." in html
+        assert "Outro text." in html
+
+    def test_markers_inside_fence_left_untouched(self):
+        md = "```\n{% tabs %}\n{% endtabs %}\n```\n"
+        html = render_markdown(md)
+        assert "code-tabs" not in html
+        assert "{% tabs %}" in html
+
+    def test_text_between_fences_not_converted(self):
+        md = (
+            "{% tabs %}\n\n"
+            "```python\nx = 1\n```\n\n"
+            "Some stray text.\n\n"
+            "{% endtabs %}\n"
+        )
+        html = render_markdown(md)
+        assert "code-tabs" not in html
+        assert "{% tabs %}" in html
+
+
+class TestStripMarkdownCodeTabs:
+    """strip_markdown should remove {% tabs %} markers."""
+
+    def test_strips_tab_markers(self):
+        md = "Before.\n\n{% tabs %}\n\n```python\nx = 1\n```\n\n{% endtabs %}\n\nAfter."
+        result = strip_markdown(md)
+        assert "{% tabs %}" not in result
+        assert "{% endtabs %}" not in result
+        assert "Before." in result
+        assert "After." in result
 
 
 class TestAddNofollowToNonPublicLinks:

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -727,6 +727,10 @@ class TestConvertCodeTabs:
         html = f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}"
         assert _convert_code_tabs(html) == html
 
+    def test_empty_group_left_untouched(self):
+        html = "<p>{% tabs %}</p>\n<p>{% endtabs %}</p>"
+        assert _convert_code_tabs(html) == html
+
     def test_unclosed_marker_with_many_blocks_is_fast(self):
         """Regression guard against catastrophic regex backtracking.
 

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -312,6 +312,33 @@ def hello():
 ```
 ````
 
+### Tabbed code blocks
+
+To show the same example in several languages, wrap ordinary code
+fences in `{% tabs %}` and `{% endtabs %}` markers. Each fence becomes
+a tab, labeled by its language. Use ` ```curl ` for a cURL tab — it
+highlights as shell but gets a cURL label.
+
+````markdown
+{% tabs %}
+
+```curl
+curl https://example.com/api/
+```
+
+```python
+import requests
+requests.get("https://example.com/api/")
+```
+
+{% endtabs %}
+````
+
+Picking a tab switches every tab group on the page to that language,
+and the wiki remembers your choice on future pages. Only code fences
+may appear between the markers — anything else leaves the group
+unconverted so you can spot the mistake.
+
 ### Tables
 
 ```markdown

--- a/wiki/pages/templates/pages/form.html
+++ b/wiki/pages/templates/pages/form.html
@@ -197,6 +197,7 @@
 {% block footer_scripts %}
 <script src="{% static 'js/easymde.min.js' %}"></script>
 <script src="{% static 'js/highlight.min.js' %}"></script>
+<script src="{% static 'js/code-blocks.js' %}"></script>
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",

--- a/wiki/proposals/templates/proposals/feedback.html
+++ b/wiki/proposals/templates/proposals/feedback.html
@@ -6,6 +6,7 @@
 {% block head %}
 <link rel="stylesheet" href="{% static 'css/font-awesome.min.css' %}">
 <link rel="stylesheet" href="{% static 'css/easymde.min.css' %}">
+<link rel="stylesheet" href="{% static 'css/highlight.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -102,6 +103,8 @@
 
 {% block footer_scripts %}
 <script src="{% static 'js/easymde.min.js' %}"></script>
+<script src="{% static 'js/highlight.min.js' %}"></script>
+<script src="{% static 'js/code-blocks.js' %}"></script>
 <script type="application/json" id="editor-config">
 {
   "csrfToken": "{{ csrf_token }}",

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -668,3 +668,163 @@ class TestWikiLinkAutocomplete:
         with browser_page.expect_response("**/api/page-search/**"):
             browser_page.keyboard.type("f")
         dropdown.locator("[data-path]").first.wait_for(state="visible")
+
+
+# ── Tabbed code blocks ({% tabs %}) ──────────────────────────────────
+
+_TABS_GROUP_FULL = (
+    "{% tabs %}\n\n"
+    "```curl\ncurl -L https://example.com/api/\n```\n\n"
+    "```python\nimport requests\n```\n\n"
+    "```javascript\nawait fetch(url)\n```\n\n"
+    "{% endtabs %}"
+)
+_TABS_GROUP_SHORT = (
+    "{% tabs %}\n\n"
+    "```curl\ncurl -X POST https://example.com/api/\n```\n\n"
+    "```python\nimport httpx\n```\n\n"
+    "{% endtabs %}"
+)
+
+
+@pytest.fixture
+def tabbed_pages(browser_user, dir_tree):
+    """Two pages with tabbed code groups in the public docs directory."""
+    docs = Directory.objects.get(path="docs")
+
+    def make(slug, title, content):
+        p = WikiPage.objects.create(
+            title=title,
+            slug=slug,
+            content=content,
+            directory=docs,
+            owner=browser_user,
+            created_by=browser_user,
+            updated_by=browser_user,
+        )
+        PageRevision.objects.create(
+            page=p,
+            title=p.title,
+            content=p.content,
+            change_message="Initial creation",
+            revision_number=1,
+            created_by=browser_user,
+        )
+        return p
+
+    first = make(
+        "api-examples",
+        "API Examples",
+        f"Intro.\n\n{_TABS_GROUP_FULL}\n\nMiddle.\n\n{_TABS_GROUP_SHORT}\n",
+    )
+    second = make("more-examples", "More Examples", _TABS_GROUP_FULL)
+    return first, second
+
+
+@pytest.mark.django_db(transaction=True)
+class TestCodeTabs:
+    """Tabbed code groups: labels, cross-group sync, persistence, copy."""
+
+    def _goto(self, browser_page, live_server, wiki_page):
+        url = reverse("resolve_path", kwargs={"path": wiki_page.content_path})
+        browser_page.goto(f"{live_server.url}{url}")
+
+    def test_labels_and_default_selection(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[0])
+
+        groups = browser_page.locator(".code-tabs")
+        expect(groups).to_have_count(2)
+        first_tabs = groups.nth(0).locator("[role='tab']")
+        expect(first_tabs).to_have_text(["cURL", "Python", "JavaScript"])
+        expect(first_tabs.nth(0)).to_have_attribute("aria-selected", "true")
+
+        panels = groups.nth(0).locator(".code-block-wrapper")
+        expect(panels.nth(0)).to_be_visible()
+        expect(panels.nth(1)).to_be_hidden()
+        expect(panels.nth(2)).to_be_hidden()
+
+    def test_click_syncs_all_groups(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[0])
+
+        groups = browser_page.locator(".code-tabs")
+        groups.nth(0).get_by_role("tab", name="Python").click()
+
+        # Both groups switch to Python
+        expect(
+            groups.nth(0).get_by_role("tab", name="Python")
+        ).to_have_attribute("aria-selected", "true")
+        expect(
+            groups.nth(1).get_by_role("tab", name="Python")
+        ).to_have_attribute("aria-selected", "true")
+        expect(
+            groups.nth(1).locator(".code-block-wrapper").nth(0)
+        ).to_be_hidden()
+        expect(
+            groups.nth(1).locator(".code-block-wrapper").nth(1)
+        ).to_be_visible()
+
+    def test_selection_persists_across_pages(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[0])
+
+        browser_page.locator(".code-tabs").nth(0).get_by_role(
+            "tab", name="JavaScript"
+        ).click()
+
+        self._goto(browser_page, live_server, tabbed_pages[1])
+        group = browser_page.locator(".code-tabs").nth(0)
+        expect(group.get_by_role("tab", name="JavaScript")).to_have_attribute(
+            "aria-selected", "true"
+        )
+        expect(group.locator(".code-block-wrapper").nth(2)).to_be_visible()
+
+    def test_tabs_render_in_editor_preview(
+        self, browser_page, live_server, browser_user, dir_tree
+    ):
+        """The editor's Preview tab enhances injected HTML, so tab groups
+        get their tab bar there too — not just on detail views."""
+        _force_login(browser_page, live_server, browser_user)
+        browser_page.goto(f"{live_server.url}{reverse('page_create')}")
+
+        browser_page.wait_for_selector(".CodeMirror")
+        browser_page.evaluate(
+            "(content) => document.querySelector('.CodeMirror')"
+            ".CodeMirror.setValue(content)",
+            _TABS_GROUP_FULL,
+        )
+        with browser_page.expect_response("**/api/preview/**"):
+            browser_page.locator(".editor-tab[data-tab='preview']").click()
+
+        preview = browser_page.locator("#tab-preview-content")
+        expect(preview.locator(".code-tabs-bar")).to_be_visible()
+        tabs = preview.locator("[role='tab']")
+        expect(tabs).to_have_text(["cURL", "Python", "JavaScript"])
+        expect(tabs.nth(0)).to_have_attribute("aria-selected", "true")
+
+    def test_copy_button_copies_active_tab(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        browser_page.context.grant_permissions(
+            ["clipboard-read", "clipboard-write"]
+        )
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[1])
+
+        group = browser_page.locator(".code-tabs").nth(0)
+        group.get_by_role("tab", name="Python").click()
+        group.locator(
+            ".code-block-wrapper:not([hidden]) .copy-code-btn"
+        ).click()
+
+        clipboard = browser_page.evaluate(
+            "() => navigator.clipboard.readText()"
+        )
+        assert "import requests" in clipboard

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -685,6 +685,12 @@ _TABS_GROUP_SHORT = (
     "```python\nimport httpx\n```\n\n"
     "{% endtabs %}"
 )
+_TABS_GROUP_PLAIN = (
+    "{% tabs %}\n\n"
+    "```\nfirst plain block\n```\n\n"
+    "```\nsecond plain block\n```\n\n"
+    "{% endtabs %}"
+)
 
 
 @pytest.fixture
@@ -717,7 +723,11 @@ def tabbed_pages(browser_user, dir_tree):
         "API Examples",
         f"Intro.\n\n{_TABS_GROUP_FULL}\n\nMiddle.\n\n{_TABS_GROUP_SHORT}\n",
     )
-    second = make("more-examples", "More Examples", _TABS_GROUP_FULL)
+    second = make(
+        "more-examples",
+        "More Examples",
+        f"{_TABS_GROUP_FULL}\n\n{_TABS_GROUP_PLAIN}\n",
+    )
     return first, second
 
 
@@ -808,6 +818,31 @@ class TestCodeTabs:
         tabs = preview.locator("[role='tab']")
         expect(tabs).to_have_text(["cURL", "Python", "JavaScript"])
         expect(tabs.nth(0)).to_have_attribute("aria-selected", "true")
+
+    def test_unlabeled_tab_click_activates_clicked_tab(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        """Bare ``` fences have no language: clicking such a tab must
+        activate the clicked tab, not reset the group to its first tab
+        (regression: index lookup used to require a language)."""
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[1])
+
+        plain = browser_page.locator(".code-tabs").nth(1)
+        tabs = plain.locator("[role='tab']")
+        expect(tabs).to_have_text(["Text", "Text"])
+
+        tabs.nth(1).click()
+        expect(tabs.nth(1)).to_have_attribute("aria-selected", "true")
+        expect(plain.locator(".code-block-wrapper").nth(1)).to_be_visible()
+        expect(plain.locator(".code-block-wrapper").nth(0)).to_be_hidden()
+
+        # A language-less selection is local: the labeled group keeps its
+        # own selection.
+        labeled = browser_page.locator(".code-tabs").nth(0)
+        expect(labeled.get_by_role("tab", name="cURL")).to_have_attribute(
+            "aria-selected", "true"
+        )
 
     def test_copy_button_copies_active_tab(
         self, browser_page, live_server, browser_user, tabbed_pages


### PR DESCRIPTION
## Fixes
Fixes: #133

## Summary
This PR adds tabbed code blocks: authors wrap ordinary code fences in GitBook-style `{% tabs %}` / `{% endtabs %}` markers, and each fence renders as a tab labeled by its language. Selecting a language switches every tab group on the page and persists to future pages via localStorage. ` ```curl ` fences get a "cURL" label while highlighting with bash rules.

**Approach:**
- **Server** (`wiki/lib/markdown.py`): a post-sanitize regex transform (same pattern as the GitHub-alerts converter) wraps the fence run in `<div class="code-tabs">`. It only matches when nothing but `<pre>` blocks sit between the markers — malformed groups keep their visible markers as an authoring hint, and markers inside a code fence stay literal. Because it runs inside `render_markdown()`, the editor preview endpoint gets it for free.
- **Client** (`code-blocks.js`): builds the tab bar client-side (ARIA tablist/tab roles, arrow-key navigation, `aria-selected`) from each block's `language-*` class. Vanilla JS rather than Alpine because the markup comes from user content, so Alpine directives would have had to survive nh3 sanitization. The file now exposes `window.enhanceCodeBlocks(root)`, which the editor preview calls on injected HTML — tabs and copy buttons now work in Preview too.
- `strip_markdown()` strips the markers so they don't leak into search previews.
- The markdown-syntax help page documents the new syntax (updates on deploy via `seed_help_pages` in the entrypoint).
- Drive-by: the directory-edit and proposal-feedback editor previews were silently skipping syntax highlighting (no highlight.js loaded); they now load it.

**Compromises/gotchas:**
- Tab labels derive from the fence language via a friendly-name map (custom titles in the fence info string break markdown2's fence parsing entirely).
- Without JS the group degrades to stacked code blocks (e.g. proposals review page, which loads no code JS).

**Testing:** 13 new unit tests (`wiki/lib/tests_markdown.py`) and 5 new Playwright tests (`wiki/tests_browser.py`) covering labels, cross-group sync, localStorage persistence across pages, per-tab copy, and editor preview. Full suite passes.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No special steps beyond the standard deploy; the help page updates automatically via `seed_help_pages` in the entrypoint.

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>
<!-- Screenshots to be dragged in -->
</details>
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tabbed code blocks (`{% tabs %}` / `{% endtabs %}`) with language-labeled tabs, synchronized selection across multiple groups, keyboard navigation, and persisted tab choice across pages.
  * Improved syntax highlighting and copy-to-clipboard for the active tab, including in the editor preview.
* **Bug Fixes**
  * Convert only well-formed tab groups containing code blocks; malformed/unclosed markers remain unchanged.
  * Text extraction now omits tab markers while preserving surrounding content.
* **Documentation**
  * Updated the Markdown Syntax help page with tabbed code block instructions and examples.
* **Tests**
  * Added end-to-end and unit coverage for tab rendering, selection behavior, and clipboard copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->