### PR TITLE
Add public/private emoji to page change notification emails

### DIFF
--- a/wiki/subscriptions/tasks.py
+++ b/wiki/subscriptions/tasks.py
@@ -7,6 +7,7 @@ from django.core.mail import EmailMessage, send_mail
 from django.core.signing import Signer
 from django.urls import reverse
 
+from wiki.lib.inheritance import resolve_effective_value
 from wiki.lib.permissions import can_view_page
 from wiki.lib.users import display_name, user_by_handle
 from wiki.pages.models import Page, PagePermission
@@ -92,7 +93,11 @@ def notify_subscribers(
 
     signer = Signer()
     base = settings.BASE_URL
-    subject = f'[FLP Wiki] "{page.title}" was {action}'
+    effective_visibility, _ = resolve_effective_value(page, "visibility")
+    visibility_emoji = (
+        "\U0001f310" if effective_visibility == "public" else "\U0001f512"
+    )
+    subject = f'[FLP Wiki] {visibility_emoji} "{page.title}" was {action}'
 
     # A "View" link to a deleted page would 404, and a diff only makes sense
     # for an update between two revisions.


### PR DESCRIPTION
## Fixes
N/A — no linked issue; requested directly by @mlissner.

## Summary
Page create/update/delete notification emails (`notify_subscribers` in `wiki/subscriptions/tasks.py`) now prefix the subject line with an emoji showing the page's effective visibility: 🌐 for public, 🔒 for internal/private. Visibility is resolved with the existing `resolve_effective_value(page, "visibility")` helper so directory-inherited visibility is handled the same way as the view-permission check. The `@mention` and subscription-confirmation emails are unchanged since they aren't the page create/update notification.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-daemon-deploy`

1. No special steps — standard deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification email subjects now include a visibility indicator, using a green icon for public pages and a purple icon for other visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->