### PR TITLE
H1-defined content tabs + document markdown in data-source values

### DIFF
--- a/wiki/assets/static-global/js/code-blocks.js
+++ b/wiki/assets/static-global/js/code-blocks.js
@@ -137,6 +137,10 @@
       tab.addEventListener('click', function () {
         rememberTab(label);
         selectTab(label);
+        // selectTab resolves a label to the first match per group; make
+        // the clicked tab win in its own group so a duplicate name
+        // doesn't leave later occurrences unreachable.
+        activateGroup(group, i);
       });
       bar.appendChild(tab);
     });

--- a/wiki/assets/static-global/js/code-blocks.js
+++ b/wiki/assets/static-global/js/code-blocks.js
@@ -1,65 +1,20 @@
 /**
  * Code block enhancements: syntax highlighting, copy buttons, and tabbed
- * code groups ({% tabs %} markup, rendered as <div class="code-tabs">).
+ * content groups ({% tabs %} markup, rendered as <div class="content-tabs">
+ * of labeled panels).
  *
  * Loaded after highlight.js on detail views and editor forms. Runs on DOM
  * ready for each .wiki-content container, and is exposed as
  * window.enhanceCodeBlocks(root) so the editor preview can enhance
  * HTML it injects after the fact.
  *
- * Tab selection is shared: picking a language activates it in every tab
- * group on the page that offers it, and persists across pages via
- * localStorage.
+ * Tab selection is shared: picking a tab activates every same-named tab
+ * on the page, and persists across pages via localStorage.
  */
 (function () {
-  var STORAGE_KEY = 'wiki-code-tab';
+  var STORAGE_KEY = 'wiki-content-tab';
 
-  var LANG_LABELS = {
-    bash: 'Bash',
-    cpp: 'C++',
-    csharp: 'C#',
-    css: 'CSS',
-    curl: 'cURL',
-    go: 'Go',
-    html: 'HTML',
-    java: 'Java',
-    javascript: 'JavaScript',
-    js: 'JavaScript',
-    json: 'JSON',
-    php: 'PHP',
-    plaintext: 'Text',
-    py: 'Python',
-    python: 'Python',
-    ruby: 'Ruby',
-    rust: 'Rust',
-    sh: 'Shell',
-    shell: 'Shell',
-    sql: 'SQL',
-    ts: 'TypeScript',
-    typescript: 'TypeScript',
-    xml: 'XML',
-    yaml: 'YAML',
-    yml: 'YAML',
-  };
-
-  // ```curl fences keep their language-curl class (and cURL tab label) but
-  // highlight with bash rules.
-  if (typeof hljs !== 'undefined') {
-    hljs.registerAliases('curl', { languageName: 'bash' });
-  }
-
-  function langOf(code) {
-    var match = code.className.match(/language-([\w+-]+)/);
-    return match ? match[1].toLowerCase() : '';
-  }
-
-  function labelFor(lang) {
-    if (!lang) return 'Text';
-    if (LANG_LABELS[lang]) return LANG_LABELS[lang];
-    return lang.charAt(0).toUpperCase() + lang.slice(1);
-  }
-
-  function storedLang() {
+  function storedTab() {
     try {
       return localStorage.getItem(STORAGE_KEY);
     } catch (e) {
@@ -67,9 +22,9 @@
     }
   }
 
-  function rememberLang(lang) {
+  function rememberTab(label) {
     try {
-      localStorage.setItem(STORAGE_KEY, lang);
+      localStorage.setItem(STORAGE_KEY, label);
     } catch (e) {
       /* storage unavailable — selection just won't persist */
     }
@@ -80,10 +35,6 @@
   function enhanceBlock(code) {
     if (code.dataset.enhanced) return;
     code.dataset.enhanced = 'true';
-
-    // Record the authored language before highlighting: hljs auto-detection
-    // adds a language-* class to bare blocks, which would fake a tab label.
-    code.dataset.lang = langOf(code);
 
     if (typeof hljs !== 'undefined') {
       hljs.highlightElement(code);
@@ -123,20 +74,20 @@
     wrapper.appendChild(btn);
   }
 
-  // ── Tabbed code groups ─────────────────────────────────────────────
+  // ── Tabbed content groups ──────────────────────────────────────────
 
   var groupCount = 0;
 
   function groupPanels(group) {
     return [].slice.call(group.children).filter(function (el) {
-      return el.classList.contains('code-block-wrapper');
+      return el.classList.contains('content-tab-panel');
     });
   }
 
-  function tabIndexForLang(group, lang) {
+  function tabIndexForLabel(group, label) {
     var tabs = group.querySelectorAll('[role="tab"]');
     for (var i = 0; i < tabs.length; i++) {
-      if (tabs[i].dataset.lang === lang) return i;
+      if (tabs[i].dataset.label === label) return i;
     }
     return -1;
   }
@@ -153,44 +104,39 @@
     });
   }
 
-  function selectLang(lang) {
-    document.querySelectorAll('.code-tabs').forEach(function (group) {
-      var index = tabIndexForLang(group, lang);
+  function selectTab(label) {
+    document.querySelectorAll('.content-tabs').forEach(function (group) {
+      var index = tabIndexForLabel(group, label);
       if (index !== -1) activateGroup(group, index);
     });
   }
 
   function buildTabGroup(group) {
-    if (group.querySelector('.code-tabs-bar')) return;
+    if (group.querySelector('.content-tabs-bar')) return;
     var panels = groupPanels(group);
     if (!panels.length) return;
     var groupId = ++groupCount;
 
     var bar = document.createElement('div');
-    bar.className = 'code-tabs-bar';
+    bar.className = 'content-tabs-bar';
     bar.setAttribute('role', 'tablist');
-    bar.setAttribute('aria-label', 'Code examples');
+    bar.setAttribute('aria-label', 'Tabs');
 
     panels.forEach(function (panel, i) {
-      var code = panel.querySelector('pre code');
-      var lang = (code && code.dataset.lang) || '';
+      var label = panel.dataset.label || 'Tab ' + (i + 1);
       var tab = document.createElement('button');
       tab.type = 'button';
-      tab.id = 'code-tab-' + groupId + '-' + i;
+      tab.id = 'content-tab-' + groupId + '-' + i;
       tab.setAttribute('role', 'tab');
-      tab.setAttribute('aria-controls', 'code-tabpanel-' + groupId + '-' + i);
-      tab.dataset.lang = lang;
-      tab.textContent = labelFor(lang);
-      panel.id = 'code-tabpanel-' + groupId + '-' + i;
+      tab.setAttribute('aria-controls', 'content-tabpanel-' + groupId + '-' + i);
+      tab.dataset.label = label;
+      tab.textContent = label;
+      panel.id = 'content-tabpanel-' + groupId + '-' + i;
       panel.setAttribute('role', 'tabpanel');
       panel.setAttribute('aria-labelledby', tab.id);
       tab.addEventListener('click', function () {
-        if (lang) {
-          rememberLang(lang);
-          selectLang(lang);
-        } else {
-          activateGroup(group, i);
-        }
+        rememberTab(label);
+        selectTab(label);
       });
       bar.appendChild(tab);
     });
@@ -209,8 +155,8 @@
 
     group.insertBefore(bar, group.firstChild);
 
-    var remembered = storedLang();
-    var index = remembered ? tabIndexForLang(group, remembered) : -1;
+    var remembered = storedTab();
+    var index = remembered ? tabIndexForLabel(group, remembered) : -1;
     activateGroup(group, index === -1 ? 0 : index);
   }
 
@@ -218,7 +164,7 @@
 
   function enhanceCodeBlocks(root) {
     root.querySelectorAll('pre code').forEach(enhanceBlock);
-    root.querySelectorAll('.code-tabs').forEach(buildTabGroup);
+    root.querySelectorAll('.content-tabs').forEach(buildTabGroup);
   }
 
   window.enhanceCodeBlocks = enhanceCodeBlocks;

--- a/wiki/assets/tailwind/input.css
+++ b/wiki/assets/tailwind/input.css
@@ -322,32 +322,35 @@
     @apply block;
   }
 
-  /* === Tabbed code groups ({% tabs %} … {% endtabs %}) === */
-  .code-tabs {
+  /* === Tabbed content groups ({% tabs %} … {% endtabs %}) === */
+  .content-tabs {
     @apply my-3 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700;
   }
-  .code-tabs [hidden] {
+  .content-tabs [hidden] {
     display: none;
   }
-  .code-tabs-bar {
+  .content-tabs-bar {
     @apply flex flex-wrap gap-1 p-1.5 bg-gray-100 dark:bg-gray-900
            border-b border-gray-200 dark:border-gray-700;
   }
-  .code-tabs-bar [role='tab'] {
+  .content-tabs-bar [role='tab'] {
     @apply px-3 py-1 text-sm font-medium rounded-md
            text-gray-500 hover:text-gray-700 hover:bg-gray-200/60
            dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-700/60
            transition-colors;
   }
-  .code-tabs-bar [role='tab'].active {
+  .content-tabs-bar [role='tab'].active {
     @apply bg-white text-gray-900 shadow-sm
            dark:bg-gray-700 dark:text-gray-100;
   }
-  .code-tabs .code-block-wrapper {
-    @apply m-0;
+  .content-tab-panel {
+    @apply px-4 py-3;
   }
-  .code-tabs pre code {
-    @apply rounded-none;
+  .content-tab-panel > :first-child {
+    @apply mt-0;
+  }
+  .content-tab-panel > :last-child {
+    @apply mb-0;
   }
 }
 

--- a/wiki/lib/data_source.py
+++ b/wiki/lib/data_source.py
@@ -28,8 +28,12 @@ _cache_lock = threading.Lock()
 # Matches [[ key ]] or [[ nested.key ]] placeholders
 DATA_VAR_RE = re.compile(r"\[\[\s*([\w.]+)\s*\]\]")
 
-# Protect fenced code blocks and inline code from substitution
-_FENCED_CODE_RE = re.compile(r"```[\s\S]*?```")
+# Protect fenced code blocks and inline code from substitution. The
+# fence pattern is length-aware (a fence closes only on a run at least
+# as long as its opener, per markdown2) so an outer ```` fence wrapping
+# a literal ``` example is protected as one region, not two — a naive
+# ``` matcher left the wrapped content in an unprotected gap.
+_FENCED_CODE_RE = re.compile(r"(`{3,})[\s\S]*?\1`*")
 _INLINE_CODE_RE = re.compile(r"`[^`]+`")
 
 # Safety limits

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -5,6 +5,8 @@ resolved to actual page URLs or shown as red links for missing pages.
 """
 
 import re
+from html import escape as html_escape
+from html import unescape as html_unescape
 from urllib.parse import urlparse
 
 import markdown2
@@ -42,12 +44,29 @@ _BUTTON_LINK_RE = re.compile(
 # Matches a {% tabs %}…{% endtabs %} marker pair (runs on sanitized HTML,
 # where the markers render as bare <p> tags). Deliberately just a single
 # lazy group with no nested quantifiers — regex-based validation of the
-# enclosed <pre> blocks risks exponential backtracking (CodeQL); the
-# "only code blocks between markers" rule is checked by
-# _contains_only_pre_blocks with a linear string scan instead.
-_CODE_TABS_RE = re.compile(
+# enclosed content risks exponential backtracking (CodeQL); structure is
+# validated by splitting on _TAB_MARKER_HTML_RE instead.
+_TABS_RE = re.compile(
     r"<p>\{%\s*tabs\s*%\}</p>(.*?)<p>\{%\s*endtabs\s*%\}</p>",
     re.DOTALL | re.IGNORECASE,
+)
+
+# Matches the {% tab Name %} paragraphs emitted by _convert_tab_headings
+# once markdown rendering wraps them in <p> tags. Name may carry inline
+# HTML (a heading like `# *macOS*`) — tags are stripped on extraction.
+_TAB_MARKER_HTML_RE = re.compile(
+    r"<p>\{%\s*tab\s+(.*?)\s*%\}</p>", re.DOTALL | re.IGNORECASE
+)
+
+# A {% tabs %} or {% endtabs %} line in markdown source (group 1 is the
+# "end" prefix, absent on the opening marker)
+_TABS_BOUNDARY_RE = re.compile(
+    r"^\s*\{%\s*(end)?tabs\s*%\}\s*$", re.IGNORECASE
+)
+
+# An ATX H1 line: exactly one #, required space, optional closing hashes
+_TAB_HEADING_RE = re.compile(
+    r"^ {0,3}#[ \t]+(?P<name>.+?)(?:[ \t]+#+)?[ \t]*$"
 )
 
 _SLUG_CHARS = r"[a-z0-9]+(?:-[a-z0-9]+)*"
@@ -730,42 +749,80 @@ def _convert_button_links(html):
     return _BUTTON_LINK_RE.sub(replace_button, html)
 
 
-def _contains_only_pre_blocks(fragment):
-    """Return True when fragment is one or more <pre>…</pre> blocks.
+def _convert_tab_headings(content):
+    """Rewrite H1 lines inside {% tabs %} regions to {% tab %} markers.
 
-    Only whitespace may separate the blocks. A linear string scan rather
-    than a regex, so pathological inputs can't trigger backtracking.
+    Runs on markdown source, before markdown2, so the tab-name headings
+    never get header ids and never enter the TOC — they are UI labels,
+    not document structure. Each marker is padded with blank lines so it
+    renders as its own ``<p>{% tab Name %}</p>``, which _convert_tabs
+    then turns into a panel boundary.
+
+    A line-by-line scan tracks fence state so H1s inside code blocks
+    (and marker examples shown in fences) are left alone.
     """
-    rest = fragment
-    if not rest:
-        return False
-    while rest:
-        if not rest.startswith("<pre>"):
-            return False
-        end = rest.find("</pre>")
-        if end == -1:
-            return False
-        rest = rest[end + len("</pre>") :].lstrip()
-    return True
+    if "{%" not in content:
+        return content
+
+    out = []
+    in_fence = False
+    in_tabs = False
+    for line in content.split("\n"):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+        boundary = _TABS_BOUNDARY_RE.match(line)
+        if boundary:
+            in_tabs = boundary.group(1) is None
+            out.append(line)
+            continue
+        if in_tabs:
+            heading = _TAB_HEADING_RE.match(line)
+            if heading:
+                out.extend(["", f"{{% tab {heading.group('name')} %}}", ""])
+                continue
+        out.append(line)
+    return "\n".join(out)
 
 
-def _convert_code_tabs(html):
-    """Convert {% tabs %}…{% endtabs %} code-fence groups to tab containers.
+def _convert_tabs(html):
+    """Convert {% tabs %}…{% endtabs %} groups to content-tab containers.
 
-    Wraps the enclosed <pre> blocks in <div class="code-tabs">; the tab bar
-    itself is built client-side by code-blocks.js from each block's
-    language-* class. Runs after sanitization so injected HTML is already
-    stripped. Groups containing anything other than code blocks are left
-    untouched, keeping the markers visible as an authoring hint.
+    Splits the region on the ``<p>{% tab Name %}</p>`` markers produced by
+    _convert_tab_headings and wraps each section in a labeled panel div;
+    the tab bar itself is built client-side by code-blocks.js from each
+    panel's data-label. Regions with no tab markers, content before the
+    first marker, or an empty tab name are left untouched, keeping the
+    markers visible as an authoring hint.
     """
 
     def replace_tabs(match):
-        blocks = match.group(1).strip()
-        if not _contains_only_pre_blocks(blocks):
+        parts = _TAB_MARKER_HTML_RE.split(match.group(1))
+        # parts = [before_first_marker, label1, body1, label2, body2, …]
+        if len(parts) < 3 or parts[0].strip():
             return match.group(0)
-        return f'<div class="code-tabs">\n{blocks}\n</div>'
+        panels = []
+        for label_html, body in zip(parts[1::2], parts[2::2]):
+            label = _HTML_TAG_RE.sub("", label_html)
+            label = _WHITESPACE_RE.sub(" ", label).strip()
+            if not label:
+                return match.group(0)
+            # SECURITY: runs post-sanitization, so a quote in the heading
+            # text could otherwise break out of the data-label attribute.
+            # Unescape first — the label text is already entity-encoded
+            # sanitized HTML and would double-escape.
+            attr = html_escape(html_unescape(label))
+            panels.append(
+                f'<div class="content-tab-panel" data-label="{attr}">\n'
+                f"{body.strip()}\n</div>"
+            )
+        return '<div class="content-tabs">\n' + "\n".join(panels) + "\n</div>"
 
-    return _CODE_TABS_RE.sub(replace_tabs, html)
+    return _TABS_RE.sub(replace_tabs, html)
 
 
 def render_markdown(content, viewer=None):
@@ -777,6 +834,7 @@ def render_markdown(content, viewer=None):
     user-facing call site; leave it None only for system/no-viewer contexts.
     """
     content = resolve_wiki_links(content, viewer=viewer)
+    content = _convert_tab_headings(content)
     html = markdown2.markdown(
         content,
         extras={
@@ -808,7 +866,7 @@ def render_markdown(content, viewer=None):
     processed = _add_nofollow_to_non_public_links(sanitized)
     processed = _convert_alerts(processed)
     processed = _convert_button_links(processed)
-    processed = _convert_code_tabs(processed)
+    processed = _convert_tabs(processed)
     result = MarkdownResult(processed)
     result.toc_html = _sanitize(toc) if toc else ""
     return result

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -749,6 +749,34 @@ def _convert_button_links(html):
     return _BUTTON_LINK_RE.sub(replace_button, html)
 
 
+def _closed_tabs_ranges(lines):
+    """Return (start, end) line-index pairs of closed {% tabs %} regions.
+
+    Fence-aware: markers inside code fences don't count. Only regions
+    with a matching ``{% endtabs %}`` are returned — an unclosed opening
+    marker yields no range, so headings after it are left alone rather
+    than silently consumed for the rest of the document.
+    """
+    ranges = []
+    in_fence = False
+    open_idx = None
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        boundary = _TABS_BOUNDARY_RE.match(line)
+        if not boundary:
+            continue
+        if boundary.group(1) is None:
+            open_idx = i
+        elif open_idx is not None:
+            ranges.append((open_idx, i))
+            open_idx = None
+    return ranges
+
+
 def _convert_tab_headings(content):
     """Rewrite H1 lines inside {% tabs %} regions to {% tab %} markers.
 
@@ -758,29 +786,25 @@ def _convert_tab_headings(content):
     renders as its own ``<p>{% tab Name %}</p>``, which _convert_tabs
     then turns into a panel boundary.
 
-    A line-by-line scan tracks fence state so H1s inside code blocks
-    (and marker examples shown in fences) are left alone.
+    Only properly closed regions are rewritten (see _closed_tabs_ranges),
+    and H1s inside code fences are left alone.
     """
     if "{%" not in content:
         return content
 
+    lines = content.split("\n")
+    ranges = _closed_tabs_ranges(lines)
+    if not ranges:
+        return content
+
     out = []
     in_fence = False
-    in_tabs = False
-    for line in content.split("\n"):
+    for i, line in enumerate(lines):
         if line.lstrip().startswith("```"):
             in_fence = not in_fence
             out.append(line)
             continue
-        if in_fence:
-            out.append(line)
-            continue
-        boundary = _TABS_BOUNDARY_RE.match(line)
-        if boundary:
-            in_tabs = boundary.group(1) is None
-            out.append(line)
-            continue
-        if in_tabs:
+        if not in_fence and any(start < i < end for start, end in ranges):
             heading = _TAB_HEADING_RE.match(line)
             if heading:
                 out.extend(["", f"{{% tab {heading.group('name')} %}}", ""])
@@ -806,7 +830,7 @@ def _convert_tabs(html):
         if len(parts) < 3 or parts[0].strip():
             return match.group(0)
         panels = []
-        for label_html, body in zip(parts[1::2], parts[2::2]):
+        for label_html, body in zip(parts[1::2], parts[2::2], strict=True):
             label = _HTML_TAG_RE.sub("", label_html)
             label = _WHITESPACE_RE.sub(" ", label).strip()
             if not label:

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -69,6 +69,9 @@ _TAB_HEADING_RE = re.compile(
     r"^ {0,3}#[ \t]+(?P<name>.+?)(?:[ \t]+#+)?[ \t]*$"
 )
 
+# A fence delimiter line; group 1's length decides what closes the fence
+_FENCE_LINE_RE = re.compile(r"^\s*(`{3,})")
+
 _SLUG_CHARS = r"[a-z0-9]+(?:-[a-z0-9]+)*"
 
 # Captures a wiki-link target: an optional directory path, the page slug,
@@ -749,6 +752,28 @@ def _convert_button_links(html):
     return _BUTTON_LINK_RE.sub(replace_button, html)
 
 
+def _fence_scan(lines):
+    """Yield (index, line, in_fence) with length-aware fence tracking.
+
+    Mirrors markdown2's rule: a fence closes only on a backtick run at
+    least as long as the one that opened it, so an outer ```` fence
+    wrapping a literal ``` example stays open across the inner fences.
+    Delimiter lines themselves report ``in_fence=True``.
+    """
+    fence_len = 0
+    for i, line in enumerate(lines):
+        delim = _FENCE_LINE_RE.match(line)
+        if delim:
+            run = len(delim.group(1))
+            if not fence_len:
+                fence_len = run
+            elif run >= fence_len:
+                fence_len = 0
+            yield i, line, True
+            continue
+        yield i, line, bool(fence_len)
+
+
 def _closed_tabs_ranges(lines):
     """Return (start, end) line-index pairs of closed {% tabs %} regions.
 
@@ -758,12 +783,8 @@ def _closed_tabs_ranges(lines):
     than silently consumed for the rest of the document.
     """
     ranges = []
-    in_fence = False
     open_idx = None
-    for i, line in enumerate(lines):
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            continue
+    for i, line, in_fence in _fence_scan(lines):
         if in_fence:
             continue
         boundary = _TABS_BOUNDARY_RE.match(line)
@@ -784,7 +805,10 @@ def _convert_tab_headings(content):
     never get header ids and never enter the TOC — they are UI labels,
     not document structure. Each marker is padded with blank lines so it
     renders as its own ``<p>{% tab Name %}</p>``, which _convert_tabs
-    then turns into a panel boundary.
+    then turns into a panel boundary. The {% tabs %}/{% endtabs %} lines
+    of converted regions get the same padding, so a missing blank line
+    around a boundary can't merge it into a neighboring paragraph and
+    stop _TABS_RE from matching.
 
     Only properly closed regions are rewritten (see _closed_tabs_ranges),
     and H1s inside code fences are left alone.
@@ -796,13 +820,12 @@ def _convert_tab_headings(content):
     ranges = _closed_tabs_ranges(lines)
     if not ranges:
         return content
+    boundary_lines = {i for pair in ranges for i in pair}
 
     out = []
-    in_fence = False
-    for i, line in enumerate(lines):
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            out.append(line)
+    for i, line, in_fence in _fence_scan(lines):
+        if i in boundary_lines:
+            out.extend(["", line, ""])
             continue
         if not in_fence and any(start < i < end for start, end in ranges):
             heading = _TAB_HEADING_RE.match(line)

--- a/wiki/lib/tests_data_source.py
+++ b/wiki/lib/tests_data_source.py
@@ -130,6 +130,14 @@ class TestSubstituteDataVariables:
         data = {"key": "replaced"}
         assert substitute_data_variables(content, data) == content
 
+    def test_nested_fence_fully_protected(self):
+        """A ```` fence wrapping a literal ``` example is one protected
+        region — the wrapped placeholder must not sit in an unprotected
+        gap between two naive triple-backtick matches."""
+        content = "````\n```\nUse [[ key ]] to show the count.\n```\n````"
+        data = {"key": "replaced"}
+        assert substitute_data_variables(content, data) == content
+
     def test_inline_code_not_substituted(self):
         content = "Use `[[ key ]]` syntax"
         data = {"key": "replaced"}

--- a/wiki/lib/tests_data_source.py
+++ b/wiki/lib/tests_data_source.py
@@ -17,6 +17,7 @@ from wiki.lib.data_source import (
     is_domain_allowed,
     substitute_data_variables,
 )
+from wiki.pages.models import Page
 
 
 @pytest.fixture(autouse=True)
@@ -256,15 +257,11 @@ class TestFetchPageData:
 @pytest.mark.django_db
 class TestPageDataSourceIntegration:
     def test_page_has_data_source_fields(self):
-        from wiki.pages.models import Page
-
         page = Page(title="Test", content="Hello [[ name ]]")
         assert page.data_source_url == ""
         assert page.data_source_ttl == 300
 
     def test_render_with_data_source(self, client, json_server):
-        from wiki.pages.models import Page
-
         url = json_server({"name": "World"})
         page = Page.objects.create(
             title="Data Test",
@@ -277,8 +274,6 @@ class TestPageDataSourceIntegration:
         assert b"Hello World!" in response.content
 
     def test_render_without_data_source(self, client):
-        from wiki.pages.models import Page
-
         page = Page.objects.create(
             title="Plain Page",
             content="Hello [[ name ]]!",
@@ -287,6 +282,38 @@ class TestPageDataSourceIntegration:
         assert response.status_code == 200
         # Placeholder should remain (no data source configured)
         assert b"[[ name ]]" in response.content
+
+    def test_markdown_in_value_is_rendered(self, client, json_server):
+        """Substitution runs before markdown rendering, so markdown in
+        API values is parsed like any other page content."""
+        url = json_server(
+            {"status": "**degraded** ([details](https://status.example.com))"}
+        )
+        page = Page.objects.create(
+            title="Markdown Value Test",
+            content="Current status: [[ status ]]",
+            data_source_url=url,
+            data_source_ttl=60,
+        )
+        response = client.get(page.get_absolute_url())
+        assert response.status_code == 200
+        assert b"<strong>degraded</strong>" in response.content
+        assert b'href="https://status.example.com"' in response.content
+
+    def test_html_in_value_is_sanitized(self, client, json_server):
+        """Raw HTML arriving via API values goes through the same nh3
+        sanitization as authored content."""
+        url = json_server({"evil": "<script>alert('xss')</script>"})
+        page = Page.objects.create(
+            title="Sanitize Value Test",
+            content="Payload: [[ evil ]]",
+            data_source_url=url,
+            data_source_ttl=60,
+        )
+        response = client.get(page.get_absolute_url())
+        assert response.status_code == 200
+        assert b"<script>" not in response.content
+        assert b"alert(" not in response.content
 
 
 # ── Domain allowlist ──────────────────────────────────────────────────

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -13,7 +13,8 @@ from wiki.lib.markdown import (
     _add_nofollow_to_non_public_links,
     _convert_alerts,
     _convert_button_links,
-    _convert_code_tabs,
+    _convert_tab_headings,
+    _convert_tabs,
     extract_all_wiki_slugs,
     extract_slugs_from_internal_urls,
     render_markdown,
@@ -657,79 +658,115 @@ class TestStripMarkdownButtons:
         assert "{button-danger}" not in result
 
 
-class TestConvertCodeTabs:
-    """{% tabs %} groups of code blocks should become tab containers."""
+class TestConvertTabHeadings:
+    """H1 lines inside {% tabs %} regions become {% tab %} markers."""
 
-    PYTHON_PRE = (
-        '<pre><code class="python language-python">import requests\n'
-        "</code></pre>"
-    )
-    CURL_PRE = (
-        '<pre><code class="curl language-curl">curl -L https://x\n'
-        "</code></pre>"
-    )
+    def test_h1_inside_tabs_rewritten(self):
+        md = "{% tabs %}\n# One\nBody.\n{% endtabs %}"
+        out = _convert_tab_headings(md)
+        assert "{% tab One %}" in out
+        assert "# One" not in out
+
+    def test_h1_outside_tabs_untouched(self):
+        md = "# Title\n\n{% tabs %}\n# One\n{% endtabs %}"
+        out = _convert_tab_headings(md)
+        assert out.startswith("# Title")
+        assert "{% tab One %}" in out
+
+    def test_h1_inside_fence_untouched(self):
+        md = "{% tabs %}\n# One\n```\n# comment\n```\n{% endtabs %}"
+        out = _convert_tab_headings(md)
+        assert "{% tab One %}" in out
+        assert "# comment" in out
+        assert "{% tab comment %}" not in out
+
+    def test_h2_not_a_tab(self):
+        md = "{% tabs %}\n# One\n## Sub\n{% endtabs %}"
+        out = _convert_tab_headings(md)
+        assert "## Sub" in out
+
+    def test_closing_hashes_stripped(self):
+        md = "{% tabs %}\n# One #\nBody\n{% endtabs %}"
+        assert "{% tab One %}" in _convert_tab_headings(md)
+
+    def test_markers_inside_fence_ignored(self):
+        md = "```\n{% tabs %}\n# Not a tab\n{% endtabs %}\n```"
+        assert _convert_tab_headings(md) == md
+
+    def test_no_markers_fast_path(self):
+        md = "# Plain page\n\nNo tabs here."
+        assert _convert_tab_headings(md) == md
+
+
+class TestConvertTabs:
+    """{% tabs %} groups with {% tab %} markers become tab containers."""
+
+    ONE = "<p>{% tab One %}</p>\n<p>First body.</p>"
+    TWO = "<p>{% tab Two %}</p>\n<p>Second body.</p>"
+
+    def _group(self, inner):
+        return f"<p>{{% tabs %}}</p>\n{inner}\n<p>{{% endtabs %}}</p>"
 
     def test_basic_group(self):
-        html = (
-            "<p>{% tabs %}</p>\n\n"
-            f"{self.PYTHON_PRE}\n\n{self.CURL_PRE}\n\n"
-            "<p>{% endtabs %}</p>"
-        )
-        result = _convert_code_tabs(html)
-        assert '<div class="code-tabs">' in result
-        assert result.count("<pre>") == 2
-        assert "{% tabs %}" not in result
-        assert "{% endtabs %}" not in result
+        result = _convert_tabs(self._group(f"{self.ONE}\n{self.TWO}"))
+        assert '<div class="content-tabs">' in result
+        assert result.count('class="content-tab-panel"') == 2
+        assert 'data-label="One"' in result
+        assert 'data-label="Two"' in result
+        assert "<p>First body.</p>" in result
+        assert "{%" not in result
 
     def test_marker_spacing_variants(self):
         html = (
-            f"<p>{{%tabs%}}</p>\n{self.PYTHON_PRE}\n<p>{{%  endtabs  %}}</p>"
+            "<p>{%tabs%}</p>\n"
+            "<p>{%  tab  One  %}</p>\n<p>Body.</p>\n"
+            "<p>{%  ENDTABS  %}</p>"
         )
-        result = _convert_code_tabs(html)
-        assert '<div class="code-tabs">' in result
+        result = _convert_tabs(html)
+        assert '<div class="content-tabs">' in result
+        assert 'data-label="One"' in result
         assert "{%" not in result
 
-    def test_single_block_converts(self):
-        html = (
-            f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}\n<p>{{% endtabs %}}</p>"
-        )
-        result = _convert_code_tabs(html)
-        assert '<div class="code-tabs">' in result
+    def test_single_tab_converts(self):
+        result = _convert_tabs(self._group(self.ONE))
+        assert '<div class="content-tabs">' in result
+        assert result.count('class="content-tab-panel"') == 1
 
     def test_multiple_groups(self):
-        group = (
-            f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}\n<p>{{% endtabs %}}</p>"
-        )
-        html = f"{group}\n<p>Between.</p>\n{group}"
-        result = _convert_code_tabs(html)
-        assert result.count('<div class="code-tabs">') == 2
+        group = self._group(self.ONE)
+        result = _convert_tabs(f"{group}\n<p>Between.</p>\n{group}")
+        assert result.count('<div class="content-tabs">') == 2
         assert "<p>Between.</p>" in result
 
-    def test_non_code_content_left_untouched(self):
-        html = (
-            "<p>{% tabs %}</p>\n"
-            "<p>Stray paragraph.</p>\n"
-            f"{self.PYTHON_PRE}\n"
-            "<p>{% endtabs %}</p>"
-        )
-        assert _convert_code_tabs(html) == html
+    def test_content_before_first_marker_left_untouched(self):
+        html = self._group(f"<p>Stray paragraph.</p>\n{self.ONE}")
+        assert _convert_tabs(html) == html
 
-    def test_content_after_blocks_left_untouched(self):
-        html = (
-            "<p>{% tabs %}</p>\n"
-            f"{self.PYTHON_PRE}\n"
-            "<p>Stray paragraph.</p>\n"
-            "<p>{% endtabs %}</p>"
-        )
-        assert _convert_code_tabs(html) == html
+    def test_no_markers_left_untouched(self):
+        html = self._group("<p>Stray paragraph.</p>")
+        assert _convert_tabs(html) == html
 
     def test_unclosed_marker_left_untouched(self):
-        html = f"<p>{{% tabs %}}</p>\n{self.PYTHON_PRE}"
-        assert _convert_code_tabs(html) == html
+        html = f"<p>{{% tabs %}}</p>\n{self.ONE}"
+        assert _convert_tabs(html) == html
 
     def test_empty_group_left_untouched(self):
         html = "<p>{% tabs %}</p>\n<p>{% endtabs %}</p>"
-        assert _convert_code_tabs(html) == html
+        assert _convert_tabs(html) == html
+
+    def test_empty_label_left_untouched(self):
+        html = self._group("<p>{% tab  %}</p>\n<p>Body.</p>")
+        assert _convert_tabs(html) == html
+
+    def test_label_quote_escaped(self):
+        html = self._group('<p>{% tab Say "hi" %}</p>\n<p>Body.</p>')
+        result = _convert_tabs(html)
+        assert 'data-label="Say &quot;hi&quot;"' in result
+
+    def test_label_tags_stripped(self):
+        html = self._group("<p>{% tab <em>Fancy</em> %}</p>\n<p>Body.</p>")
+        result = _convert_tabs(html)
+        assert 'data-label="Fancy"' in result
 
     def test_unclosed_marker_with_many_blocks_is_fast(self):
         """Regression guard against catastrophic regex backtracking.
@@ -740,53 +777,100 @@ class TestConvertCodeTabs:
         """
         html = "<p>{% tabs %}</p>" + "<pre><code>x</code></pre>" * 40
         start = time.monotonic()
-        assert _convert_code_tabs(html) == html
+        assert _convert_tabs(html) == html
         assert time.monotonic() - start < 1.0
 
 
-class TestCodeTabsEndToEnd:
+class TestContentTabsEndToEnd:
     """Test {% tabs %} rendering through the full render_markdown pipeline."""
 
     def test_tabs_render(self):
         md = (
             "{% tabs %}\n\n"
-            "```python\nimport requests\n```\n\n"
-            "```curl\ncurl -L https://example.com\n```\n\n"
+            "# macOS\n\nInstall with brew.\n\n"
+            "# Linux\n\nInstall with apt.\n\n"
             "{% endtabs %}\n"
         )
         html = render_markdown(md)
-        assert '<div class="code-tabs">' in html
-        assert "language-python" in html
-        assert "language-curl" in html
+        assert '<div class="content-tabs">' in html
+        assert 'data-label="macOS"' in html
+        assert 'data-label="Linux"' in html
+        assert "Install with brew." in html
         assert "{% tabs %}" not in html
 
     def test_mixed_content(self):
         md = (
             "Intro text.\n\n"
-            "{% tabs %}\n\n```python\nx = 1\n```\n\n{% endtabs %}\n\n"
+            "{% tabs %}\n\n# One\n\nBody.\n\n{% endtabs %}\n\n"
             "Outro text.\n"
         )
         html = render_markdown(md)
-        assert '<div class="code-tabs">' in html
+        assert '<div class="content-tabs">' in html
         assert "Intro text." in html
         assert "Outro text." in html
+
+    def test_tab_headings_excluded_from_toc(self):
+        md = (
+            "## Real Section\n\n"
+            "{% tabs %}\n\n# TabName\n\nBody.\n\n{% endtabs %}\n"
+        )
+        html = render_markdown(md)
+        assert "Real Section" in html.toc_html
+        assert "TabName" not in html.toc_html
+        assert "<h1" not in html
+
+    def test_h2_inside_tab_body_renders(self):
+        md = "{% tabs %}\n\n# One\n\n## Inside\n\nBody.\n\n{% endtabs %}\n"
+        html = render_markdown(md)
+        assert "<h2" in html
+        assert 'data-label="One"' in html
+
+    def test_code_fences_inside_tabs(self):
+        md = (
+            "{% tabs %}\n\n"
+            "# Shell\n\n```bash\necho hi\n```\n\n"
+            "# Python\n\n```python\nx = 1\n```\n\n"
+            "{% endtabs %}\n"
+        )
+        html = render_markdown(md)
+        assert '<div class="content-tabs">' in html
+        assert html.count('class="content-tab-panel"') == 2
+        assert "language-bash" in html
+        assert "language-python" in html
+
+    def test_h1_inside_fence_not_a_tab(self):
+        md = "{% tabs %}\n\n# Real\n\n```\n# comment\n```\n\n{% endtabs %}\n"
+        html = render_markdown(md)
+        assert html.count('class="content-tab-panel"') == 1
+        assert "# comment" in html
+
+    def test_content_before_first_heading_left_unconverted(self):
+        md = "{% tabs %}\n\nStray text.\n\n# One\n\nBody.\n\n{% endtabs %}\n"
+        html = render_markdown(md)
+        assert "content-tabs" not in html
+        assert "{% tabs %}" in html
+
+    def test_group_without_headings_left_unconverted(self):
+        md = "{% tabs %}\n\n```python\nx = 1\n```\n\n{% endtabs %}\n"
+        html = render_markdown(md)
+        assert "content-tabs" not in html
+        assert "{% tabs %}" in html
 
     def test_markers_inside_fence_left_untouched(self):
         md = "```\n{% tabs %}\n{% endtabs %}\n```\n"
         html = render_markdown(md)
-        assert "code-tabs" not in html
+        assert "content-tabs" not in html
         assert "{% tabs %}" in html
 
-    def test_text_between_fences_not_converted(self):
-        md = (
-            "{% tabs %}\n\n"
-            "```python\nx = 1\n```\n\n"
-            "Some stray text.\n\n"
-            "{% endtabs %}\n"
-        )
+    def test_label_with_quote_is_escaped(self):
+        md = '{% tabs %}\n\n# Say "hi"\n\nBody.\n\n{% endtabs %}\n'
         html = render_markdown(md)
-        assert "code-tabs" not in html
-        assert "{% tabs %}" in html
+        assert 'data-label="Say &quot;hi&quot;"' in html
+
+    def test_markdown_in_tab_name_stripped(self):
+        md = "{% tabs %}\n\n# **Bold** Name\n\nBody.\n\n{% endtabs %}\n"
+        html = render_markdown(md)
+        assert 'data-label="Bold Name"' in html
 
 
 class TestStripMarkdownCodeTabs:

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -703,6 +703,25 @@ class TestConvertTabHeadings:
         md = "{% tabs %}\n# One\nBody.\n\n# Later Heading\nMore text."
         assert _convert_tab_headings(md) == md
 
+    def test_nested_fence_inside_tab_untouched(self):
+        """A ```` fence wrapping a literal ``` example stays one fence:
+        the scanner must not desync on the inner delimiters and misread
+        a code comment as a tab heading."""
+        md = (
+            "{% tabs %}\n"
+            "# One\n"
+            "````markdown\n"
+            "```python\n"
+            "# a comment, not a tab\n"
+            "x = 1\n"
+            "```\n"
+            "````\n"
+            "{% endtabs %}"
+        )
+        out = _convert_tab_headings(md)
+        assert "# a comment, not a tab" in out
+        assert "{% tab a comment, not a tab %}" not in out
+
     def test_heading_after_closed_region_untouched(self):
         md = "{% tabs %}\n# One\n{% endtabs %}\n# After"
         out = _convert_tab_headings(md)
@@ -893,6 +912,24 @@ class TestContentTabsEndToEnd:
         assert "content-tabs" not in html
         assert html.count("<h1") == 2
         assert "Section One" in html.toc_html
+
+    def test_no_blank_lines_around_markers_still_converts(self):
+        """Boundary markers are padded during conversion, so a missing
+        blank line before {% endtabs %} (or around {% tabs %}) must not
+        merge the marker into a neighboring paragraph and leak the
+        markers as literal text."""
+        md = (
+            "Intro.\n{% tabs %}\n"
+            "# macOS\nInstall with brew.\n"
+            "# Linux\nInstall with apt.\n"
+            "{% endtabs %}\nOutro.\n"
+        )
+        html = render_markdown(md)
+        assert '<div class="content-tabs">' in html
+        assert html.count('class="content-tab-panel"') == 2
+        assert "{%" not in html
+        assert "Intro." in html
+        assert "Outro." in html
 
 
 class TestStripMarkdownCodeTabs:

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -697,6 +697,18 @@ class TestConvertTabHeadings:
         md = "# Plain page\n\nNo tabs here."
         assert _convert_tab_headings(md) == md
 
+    def test_unclosed_region_leaves_headings_untouched(self):
+        """An unclosed {% tabs %} must not consume headings for the
+        rest of the document."""
+        md = "{% tabs %}\n# One\nBody.\n\n# Later Heading\nMore text."
+        assert _convert_tab_headings(md) == md
+
+    def test_heading_after_closed_region_untouched(self):
+        md = "{% tabs %}\n# One\n{% endtabs %}\n# After"
+        out = _convert_tab_headings(md)
+        assert "{% tab One %}" in out
+        assert out.rstrip().endswith("# After")
+
 
 class TestConvertTabs:
     """{% tabs %} groups with {% tab %} markers become tab containers."""
@@ -871,6 +883,16 @@ class TestContentTabsEndToEnd:
         md = "{% tabs %}\n\n# **Bold** Name\n\nBody.\n\n{% endtabs %}\n"
         html = render_markdown(md)
         assert 'data-label="Bold Name"' in html
+
+    def test_unclosed_group_leaves_document_intact(self):
+        """A {% tabs %} with no {% endtabs %} must leave the rest of the
+        document's headings (and their TOC entries) untouched."""
+        md = "{% tabs %}\n\n# Section One\n\nBody.\n\n# Section Two\n\nMore.\n"
+        html = render_markdown(md)
+        assert "{% tab " not in html
+        assert "content-tabs" not in html
+        assert html.count("<h1") == 2
+        assert "Section One" in html.toc_html
 
 
 class TestStripMarkdownCodeTabs:

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -319,7 +319,8 @@ per-platform install steps, the same API call in several languages —
 wrap it in `{% tabs %}` and `{% endtabs %}` markers. Inside the
 markers, each level-one heading (`# Name`) starts a new tab: the
 heading text becomes the tab's name, and everything up to the next
-`#` heading (or `{% endtabs %}`) is that tab's content.
+level-one heading (or `{% endtabs %}`) is that tab's content.
+Deeper headings (`##` and below) stay inside the current tab.
 
 ````markdown
 {% tabs %}

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -1658,6 +1658,35 @@ Use dot notation to access nested objects. If the API returns:
 
 You can write `[[ stats.open ]]` and `[[ stats.closed ]]`.
 
+### Markdown in values
+
+Values are substituted **before** the page is rendered, so markdown
+inside an API value is parsed like any other page content. If the
+API returns:
+
+```json
+{
+  "status": "**degraded** — see [the incident page](https://status.example.com)"
+}
+```
+
+Then `Current status: [[ status ]]` renders with real bold text and
+a working link.
+
+A few things to keep in mind:
+
+- **Inline markdown is the reliable case** (bold, italics, links,
+  inline code). Block-level markdown (lists, headings) only works
+  if the placeholder sits where a block can start — on its own
+  line, as its own paragraph.
+- **There is no escaping.** Characters like `*` and `_` in a value
+  are interpreted as markdown. If a value must appear literally,
+  put the placeholder in inline code — code regions are never
+  substituted.
+- **HTML is sanitized.** Raw HTML in a value passes through the
+  same sanitizer as authored content, so tags like `<script>` are
+  stripped.
+
 ### Unresolved placeholders
 
 If a placeholder doesn't match any key in the JSON (or the key's

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -312,32 +312,50 @@ def hello():
 ```
 ````
 
-### Tabbed code blocks
+### Tabs
 
-To show the same example in several languages, wrap ordinary code
-fences in `{% tabs %}` and `{% endtabs %}` markers. Each fence becomes
-a tab, labeled by its language. Use ` ```curl ` for a cURL tab — it
-highlights as shell but gets a cURL label.
+To show alternative versions of the same content side by side —
+per-platform install steps, the same API call in several languages —
+wrap it in `{% tabs %}` and `{% endtabs %}` markers. Inside the
+markers, each level-one heading (`# Name`) starts a new tab: the
+heading text becomes the tab's name, and everything up to the next
+`#` heading (or `{% endtabs %}`) is that tab's content.
 
 ````markdown
 {% tabs %}
 
-```curl
-curl https://example.com/api/
+# macOS
+
+Install with [Homebrew](https://brew.sh):
+
+```bash
+brew install foo
 ```
 
-```python
-import requests
-requests.get("https://example.com/api/")
+# Linux
+
+Install with apt:
+
+```bash
+sudo apt install foo
 ```
 
 {% endtabs %}
 ````
 
-Picking a tab switches every tab group on the page to that language,
-and the wiki remembers your choice on future pages. Only code fences
-may appear between the markers — anything else leaves the group
-unconverted so you can spot the mistake.
+Any markdown works inside a tab — paragraphs, lists, images, code
+fences. A few details:
+
+- **Tab names are plain text.** Markdown formatting in the heading
+  is ignored.
+- **Tab headings don't appear in the table of contents** — they're
+  labels, not document structure.
+- **Same-named tabs sync.** Picking "macOS" switches every tab group
+  on the page that has a macOS tab, and the wiki remembers your
+  choice on future pages.
+- The content must start with a `#` heading. A group with content
+  before the first heading (or no headings at all) is left
+  unconverted so you can spot the mistake.
 
 ### Tables
 

--- a/wiki/pages/management/commands/seed_help_pages.py
+++ b/wiki/pages/management/commands/seed_help_pages.py
@@ -353,7 +353,8 @@ fences. A few details:
   labels, not document structure.
 - **Same-named tabs sync.** Picking "macOS" switches every tab group
   on the page that has a macOS tab, and the wiki remembers your
-  choice on future pages.
+  choice on future pages. Give each tab within a group a unique
+  name — the name is the tab's identity.
 - The content must start with a `#` heading. A group with content
   before the first heading (or no headings at all) is left
   unconverted so you can spot the mistake.

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -680,32 +680,32 @@ class TestWikiLinkAutocomplete:
         dropdown.locator("[data-path]").first.wait_for(state="visible")
 
 
-# ── Tabbed code blocks ({% tabs %}) ──────────────────────────────────
+# ── Tabbed content groups ({% tabs %}) ───────────────────────────────
 
 _TABS_GROUP_FULL = (
     "{% tabs %}\n\n"
-    "```curl\ncurl -L https://example.com/api/\n```\n\n"
-    "```python\nimport requests\n```\n\n"
-    "```javascript\nawait fetch(url)\n```\n\n"
+    "# macOS\n\nInstall with brew.\n\n"
+    "# Linux\n\nInstall with apt.\n\n"
+    "# Windows\n\nInstall with winget.\n\n"
     "{% endtabs %}"
 )
 _TABS_GROUP_SHORT = (
     "{% tabs %}\n\n"
-    "```curl\ncurl -X POST https://example.com/api/\n```\n\n"
-    "```python\nimport httpx\n```\n\n"
+    "# macOS\n\nUpdate with brew.\n\n"
+    "# Linux\n\nUpdate with apt.\n\n"
     "{% endtabs %}"
 )
-_TABS_GROUP_PLAIN = (
+_TABS_GROUP_CODE = (
     "{% tabs %}\n\n"
-    "```\nfirst plain block\n```\n\n"
-    "```\nsecond plain block\n```\n\n"
+    "# Python\n\n```python\nimport requests\n```\n\n"
+    "# Shell\n\n```bash\ncurl -L https://example.com/api/\n```\n\n"
     "{% endtabs %}"
 )
 
 
 @pytest.fixture
 def tabbed_pages(browser_user, dir_tree):
-    """Two pages with tabbed code groups in the public docs directory."""
+    """Two pages with tabbed content groups in the public docs directory."""
     docs = Directory.objects.get(path="docs")
 
     def make(slug, title, content):
@@ -729,21 +729,21 @@ def tabbed_pages(browser_user, dir_tree):
         return p
 
     first = make(
-        "api-examples",
-        "API Examples",
+        "install-guide",
+        "Install Guide",
         f"Intro.\n\n{_TABS_GROUP_FULL}\n\nMiddle.\n\n{_TABS_GROUP_SHORT}\n",
     )
     second = make(
-        "more-examples",
-        "More Examples",
-        f"{_TABS_GROUP_FULL}\n\n{_TABS_GROUP_PLAIN}\n",
+        "usage-guide",
+        "Usage Guide",
+        f"{_TABS_GROUP_FULL}\n\n{_TABS_GROUP_CODE}\n",
     )
     return first, second
 
 
 @pytest.mark.django_db(transaction=True)
-class TestCodeTabs:
-    """Tabbed code groups: labels, cross-group sync, persistence, copy."""
+class TestContentTabs:
+    """Tabbed content groups: labels, cross-group sync, persistence."""
 
     def _goto(self, browser_page, live_server, wiki_page):
         url = reverse("resolve_path", kwargs={"path": wiki_page.content_path})
@@ -755,13 +755,13 @@ class TestCodeTabs:
         _force_login(browser_page, live_server, browser_user)
         self._goto(browser_page, live_server, tabbed_pages[0])
 
-        groups = browser_page.locator(".code-tabs")
+        groups = browser_page.locator(".content-tabs")
         expect(groups).to_have_count(2)
         first_tabs = groups.nth(0).locator("[role='tab']")
-        expect(first_tabs).to_have_text(["cURL", "Python", "JavaScript"])
+        expect(first_tabs).to_have_text(["macOS", "Linux", "Windows"])
         expect(first_tabs.nth(0)).to_have_attribute("aria-selected", "true")
 
-        panels = groups.nth(0).locator(".code-block-wrapper")
+        panels = groups.nth(0).locator(".content-tab-panel")
         expect(panels.nth(0)).to_be_visible()
         expect(panels.nth(1)).to_be_hidden()
         expect(panels.nth(2)).to_be_hidden()
@@ -772,22 +772,40 @@ class TestCodeTabs:
         _force_login(browser_page, live_server, browser_user)
         self._goto(browser_page, live_server, tabbed_pages[0])
 
-        groups = browser_page.locator(".code-tabs")
-        groups.nth(0).get_by_role("tab", name="Python").click()
+        groups = browser_page.locator(".content-tabs")
+        groups.nth(0).get_by_role("tab", name="Linux").click()
 
-        # Both groups switch to Python
+        # Both groups switch to Linux
         expect(
-            groups.nth(0).get_by_role("tab", name="Python")
+            groups.nth(0).get_by_role("tab", name="Linux")
         ).to_have_attribute("aria-selected", "true")
         expect(
-            groups.nth(1).get_by_role("tab", name="Python")
+            groups.nth(1).get_by_role("tab", name="Linux")
         ).to_have_attribute("aria-selected", "true")
         expect(
-            groups.nth(1).locator(".code-block-wrapper").nth(0)
+            groups.nth(1).locator(".content-tab-panel").nth(0)
         ).to_be_hidden()
         expect(
-            groups.nth(1).locator(".code-block-wrapper").nth(1)
+            groups.nth(1).locator(".content-tab-panel").nth(1)
         ).to_be_visible()
+
+    def test_groups_without_label_keep_selection(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        """Selecting a tab only switches groups that offer that name."""
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[0])
+
+        groups = browser_page.locator(".content-tabs")
+        groups.nth(0).get_by_role("tab", name="Windows").click()
+
+        expect(
+            groups.nth(0).get_by_role("tab", name="Windows")
+        ).to_have_attribute("aria-selected", "true")
+        # The short group has no Windows tab and stays on macOS
+        expect(
+            groups.nth(1).get_by_role("tab", name="macOS")
+        ).to_have_attribute("aria-selected", "true")
 
     def test_selection_persists_across_pages(
         self, browser_page, live_server, browser_user, tabbed_pages
@@ -795,16 +813,31 @@ class TestCodeTabs:
         _force_login(browser_page, live_server, browser_user)
         self._goto(browser_page, live_server, tabbed_pages[0])
 
-        browser_page.locator(".code-tabs").nth(0).get_by_role(
-            "tab", name="JavaScript"
+        browser_page.locator(".content-tabs").nth(0).get_by_role(
+            "tab", name="Windows"
         ).click()
 
         self._goto(browser_page, live_server, tabbed_pages[1])
-        group = browser_page.locator(".code-tabs").nth(0)
-        expect(group.get_by_role("tab", name="JavaScript")).to_have_attribute(
+        group = browser_page.locator(".content-tabs").nth(0)
+        expect(group.get_by_role("tab", name="Windows")).to_have_attribute(
             "aria-selected", "true"
         )
-        expect(group.locator(".code-block-wrapper").nth(2)).to_be_visible()
+        expect(group.locator(".content-tab-panel").nth(2)).to_be_visible()
+
+    def test_keyboard_navigation(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[0])
+
+        group = browser_page.locator(".content-tabs").nth(0)
+        group.get_by_role("tab", name="macOS").focus()
+        browser_page.keyboard.press("ArrowRight")
+
+        expect(group.get_by_role("tab", name="Linux")).to_have_attribute(
+            "aria-selected", "true"
+        )
+        expect(group.locator(".content-tab-panel").nth(1)).to_be_visible()
 
     def test_tabs_render_in_editor_preview(
         self, browser_page, live_server, browser_user, dir_tree
@@ -824,52 +857,28 @@ class TestCodeTabs:
             browser_page.locator(".editor-tab[data-tab='preview']").click()
 
         preview = browser_page.locator("#tab-preview-content")
-        expect(preview.locator(".code-tabs-bar")).to_be_visible()
+        expect(preview.locator(".content-tabs-bar")).to_be_visible()
         tabs = preview.locator("[role='tab']")
-        expect(tabs).to_have_text(["cURL", "Python", "JavaScript"])
+        expect(tabs).to_have_text(["macOS", "Linux", "Windows"])
         expect(tabs.nth(0)).to_have_attribute("aria-selected", "true")
 
-    def test_unlabeled_tab_click_activates_clicked_tab(
+    def test_code_blocks_inside_tabs_get_copy_button(
         self, browser_page, live_server, browser_user, tabbed_pages
     ):
-        """Bare ``` fences have no language: clicking such a tab must
-        activate the clicked tab, not reset the group to its first tab
-        (regression: index lookup used to require a language)."""
-        _force_login(browser_page, live_server, browser_user)
-        self._goto(browser_page, live_server, tabbed_pages[1])
-
-        plain = browser_page.locator(".code-tabs").nth(1)
-        tabs = plain.locator("[role='tab']")
-        expect(tabs).to_have_text(["Text", "Text"])
-
-        tabs.nth(1).click()
-        expect(tabs.nth(1)).to_have_attribute("aria-selected", "true")
-        expect(plain.locator(".code-block-wrapper").nth(1)).to_be_visible()
-        expect(plain.locator(".code-block-wrapper").nth(0)).to_be_hidden()
-
-        # A language-less selection is local: the labeled group keeps its
-        # own selection.
-        labeled = browser_page.locator(".code-tabs").nth(0)
-        expect(labeled.get_by_role("tab", name="cURL")).to_have_attribute(
-            "aria-selected", "true"
-        )
-
-    def test_copy_button_copies_active_tab(
-        self, browser_page, live_server, browser_user, tabbed_pages
-    ):
+        """Code fences inside tab panels are enhanced like any other."""
         browser_page.context.grant_permissions(
             ["clipboard-read", "clipboard-write"]
         )
         _force_login(browser_page, live_server, browser_user)
         self._goto(browser_page, live_server, tabbed_pages[1])
 
-        group = browser_page.locator(".code-tabs").nth(0)
-        group.get_by_role("tab", name="Python").click()
+        group = browser_page.locator(".content-tabs").nth(1)
+        group.get_by_role("tab", name="Shell").click()
         group.locator(
-            ".code-block-wrapper:not([hidden]) .copy-code-btn"
+            ".content-tab-panel:not([hidden]) .copy-code-btn"
         ).click()
 
         clipboard = browser_page.evaluate(
             "() => navigator.clipboard.readText()"
         )
-        assert "import requests" in clipboard
+        assert "curl -L" in clipboard

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -701,6 +701,12 @@ _TABS_GROUP_CODE = (
     "# Shell\n\n```bash\ncurl -L https://example.com/api/\n```\n\n"
     "{% endtabs %}"
 )
+_TABS_GROUP_DUP = (
+    "{% tabs %}\n\n"
+    "# Step\n\nFirst step.\n\n"
+    "# Step\n\nSecond step.\n\n"
+    "{% endtabs %}"
+)
 
 
 @pytest.fixture
@@ -736,7 +742,7 @@ def tabbed_pages(browser_user, dir_tree):
     second = make(
         "usage-guide",
         "Usage Guide",
-        f"{_TABS_GROUP_FULL}\n\n{_TABS_GROUP_CODE}\n",
+        f"{_TABS_GROUP_FULL}\n\n{_TABS_GROUP_CODE}\n\n{_TABS_GROUP_DUP}\n",
     )
     return first, second
 
@@ -861,6 +867,23 @@ class TestContentTabs:
         tabs = preview.locator("[role='tab']")
         expect(tabs).to_have_text(["macOS", "Linux", "Windows"])
         expect(tabs.nth(0)).to_have_attribute("aria-selected", "true")
+
+    def test_duplicate_names_clicked_tab_wins(
+        self, browser_page, live_server, browser_user, tabbed_pages
+    ):
+        """Within one group, clicking a duplicate-named tab activates
+        the clicked tab, not the first tab with that name."""
+        _force_login(browser_page, live_server, browser_user)
+        self._goto(browser_page, live_server, tabbed_pages[1])
+
+        group = browser_page.locator(".content-tabs").nth(2)
+        tabs = group.locator("[role='tab']")
+        expect(tabs).to_have_text(["Step", "Step"])
+
+        tabs.nth(1).click()
+        expect(tabs.nth(1)).to_have_attribute("aria-selected", "true")
+        expect(group.locator(".content-tab-panel").nth(1)).to_be_visible()
+        expect(group.locator(".content-tab-panel").nth(0)).to_be_hidden()
 
     def test_code_blocks_inside_tabs_get_copy_button(
         self, browser_page, live_server, browser_user, tabbed_pages


### PR DESCRIPTION
## Fixes
No linked issue — grew out of a discussion about data-source markdown handling and making `{% tabs %}` more powerful.

## Summary
Two related pieces of work:

**1. Content tabs (`{% tabs %}` rework).** The old tabs feature only grouped code fences, labeling tabs by language, and was never used. It's replaced outright: inside `{% tabs %}…{% endtabs %}`, each `# Heading` now starts a tab named by the heading text, and everything until the next `#` heading is that tab's body — any markdown allowed, including code fences.

- Conversion is two-stage: `_convert_tab_headings()` rewrites the H1 lines into `{% tab %}` markers on the markdown source *before* markdown2 runs, so tab names never get header ids or TOC entries (they're UI labels, not document structure). `_convert_tabs()` then splits the sanitized HTML into `<div class="content-tabs">` panels carrying `data-label` attributes — escaped, since this runs post-sanitization.
- `code-blocks.js` builds the tab bar from panel labels: same a11y roles and arrow-key navigation as before, same-named tabs sync across groups on a page, and the selection persists across pages via localStorage. The `LANG_LABELS` table and the `curl` highlight alias (which existed only to label a cURL tab) are deleted.
- Invalid groups (no headings, or content before the first heading) are left unconverted so authors can spot the mistake — same philosophy as before.
- Help docs rewritten with a macOS/Linux example.

**2. Markdown in data-source values.** Substitution runs before `render_markdown`, so markdown in external API values renders like authored content and raw HTML gets stripped by nh3. That was emergent behavior of pipeline ordering; it's now pinned by tests and documented in the External Data Sources guide.

**Testing:** full suite green — 1,196 non-browser tests and all 23 Playwright browser tests, including new coverage for label rendering, cross-group sync (and *no* sync for groups lacking the clicked label), persistence across pages, keyboard navigation, editor preview, and copy buttons inside panels.

**CDN:** static assets are manifest-hashed, so the new JS/CSS need no invalidation. No cached page contains the old `.code-tabs` markup (the old syntax had no users), so no HTML invalidation is needed either. Updated help pages are the exception — see deployment.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

1. Run `manage.py seed_help_pages` to update the markdown and data-source help pages.
2. If help pages are cached in CloudFront for anonymous users and reseeding doesn't invalidate them, invalidate `/c/help/markdown-syntax` and `/c/help/data-sources-guide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `{% tabs %}` / `{% tab %}` support for tabbed wiki content, rendering as label-based “content tabs”.
  - Tab labels are derived from level-one headings and are safely escaped for display.
  - Tab selection is remembered and synchronized across matching tab groups.
  - Code blocks inside tabs keep syntax highlighting and copy-to-clipboard support.
  - Markdown in API-supplied substitution values is rendered safely; unsafe HTML/scripts are removed.
- **Documentation**
  - Updated help pages to describe the new tabs syntax and Markdown-in-values behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->