### PR TITLE
Upgrade markdown2 to 2.5.5 to fix mangled double-bold rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "django-waffle",
   "factory-boy",
   "gunicorn",
-  "markdown2",
+  "markdown2>=2.5.5",
   "nh3",
   "pillow",
   "psycopg[binary,pool]",

--- a/uv.lock
+++ b/uv.lock
@@ -714,11 +714,11 @@ wheels = [
 
 [[package]]
 name = "markdown2"
-version = "2.5.4"
+version = "2.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/42/f8/b2ae8bf5f28f9b510ae097415e6e4cb63226bb28d7ee01aec03a755ba03b/markdown2-2.5.4.tar.gz", hash = "sha256:a09873f0b3c23dbfae589b0080587df52ad75bb09a5fa6559147554736676889", size = 145652, upload-time = "2025-07-27T16:16:24.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/ae/07d4a5fcaa5509221287d289323d75ac8eda5a5a4ac9de2accf7bbcc2b88/markdown2-2.5.5.tar.gz", hash = "sha256:001547e68f6e7fcf0f1cb83f7e82f48aa7d48b2c6a321f0cd20a853a8a2d1664", size = 157249, upload-time = "2026-03-02T20:46:53.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/06/2697b5043c3ecb720ce0d243fc7cf5024c0b5b1e450506e9b21939019963/markdown2-2.5.4-py3-none-any.whl", hash = "sha256:3c4b2934e677be7fec0e6f2de4410e116681f4ad50ec8e5ba7557be506d3f439", size = 49954, upload-time = "2025-07-27T16:16:23.026Z" },
+    { url = "https://files.pythonhosted.org/packages/43/af/4b3891eb0a49d6cfd5cbf3e9bf514c943afc2b0f13e2c57cc57cd88ecc21/markdown2-2.5.5-py3-none-any.whl", hash = "sha256:be798587e09d1f52d2e4d96a649c4b82a778c75f9929aad52a2c95747fa26941", size = 56250, upload-time = "2026-03-02T20:46:52.032Z" },
 ]
 
 [[package]]
@@ -1593,7 +1593,7 @@ requires-dist = [
     { name = "django-waffle" },
     { name = "factory-boy" },
     { name = "gunicorn" },
-    { name = "markdown2" },
+    { name = "markdown2", specifier = ">=2.5.5" },
     { name = "nh3" },
     { name = "pillow" },
     { name = "psycopg", extras = ["binary", "pool"] },

--- a/wiki/lib/markdown.py
+++ b/wiki/lib/markdown.py
@@ -901,9 +901,9 @@ def render_markdown(content, viewer=None):
             "link-patterns": None,
             # Disallow emphasis in the middle of words so identifiers like
             # PRAY_AND_PAY or snake_case aren't mangled into PRAY<em>AND</em>PAY.
-            # Edge-of-word _italic_, *italic*, and **bold** still work. Known
-            # trade-off (markdown2 #679): __double-underscore bold__ no longer
-            # renders as <strong>; authors should use **bold** instead.
+            # Edge-of-word _italic_, *italic*, **bold**, and __bold__ all
+            # work. Requires markdown2 >= 2.5.5: 2.5.4 broke __bold__
+            # (#679) and mis-paired two **bold** spans in one paragraph.
             "middle-word-em": False,
         },
         link_patterns=[(_AUTOLINK_RE, r"\1")],

--- a/wiki/lib/tests_data_source.py
+++ b/wiki/lib/tests_data_source.py
@@ -308,6 +308,25 @@ class TestPageDataSourceIntegration:
         assert b"<strong>degraded</strong>" in response.content
         assert b'href="https://status.example.com"' in response.content
 
+    def test_bold_wrapped_placeholders_render(self, client, json_server):
+        """Two bold-wrapped substituted values in one sentence must each
+        render as their own <strong> span (regression: markdown2 2.5.4
+        mis-paired the ** markers and leaked literal asterisks)."""
+        url = json_server({"alerts": {"free": 5, "bonus": 10}})
+        page = Page.objects.create(
+            title="Bold Values",
+            content=(
+                "We allow **[[ alerts.free ]]** docket alerts for free, "
+                "and give a bonus of **[[ alerts.bonus ]]**."
+            ),
+            data_source_url=url,
+            data_source_ttl=60,
+        )
+        response = client.get(page.get_absolute_url())
+        assert b"<strong>5</strong>" in response.content
+        assert b"<strong>10</strong>" in response.content
+        assert b"<em>*" not in response.content
+
     def test_html_in_value_is_sanitized(self, client, json_server):
         """Raw HTML arriving via API values goes through the same nh3
         sanitization as authored content."""

--- a/wiki/lib/tests_markdown.py
+++ b/wiki/lib/tests_markdown.py
@@ -147,18 +147,29 @@ class TestRenderMarkdownEmphasis:
         html = render_markdown("This is _really_ important.")
         assert "<em>really</em>" in html
 
-    def test_double_underscore_bold_known_limitation(self):
-        # Accepted trade-off of the middle-word-em extra (markdown2 #679):
-        # __double underscore bold__ is not rendered as <strong>. Authors
-        # should use **bold** instead. Documented here so the behavior is
-        # an explicit choice, not a silent regression.
+    def test_double_underscore_bold(self):
+        # markdown2 2.5.4's middle-word-em extra broke __bold__ (#679);
+        # 2.5.5 restored it.
         html = render_markdown("This is __very__ important.")
-        assert "<strong>very</strong>" not in html
+        assert "<strong>very</strong>" in html
 
     def test_star_emphasis_unaffected(self):
         html = render_markdown("Use *stars* and **double stars**.")
         assert "<em>stars</em>" in html
         assert "<strong>double stars</strong>" in html
+
+    def test_two_bold_spans_in_one_paragraph(self):
+        """Regression: markdown2 2.5.4's middle-word-em regex paired the
+        first ** opener with the last closer, turning everything between
+        two bold spans into stray <em>/<strong> soup with visible
+        asterisks. Fixed upstream in 2.5.5."""
+        html = render_markdown(
+            "allow **5** docket alerts for free, and a bonus of **10**."
+        )
+        assert "<strong>5</strong>" in html
+        assert "<strong>10</strong>" in html
+        assert "<em>" not in html
+        assert "*" not in html
 
 
 class TestExtractSlugsFromInternalUrls:


### PR DESCRIPTION
## Fixes
No linked issue — reported directly: `allow **[[ alerts.max_free_docket_alerts ]]** docket alerts for free, and give a bonus of **[[ alerts.docket_alert_recap_bonus ]]**` rendered with the middle of the sentence bold-italic and stray asterisks around the numbers.

## Summary
The `middle-word-em: False` extra we use (so `snake_case` identifiers don't italicize) has a bug in markdown2 2.5.4: its emphasis regex pairs the **first** `**` opener in a paragraph with the **last** closer. Any sentence containing two bold spans — bold numbers from a data source being the reported case, but plain words too — renders as nested `<strong>/<em>` soup with visible asterisks.

markdown2 2.5.5 fixes this upstream, and also restores `__double-underscore bold__`, which 2.5.4 had broken (markdown2 #679) — we had a test documenting that as a known limitation, which now asserts the correct behavior instead.

Changes:
- `uv.lock` bumped to markdown2 2.5.5, and `pyproject.toml` now pins `markdown2>=2.5.5` since emphasis correctness depends on it
- Regression tests: two bold spans in one paragraph (unit) and two bold-wrapped data-source placeholders end-to-end
- Updated the stale trade-off comment in `render_markdown` and the `__bold__` limitation test

**Testing:** full non-browser suite (1,204 tests) passes against 2.5.5 — no regressions beyond the intentional `__bold__` behavior change.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

Standard deploy (image rebuild picks up the new lock). No special steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of underscore-based bold text.
  * Corrected formatting when multiple bold data-source placeholders appear in the same paragraph.
  * Prevented stray emphasis markup and visible asterisks from appearing in rendered content.

* **Tests**
  * Added regression coverage for bold text and substituted data-source values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->