### PR TITLE
Add bulk Move to directory page listings

### DIFF
--- a/wiki/assets/static-global/js/alpine-components.js
+++ b/wiki/assets/static-global/js/alpine-components.js
@@ -121,6 +121,68 @@ document.addEventListener('alpine:init', () => {
     get title() {
       return this.pinned ? 'Unpin' : 'Pin'
     },
+    get unpinned() {
+      return !this.pinned
+    },
+  }))
+
+  // Bulk page selection — checkboxes on the directory listing that swap
+  // the sort-controls row for a "Bulk Move…" button once something's
+  // checked. Routing to page_bulk_move is a plain
+  // <button formmethod="get" formaction="..."> submit, not JS; this
+  // component only tracks how many checkboxes are checked.
+  //
+  // IMPORTANT: `recount`/`toggleAll` are invoked from directives on OTHER
+  // elements (each page's checkbox, the select-all checkbox) — neither is
+  // the element `x-data="bulkPageSelect"` is declared on. Alpine's `$el`
+  // always resolves to whichever element the *calling* directive is bound
+  // to, not the x-data root, so using `this.$el` inside these methods
+  // would only ever see that one leaf `<input>` (with no children to
+  // query). `init()` is the one hook Alpine always calls with `$el` bound
+  // to the x-data root itself, so capture it there as `this.root` and use
+  // that everywhere else.
+  Alpine.data('bulkPageSelect', () => ({
+    count: 0,
+    root: null,
+    init() {
+      this.root = this.$el
+      this.recount()
+    },
+    recount() {
+      var boxes = Array.from(this.root.querySelectorAll('input[name="page_ids"]'))
+      var checked = boxes.filter(function (cb) { return cb.checked }).length
+      this.count = checked
+
+      var selectAll = this.$refs.selectAll
+      if (!selectAll) return
+      if (checked === 0) {
+        selectAll.checked = false
+        selectAll.indeterminate = false
+      } else if (checked === boxes.length) {
+        selectAll.checked = true
+        selectAll.indeterminate = false
+      } else {
+        // Semi-checked: shown as checked+indeterminate so a click flips
+        // `checked` to false (native checkbox behavior toggles whatever
+        // it currently is) — read below in toggleAll() to clear everyone
+        // rather than selecting everyone.
+        selectAll.checked = true
+        selectAll.indeterminate = true
+      }
+    },
+    toggleAll() {
+      var checked = this.$refs.selectAll.checked
+      this.root.querySelectorAll('input[name="page_ids"]').forEach(function (cb) {
+        cb.checked = checked
+      })
+      this.recount()
+    },
+    get hasSelection() {
+      return this.count > 0
+    },
+    get noneSelected() {
+      return this.count === 0
+    },
   }))
 
   // Search tips toggle

--- a/wiki/assets/templates/includes/_page_move_fields.html
+++ b/wiki/assets/templates/includes/_page_move_fields.html
@@ -1,0 +1,7 @@
+    <div>
+      <label for="id_directory" class="block text-sm font-medium mb-1">Move to directory</label>
+      {{ form.directory }}
+      {% if form.directory.errors %}
+      <p class="text-red-600 dark:text-red-400 text-sm mt-1">{{ form.directory.errors.0 }}</p>
+      {% endif %}
+    </div>

--- a/wiki/directories/templates/directories/detail.html
+++ b/wiki/directories/templates/directories/detail.html
@@ -138,21 +138,46 @@
 
   {# Pages #}
   {% if pages %}
-  {# Sort controls #}
-  <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
-    <h2 class="text-lg font-semibold font-sans">Pages</h2>
-    <div class="text-sm flex items-center gap-1.5 flex-wrap">
+  {% if can_edit %}
+  <form method="post" id="bulk-pages-form" x-data="bulkPageSelect">
+    {% csrf_token %}
+    <input type="hidden" name="next" value="{{ request.get_full_path }}">
+  {% endif %}
+  {% comment %}
+    Sort controls — replaced by the "Bulk Move…" button while pages are
+    selected. min-h-10 reserves enough height for that (taller) button up
+    front, so swapping the two doesn't shift the checkboxes below when a
+    page gets selected. whitespace-nowrap on the button keeps its label on
+    one line — without it, the row can shrink narrower than the label's
+    natural width and wrap it to two lines, which also causes a shift.
+  {% endcomment %}
+  <div class="min-h-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
+    <div class="flex items-center gap-2 {% if can_edit %}pl-5{% endif %}">
+      {% if can_edit %}
+      <input type="checkbox" x-ref="selectAll" @change="toggleAll" class="accent-primary-600" aria-label="Select all pages">
+      {% endif %}
+      <h2 class="text-lg font-semibold font-sans">Pages</h2>
+    </div>
+    <div class="text-sm flex items-center gap-1.5 flex-wrap" {% if can_edit %}x-show="noneSelected"{% endif %}>
       <span class="text-gray-400 dark:text-gray-500 text-xs uppercase tracking-wide mr-0.5">Sort</span>
       {% if current_sort == "title" %}<span class="px-2 py-1 rounded-md text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">Title</span>{% else %}<a href="?sort=title" rel="nofollow" class="px-2 py-1 rounded-md text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 no-underline hover:no-underline transition-colors">Title</a>{% endif %}
       {% if current_sort == "updated" %}<span class="px-2 py-1 rounded-md text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">Last edited</span>{% else %}<a href="?sort=updated" rel="nofollow" class="px-2 py-1 rounded-md text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 no-underline hover:no-underline transition-colors">Last edited</a>{% endif %}
       {% if current_sort == "created" %}<span class="px-2 py-1 rounded-md text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">Created</span>{% else %}<a href="?sort=created" rel="nofollow" class="px-2 py-1 rounded-md text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 no-underline hover:no-underline transition-colors">Created</a>{% endif %}
       {% if current_sort == "views" %}<span class="px-2 py-1 rounded-md text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">Most viewed</span>{% else %}<a href="?sort=views" rel="nofollow" class="px-2 py-1 rounded-md text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 no-underline hover:no-underline transition-colors">Most viewed</a>{% endif %}
     </div>
+    {% if can_edit %}
+    <div class="text-sm flex items-center gap-2" x-show="hasSelection" x-cloak>
+      <button type="submit" formmethod="get" formaction="{% url 'page_bulk_move' %}" class="btn-outline text-sm whitespace-nowrap">Bulk Move…</button>
+    </div>
+    {% endif %}
   </div>
   <div class="grid gap-2">
     {% for page in pages %}
     <div class="card relative flex items-center gap-3 py-3.5 px-5 hover:shadow-card-hover hover:border-primary-300 dark:hover:border-primary-600 transition-all"
          {% if can_edit %}x-data="pinToggle" data-pinned="{% if page.is_pinned %}true{% else %}false{% endif %}" data-url="{% url 'page_toggle_pin' path=page.content_path %}"{% endif %}>
+      {% if can_edit %}
+      <input type="checkbox" name="page_ids" value="{{ page.id }}" @change="recount" class="relative z-10 accent-primary-600 flex-shrink-0" aria-label="Select {{ page.title }}">
+      {% endif %}
       {# Pin icon (shown for pinned pages) / Document icon (shown for unpinned) #}
       {% if can_edit %}
       <template x-if="pinned">
@@ -160,7 +185,7 @@
           <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a6 6 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182a.5.5 0 0 1-.707-.708l3.182-3.182L2.398 8.23a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a6 6 0 0 1 1.013.16l3.134-3.133a3 3 0 0 1-.04-.461c0-.43.109-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
         </svg>
       </template>
-      <template x-if="!pinned">
+      <template x-if="unpinned">
         <svg class="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
         </svg>
@@ -194,6 +219,9 @@
     </div>
     {% endfor %}
   </div>
+  {% if can_edit %}
+  </form>
+  {% endif %}
   {% endif %}
 
   {% if not subdirectories and not pages %}

--- a/wiki/directories/templates/directories/detail.html
+++ b/wiki/directories/templates/directories/detail.html
@@ -139,8 +139,18 @@
   {# Pages #}
   {% if pages %}
   {% if can_edit %}
-  <form method="post" id="bulk-pages-form" x-data="bulkPageSelect">
-    {% csrf_token %}
+  {% comment %}
+    method="get", no csrf_token: the only submit control this form has
+    is the "Bulk Move…" button below, which only ever navigates to the
+    confirmation page — it doesn't itself change anything. A hidden
+    CSRF token here would have been serialized straight into that GET
+    request's query string (the browser puts every field from a
+    GET-submitted form into the URL), leaking a live, session-valid
+    token into browser history, server/proxy logs, and any outbound
+    Referer header. The actual state-changing POST happens on
+    bulk_move.html's own separately-tokened form.
+  {% endcomment %}
+  <form method="get" id="bulk-pages-form" x-data="bulkPageSelect">
     <input type="hidden" name="next" value="{{ request.get_full_path }}">
   {% endif %}
   {% comment %}
@@ -167,7 +177,7 @@
     </div>
     {% if can_edit %}
     <div class="text-sm flex items-center gap-2" x-show="hasSelection" x-cloak>
-      <button type="submit" formmethod="get" formaction="{% url 'page_bulk_move' %}" class="btn-outline text-sm whitespace-nowrap">Bulk Move…</button>
+      <button type="submit" formaction="{% url 'page_bulk_move' %}" class="btn-outline text-sm whitespace-nowrap">Bulk Move…</button>
     </div>
     {% endif %}
   </div>

--- a/wiki/directories/tests.py
+++ b/wiki/directories/tests.py
@@ -117,6 +117,24 @@ class TestBulkSelectionUI:
         content = r.content.decode()
         assert 'name="page_ids"' not in content
 
+    def test_selection_form_is_get_with_no_csrf_token(
+        self, client, user, page_in_directory, sub_directory
+    ):
+        """The bulk-select form's only control is a GET-submitting
+        button; a csrf token here would serialize into the resulting
+        GET's query string (browsers put every field from a GET-method
+        form into the URL), leaking a live, replayable CSRF token into
+        browser history and server/proxy logs."""
+        client.force_login(user)
+        r = client.get(sub_directory.get_absolute_url())
+        content = r.content.decode()
+        marker = content.index('id="bulk-pages-form"')
+        start = content.rindex("<form", 0, marker)
+        end = content.index("</form>", start)
+        form_html = content[start:end]
+        assert 'method="get"' in form_html
+        assert "csrfmiddlewaretoken" not in form_html
+
 
 class TestDirectoryEdit:
     def test_edit_requires_login(self, client, sub_directory):

--- a/wiki/directories/tests.py
+++ b/wiki/directories/tests.py
@@ -88,6 +88,36 @@ class TestDirectoryDetail:
         assert r.status_code == 404
 
 
+class TestBulkSelectionUI:
+    """Checkbox selection + Bulk Move button on the directory listing."""
+
+    def test_checkboxes_shown_for_editor(
+        self, client, user, page_in_directory, sub_directory
+    ):
+        client.force_login(user)
+        r = client.get(sub_directory.get_absolute_url())
+        content = r.content.decode()
+        assert 'name="page_ids"' in content
+        assert 'aria-label="Select all pages"' in content
+        assert reverse("page_bulk_move") in content
+
+    def test_checkboxes_hidden_for_non_editor(
+        self, client, other_user, page_in_directory, sub_directory
+    ):
+        client.force_login(other_user)
+        r = client.get(sub_directory.get_absolute_url())
+        content = r.content.decode()
+        assert 'name="page_ids"' not in content
+        assert reverse("page_bulk_move") not in content
+
+    def test_checkboxes_hidden_for_anonymous(
+        self, client, page_in_directory, sub_directory
+    ):
+        r = client.get(sub_directory.get_absolute_url())
+        content = r.content.decode()
+        assert 'name="page_ids"' not in content
+
+
 class TestDirectoryEdit:
     def test_edit_requires_login(self, client, sub_directory):
         r = client.get(

--- a/wiki/pages/templates/pages/bulk_move.html
+++ b/wiki/pages/templates/pages/bulk_move.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Move Pages - FLP Wiki{% endblock %}
+
+{% block content %}
+<div class="max-w-lg">
+  <h1 class="text-2xl mb-6">Move {{ eligible_pages|length }} page{{ eligible_pages|length|pluralize }}</h1>
+
+  {% if ineligible_pages %}
+  <div class="card border-red-300 dark:border-red-700 mb-4">
+    <p class="mb-3 font-medium text-red-700 dark:text-red-400">
+      {{ ineligible_pages|length }} selected page{{ ineligible_pages|length|pluralize }} won't be moved
+      — you don't have owner rights on {{ ineligible_pages|length|pluralize:"it,them" }}:
+    </p>
+    <ul class="space-y-1">
+      {% for page in ineligible_pages %}
+      <li>{{ page.title }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  {% if eligible_pages %}
+  <div class="card mb-4">
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">Moving:</p>
+    <ul class="space-y-1">
+      {% for page in eligible_pages %}
+      <li>
+        {{ page.title }}
+        <span class="text-sm text-gray-400 dark:text-gray-500">
+          {% if page.directory %}/{{ page.directory.path }}{% else %}/ (Root){% endif %}
+        </span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+
+    {% include "includes/_page_move_fields.html" %}
+
+    {% for page in eligible_pages %}
+    <input type="hidden" name="page_ids" value="{{ page.id }}">
+    {% endfor %}
+    <input type="hidden" name="next" value="{{ next }}">
+
+    <div class="flex gap-3">
+      <button type="submit" class="btn-primary">Move {{ eligible_pages|length }} Page{{ eligible_pages|length|pluralize }}</button>
+      <a href="{{ next }}" class="btn-outline">Cancel</a>
+    </div>
+  </form>
+  {% else %}
+  <p class="text-gray-500 dark:text-gray-400 mb-4">None of the selected pages can be moved.</p>
+  <a href="{{ next }}" class="btn-outline">Back</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/wiki/pages/templates/pages/move.html
+++ b/wiki/pages/templates/pages/move.html
@@ -13,13 +13,7 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
 
-    <div>
-      <label for="id_directory" class="block text-sm font-medium mb-1">Move to directory</label>
-      {{ form.directory }}
-      {% if form.directory.errors %}
-      <p class="text-red-600 dark:text-red-400 text-sm mt-1">{{ form.directory.errors.0 }}</p>
-      {% endif %}
-    </div>
+    {% include "includes/_page_move_fields.html" %}
 
     <div class="flex gap-3">
       <button type="submit" class="btn-primary">Move Page</button>

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -46,7 +46,7 @@ from wiki.pages.tasks import (
     sync_page_view_counts,
     update_search_vectors,
 )
-from wiki.pages.views import _extract_mentions
+from wiki.pages.views import _extract_mentions, _move_page_to_directory
 from wiki.subscriptions.models import PageSubscription
 from wiki.subscriptions.tasks import _get_content_snippet
 from wiki.users.models import SystemConfig
@@ -2269,6 +2269,29 @@ class TestBulkPageMove:
         assert b"Not Yours" in r.content
         assert b"Getting Started" in r.content
 
+    def test_get_hides_unviewable_pages_entirely(
+        self, client, user, other_user, page
+    ):
+        """A page the requester can't even view must not appear at all —
+        not its title, not a count — under "won't be moved". Otherwise
+        page_ids becomes an oracle for enumerating private page titles."""
+        secret_page = Page.objects.create(
+            title="Q3 Layoff Plan",
+            slug="q3-layoff-plan",
+            content="x",
+            owner=other_user,
+            created_by=other_user,
+            updated_by=other_user,
+            visibility=Page.Visibility.PRIVATE,
+        )
+        client.force_login(user)
+        r = client.get(
+            reverse("page_bulk_move"),
+            {"page_ids": [page.pk, secret_page.pk]},
+        )
+        assert r.status_code == 200
+        assert b"Q3 Layoff Plan" not in r.content
+
     def test_post_moves_eligible_pages(
         self, client, user, page, sub_directory
     ):
@@ -2346,6 +2369,52 @@ class TestBulkPageMove:
         )
         assert r.status_code == 302
         assert r.url == reverse("root")
+
+    def test_malformed_page_id_does_not_500(self, client, user, page):
+        client.force_login(user)
+        r = client.get(
+            reverse("page_bulk_move"), {"page_ids": ["abc", str(page.pk)]}
+        )
+        assert r.status_code == 200
+        assert b"Getting Started" in r.content
+
+    def test_concurrent_slug_collision_returns_error_not_500(
+        self, monkeypatch, user, sub_directory
+    ):
+        """A slug claimed between the pre-save check and the save itself
+        (e.g. by a concurrent request) must be caught as an IntegrityError,
+        not raised — that would 500 the single-page view, and would abort
+        every other page's move in the same bulk request's transaction."""
+        movable = Page.objects.create(
+            title="Movable",
+            slug="dup",
+            content="x",
+            owner=user,
+            created_by=user,
+            updated_by=user,
+        )
+        Page.objects.create(
+            title="Already There",
+            slug="dup",
+            content="x",
+            directory=sub_directory,
+            owner=user,
+            created_by=user,
+            updated_by=user,
+        )
+        # Simulate the race: the pre-save check finds no conflict (as if
+        # the other page hadn't been created yet at check-time), so the
+        # real save() below hits the unique constraint for real.
+        monkeypatch.setattr(
+            Page.objects, "filter", lambda *a, **k: Page.objects.none()
+        )
+
+        ok, error = _move_page_to_directory(movable, sub_directory)
+
+        assert ok is False
+        assert "already exists" in error
+        movable.refresh_from_db()
+        assert movable.directory is None
 
 
 class TestPagePeople:

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -2243,6 +2243,111 @@ class TestPagePermissions:
         assert page.content == "Group edited"
 
 
+class TestBulkPageMove:
+    def test_get_requires_login(self, client, page):
+        r = client.get(reverse("page_bulk_move"), {"page_ids": [page.pk]})
+        assert r.status_code == 302
+        assert reverse("login") in r.url
+
+    def test_get_shows_eligible_and_ineligible(
+        self, client, user, other_user, page
+    ):
+        other_page = Page.objects.create(
+            title="Not Yours",
+            slug="not-yours-move",
+            content="x",
+            owner=other_user,
+            created_by=other_user,
+            updated_by=other_user,
+        )
+        client.force_login(user)
+        r = client.get(
+            reverse("page_bulk_move"),
+            {"page_ids": [page.pk, other_page.pk]},
+        )
+        assert r.status_code == 200
+        assert b"Not Yours" in r.content
+        assert b"Getting Started" in r.content
+
+    def test_post_moves_eligible_pages(
+        self, client, user, page, sub_directory
+    ):
+        client.force_login(user)
+        r = client.post(
+            reverse("page_bulk_move"),
+            {
+                "page_ids": [page.pk],
+                "directory": sub_directory.pk,
+                "next": reverse("root"),
+            },
+        )
+        assert r.status_code == 302
+        page.refresh_from_db()
+        assert page.directory == sub_directory
+
+    def test_post_skips_ineligible_pages(
+        self, client, user, other_user, page, sub_directory
+    ):
+        other_page = Page.objects.create(
+            title="Not Yours",
+            slug="not-yours-move-2",
+            content="x",
+            owner=other_user,
+            created_by=other_user,
+            updated_by=other_user,
+        )
+        client.force_login(user)
+        r = client.post(
+            reverse("page_bulk_move"),
+            {
+                "page_ids": [page.pk, other_page.pk],
+                "directory": sub_directory.pk,
+                "next": reverse("root"),
+            },
+        )
+        assert r.status_code == 302
+        page.refresh_from_db()
+        other_page.refresh_from_db()
+        assert page.directory == sub_directory
+        assert other_page.directory is None
+
+    def test_post_reports_slug_collision_without_500(
+        self, client, user, page, page_in_directory, sub_directory
+    ):
+        # page_in_directory already occupies "coding-standards" in
+        # sub_directory; moving a same-slugged page there should be
+        # skipped and reported, not raise an IntegrityError.
+        page.slug = "coding-standards"
+        page.save()
+        client.force_login(user)
+        r = client.post(
+            reverse("page_bulk_move"),
+            {
+                "page_ids": [page.pk],
+                "directory": sub_directory.pk,
+                "next": reverse("root"),
+            },
+            follow=True,
+        )
+        assert r.status_code == 200
+        page.refresh_from_db()
+        assert page.directory is None
+        assert b"Skipped" in r.content
+
+    def test_open_redirect_falls_back_to_root(self, client, user, page):
+        client.force_login(user)
+        r = client.post(
+            reverse("page_bulk_move"),
+            {
+                "page_ids": [page.pk],
+                "directory": "",
+                "next": "https://evil.example.com/",
+            },
+        )
+        assert r.status_code == 302
+        assert r.url == reverse("root")
+
+
 class TestPagePeople:
     def test_creator_shown_on_detail(self, client, page):
         r = client.get(page.get_absolute_url())

--- a/wiki/pages/tests_cdn.py
+++ b/wiki/pages/tests_cdn.py
@@ -186,6 +186,40 @@ def test_history_toggle_invalidates_feed_url(mock_invalidate, page):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_bulk_move_invalidates_each_page(
+    mock_invalidate,
+    client,
+    user,
+    page,
+    page_in_nested_directory,
+    sub_directory,
+):
+    """Bulk move must ``.save()`` each page individually.
+
+    A queryset ``.update()`` would relocate pages without firing the
+    per-page ``post_save`` CDN-invalidation signal, silently leaving
+    stale cached HTML at the old URLs.
+    """
+    client.force_login(user)
+    old_url = page.get_absolute_url()
+    old_nested_url = page_in_nested_directory.get_absolute_url()
+    mock_invalidate.reset_mock()
+    client.post(
+        reverse("page_bulk_move"),
+        {
+            "page_ids": [page.pk, page_in_nested_directory.pk],
+            "directory": sub_directory.pk,
+            "next": reverse("root"),
+        },
+    )
+    all_paths = []
+    for call in mock_invalidate.call_args_list:
+        all_paths.extend(call.args[0])
+    assert old_url in all_paths
+    assert old_nested_url in all_paths
+
+
+@pytest.mark.django_db(transaction=True)
 def test_create_revision_invalidates_feed_url(mock_invalidate, page, user):
     """Creating a revision should invalidate the page's feed URL.
 

--- a/wiki/pages/urls.py
+++ b/wiki/pages/urls.py
@@ -7,6 +7,10 @@ from . import views
 from .feeds import PageHistoryFeed
 
 urlpatterns = [
+    # Bulk actions — must come before the "<path:path>/..." patterns below,
+    # or Django would resolve e.g. "bulk/move/" as page_move with
+    # path="bulk" instead.
+    path("bulk/move/", views.page_bulk_move, name="page_bulk_move"),
     path(
         "<path:path>/permissions/",
         views.page_permissions,

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -17,6 +17,7 @@ from django.http import FileResponse, Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import escape
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.text import get_valid_filename
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -756,6 +757,81 @@ def page_edit(request, path):
     )
 
 
+def _resolve_bulk_pages(data):
+    """Resolve a bulk action's ``page_ids`` into ``Page`` objects.
+
+    ``data`` is a QueryDict — ``request.GET`` for the confirmation-page
+    views, ``request.POST`` for the direct-action and submit views. Returns
+    ``(pages, next_url)``; ``next_url`` is unvalidated — pass it through
+    ``_safe_next`` before redirecting.
+    """
+    ids = data.getlist("page_ids")
+    pages = list(Page.objects.filter(pk__in=ids, is_deleted=False))
+    return pages, data.get("next", "")
+
+
+def _safe_next(request, next_url):
+    """Validate a bulk action's ``next`` redirect target, or fall back."""
+    if url_has_allowed_host_and_scheme(
+        next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        return next_url
+    return reverse("root")
+
+
+def _split_by_administer(user, pages):
+    """Split pages into ones the user does/doesn't administer.
+
+    Used by the bulk Move/Permissions confirmation views so the user sees
+    which selected pages are actually eligible *before* filling out the
+    form — rather than finding out after submitting.
+    """
+    eligible = [p for p in pages if can_administer_page(user, p)]
+    ineligible = [p for p in pages if p not in eligible]
+    return eligible, ineligible
+
+
+def _flash_skip_summary(request, skipped):
+    """Flash a capped, comma-joined warning listing skipped items."""
+    preview = ", ".join(skipped[:5])
+    if len(skipped) > 5:
+        preview += "…"
+    messages.warning(request, f"Skipped {len(skipped)}: {preview}")
+
+
+def _move_page_to_directory(page, new_directory):
+    """Move a page to ``new_directory``, checking for path/slug collisions.
+
+    Shared by the single-page and bulk Move views. Returns ``(True, None)``
+    on success, or ``(False, error_message)`` if the destination already
+    has a directory or a page at that slug.
+    """
+    if page_path_conflicts_with_directory(page.slug, new_directory):
+        return False, (
+            "A directory already exists at that path. "
+            "Rename the page or choose a different directory."
+        )
+
+    # Under dir-scoped slugs, the destination might already have a page
+    # with the same slug — saving would raise IntegrityError. Check first
+    # and surface it as a normal error instead of a 500.
+    if (
+        Page.objects.filter(directory=new_directory, slug=page.slug)
+        .exclude(pk=page.pk)
+        .exists()
+    ):
+        return False, (
+            "A page with this slug already exists in the destination "
+            "directory. Rename the page before moving it."
+        )
+
+    page.directory = new_directory
+    page.save()
+    return True, None
+
+
 @login_required
 @ratelimit_page_write
 def page_move(request, path):
@@ -781,40 +857,15 @@ def page_move(request, path):
 
     if request.method == "POST" and form.is_valid():
         new_directory = form.cleaned_data["directory"]
-
-        if page_path_conflicts_with_directory(page.slug, new_directory):
-            messages.error(
-                request,
-                "A directory already exists at that path. "
-                "Rename the page or choose a different directory.",
-            )
+        ok, error = _move_page_to_directory(page, new_directory)
+        if not ok:
+            messages.error(request, error)
             return render(
                 request,
                 "pages/move.html",
                 {"form": form, "page": page},
             )
 
-        # Under dir-scoped slugs, the destination might already have a
-        # page with the same slug — saving would raise IntegrityError.
-        # Surface it as a form error instead of a 500.
-        if (
-            Page.objects.filter(directory=new_directory, slug=page.slug)
-            .exclude(pk=page.pk)
-            .exists()
-        ):
-            messages.error(
-                request,
-                "A page with this slug already exists in the destination "
-                "directory. Rename the page before moving it.",
-            )
-            return render(
-                request,
-                "pages/move.html",
-                {"form": form, "page": page},
-            )
-
-        page.directory = new_directory
-        page.save()
         messages.success(
             request,
             f'Moved "{page.title}" to /{new_directory.path}.'
@@ -893,6 +944,58 @@ def page_delete(request, path):
     )
 
 
+def _resolve_permission_target(target_type, form):
+    """Resolve a validated PagePermissionForm's target into grant kwargs.
+
+    Independent of any particular page, so bulk callers can resolve once
+    and reuse it across many pages instead of re-resolving per page.
+    Returns ``(lookup, defaults, label)`` — ``lookup``/``defaults`` are the
+    kwargs to pass to ``PagePermission.objects.get_or_create`` — or
+    ``(None, None, error_message)`` if the target itself is missing or
+    unresolvable.
+    """
+    if target_type == "group":
+        group = form.cleaned_data.get("group")
+        if not group:
+            return None, None, "Please select a group."
+        return {"group": group}, {"user": None}, group.name
+
+    if target_type == "domain":
+        domain = form.cleaned_data.get("allowed_domain")
+        if not domain:
+            return None, None, "Please select a domain."
+        return {"grant_domain": domain.domain}, {"user": None}, domain.domain
+
+    username = form.cleaned_data.get("username", "").strip()
+    if not username:
+        return None, None, "Please enter a username."
+    user = user_by_handle(username)
+    if not user:
+        return None, None, f'No user found with username "{username}".'
+    return {"user": user}, {}, username
+
+
+def _grant_page_permission(page, target_type, form):
+    """Grant one permission to a page from a validated PagePermissionForm.
+
+    Shared by the single-page and bulk Permissions views. Returns
+    ``(result, label)``: ``result`` is ``"granted"`` (new grant created),
+    ``"already"`` (the target already had this access), or ``"invalid"``
+    (the target field itself was missing/unresolvable). ``label`` is the
+    bare target name (group name / domain / username) on success, or an
+    error message on ``"invalid"``.
+    """
+    perm_type = form.cleaned_data["permission_type"]
+    lookup, defaults, label = _resolve_permission_target(target_type, form)
+    if lookup is None:
+        return "invalid", label
+
+    _, created = PagePermission.objects.get_or_create(
+        page=page, permission_type=perm_type, defaults=defaults, **lookup
+    )
+    return ("granted" if created else "already"), label
+
+
 @login_required
 def page_permissions(request, path):
     """Manage permissions for a page."""
@@ -924,77 +1027,38 @@ def page_permissions(request, path):
     if request.method == "POST" and form.is_valid():
         target_type = request.POST.get("target_type", "user")
         perm_type = form.cleaned_data["permission_type"]
+        result, label = _grant_page_permission(page, target_type, form)
 
-        if target_type == "group":
-            group = form.cleaned_data.get("group")
-            if group:
-                _, created = PagePermission.objects.get_or_create(
-                    page=page,
-                    group=group,
-                    permission_type=perm_type,
-                    defaults={"user": None},
+        if result == "invalid":
+            messages.error(request, label)
+        elif target_type == "group":
+            if result == "granted":
+                messages.success(
+                    request, f"Granted {perm_type} access to group {label}."
                 )
-                if created:
-                    messages.success(
-                        request,
-                        f"Granted {perm_type} access to group {group.name}.",
-                    )
-                else:
-                    messages.info(
-                        request,
-                        f"Group {group.name} already has {perm_type} access.",
-                    )
             else:
-                messages.error(request, "Please select a group.")
+                messages.info(
+                    request, f"Group {label} already has {perm_type} access."
+                )
         elif target_type == "domain":
-            domain = form.cleaned_data.get("allowed_domain")
-            if domain:
-                _, created = PagePermission.objects.get_or_create(
-                    page=page,
-                    grant_domain=domain.domain,
-                    permission_type=perm_type,
-                    defaults={"user": None},
+            if result == "granted":
+                messages.success(
+                    request,
+                    f"Granted {perm_type} access to everyone @{label}.",
                 )
-                if created:
-                    messages.success(
-                        request,
-                        f"Granted {perm_type} access to everyone "
-                        f"@{domain.domain}.",
-                    )
-                else:
-                    messages.info(
-                        request,
-                        f"@{domain.domain} already has {perm_type} access.",
-                    )
             else:
-                messages.error(request, "Please select a domain.")
+                messages.info(
+                    request, f"@{label} already has {perm_type} access."
+                )
         else:
-            username = form.cleaned_data.get("username", "").strip()
-            if not username:
-                messages.error(request, "Please enter a username.")
+            if result == "granted":
+                messages.success(
+                    request, f"Granted {perm_type} access to {label}."
+                )
             else:
-                user = user_by_handle(username)
-                if not user:
-                    messages.error(
-                        request,
-                        f'No user found with username "{username}".',
-                    )
-                else:
-                    _, created = PagePermission.objects.get_or_create(
-                        page=page,
-                        user=user,
-                        permission_type=perm_type,
-                    )
-                    if created:
-                        messages.success(
-                            request,
-                            f"Granted {perm_type} access to {username}.",
-                        )
-                    else:
-                        messages.info(
-                            request,
-                            f"{username} already has {perm_type} access.",
-                        )
+                messages.info(
+                    request, f"{label} already has {perm_type} access."
+                )
 
         return redirect(
             reverse(
@@ -1026,6 +1090,65 @@ def page_permissions(request, path):
             "user_permissions": user_perms,
             "group_permissions": group_perms,
             "domain_permissions": domain_perms,
+        },
+    )
+
+
+@login_required
+@ratelimit_page_write
+def page_bulk_move(request):
+    """Move multiple pages to a different directory.
+
+    GET renders a confirmation page showing which selected pages are
+    actually eligible (owner rights) before asking for a destination;
+    POST (from that page) performs the move. Same GET-then-POST shape as
+    the single-page ``page_move`` view above.
+    """
+    data = request.POST if request.method == "POST" else request.GET
+    pages, next_url = _resolve_bulk_pages(data)
+    next_url = _safe_next(request, next_url)
+
+    # Re-derive eligibility from scratch on every request rather than
+    # trusting the confirmation page's hidden fields — permissions may
+    # have changed between the GET and the POST.
+    eligible, ineligible = _split_by_administer(request.user, pages)
+
+    form = PageMoveForm(
+        request.POST if request.method == "POST" else None,
+        user=request.user,
+    )
+
+    if request.method == "POST" and form.is_valid():
+        new_directory = form.cleaned_data["directory"]
+        moved = 0
+        skipped = [f"{p.title} (no permission)" for p in ineligible]
+        with transaction.atomic():
+            for page in eligible:
+                ok, error = _move_page_to_directory(page, new_directory)
+                if ok:
+                    moved += 1
+                else:
+                    skipped.append(f"{page.title} ({error})")
+
+        if moved:
+            messages.success(
+                request,
+                f"Moved {moved} page(s) to /{new_directory.path}."
+                if new_directory
+                else f"Moved {moved} page(s) to root.",
+            )
+        if skipped:
+            _flash_skip_summary(request, skipped)
+        return redirect(next_url)
+
+    return render(
+        request,
+        "pages/bulk_move.html",
+        {
+            "form": form,
+            "eligible_pages": eligible,
+            "ineligible_pages": ineligible,
+            "next": next_url,
         },
     )
 

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.auth.views import redirect_to_login
 from django.core.paginator import Paginator
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.http import FileResponse, Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -765,7 +765,15 @@ def _resolve_bulk_pages(data):
     ``(pages, next_url)``; ``next_url`` is unvalidated — pass it through
     ``_safe_next`` before redirecting.
     """
-    ids = data.getlist("page_ids")
+    ids = []
+    for raw_id in data.getlist("page_ids"):
+        try:
+            ids.append(int(raw_id))
+        except (TypeError, ValueError):
+            # Malformed input (hand-crafted request, stale form, etc.) —
+            # drop it rather than letting Page.pk's int coercion 500 on
+            # the whole request.
+            continue
     pages = list(Page.objects.filter(pk__in=ids, is_deleted=False))
     return pages, data.get("next", "")
 
@@ -784,9 +792,11 @@ def _safe_next(request, next_url):
 def _split_by_administer(user, pages):
     """Split pages into ones the user does/doesn't administer.
 
-    Used by the bulk Move/Permissions confirmation views so the user sees
-    which selected pages are actually eligible *before* filling out the
-    form — rather than finding out after submitting.
+    Used by the bulk Move confirmation view so the user sees which
+    selected pages are actually eligible *before* filling out the form —
+    rather than finding out after submitting. Callers must filter to
+    pages the user can *view* first — this only decides movable-vs-not
+    among pages already known to be visible to them.
     """
     eligible = [p for p in pages if can_administer_page(user, p)]
     ineligible = [p for p in pages if p not in eligible]
@@ -816,7 +826,8 @@ def _move_page_to_directory(page, new_directory):
 
     # Under dir-scoped slugs, the destination might already have a page
     # with the same slug — saving would raise IntegrityError. Check first
-    # and surface it as a normal error instead of a 500.
+    # and surface it as a normal error instead of a 500; this is the fast
+    # path that catches the case in the vast majority of requests.
     if (
         Page.objects.filter(directory=new_directory, slug=page.slug)
         .exclude(pk=page.pk)
@@ -827,8 +838,23 @@ def _move_page_to_directory(page, new_directory):
             "directory. Rename the page before moving it."
         )
 
+    original_directory = page.directory
     page.directory = new_directory
-    page.save()
+    try:
+        # A nested atomic() gives this its own savepoint: if a concurrent
+        # request claims the same slug in new_directory between the check
+        # above and this save, only this page's savepoint rolls back — not
+        # the bulk view's outer transaction.atomic(), which would otherwise
+        # get poisoned and abort every other page's move in the same
+        # request.
+        with transaction.atomic():
+            page.save()
+    except IntegrityError:
+        page.directory = original_directory
+        return False, (
+            "A page with this slug already exists in the destination "
+            "directory. Rename the page before moving it."
+        )
     return True, None
 
 
@@ -1107,6 +1133,13 @@ def page_bulk_move(request):
     data = request.POST if request.method == "POST" else request.GET
     pages, next_url = _resolve_bulk_pages(data)
     next_url = _safe_next(request, next_url)
+
+    # Drop anything the user can't even view before it's ever shown or
+    # split — mirrors the can_view_page 404 gate every single-page view
+    # in this file has. Silent, not reported as "skipped": a page you
+    # can't view should be indistinguishable from a page ID that doesn't
+    # exist, so its title never renders under "won't be moved" either.
+    pages = [p for p in pages if can_view_page(request.user, p)]
 
     # Re-derive eligibility from scratch on every request rather than
     # trusting the confirmation page's hidden fields — permissions may

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -515,6 +515,84 @@ class TestPageCreateFromRoot:
 
 
 @pytest.fixture
+def bulk_move_pages(browser_user, dir_tree):
+    """Two pages inside 'staff', for the bulk-move browser test."""
+    staff_dir = Directory.objects.get(path="staff")
+    pages = []
+    for slug, title in [("alpha", "Alpha Page"), ("beta", "Beta Page")]:
+        p = WikiPage.objects.create(
+            title=title,
+            slug=slug,
+            content="x",
+            directory=staff_dir,
+            owner=browser_user,
+            created_by=browser_user,
+            updated_by=browser_user,
+        )
+        PageRevision.objects.create(
+            page=p,
+            title=p.title,
+            content=p.content,
+            change_message="Initial creation",
+            revision_number=1,
+            created_by=browser_user,
+        )
+        pages.append(p)
+    return pages
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBulkMoveUI:
+    """Select pages on a directory listing and move them via the UI.
+
+    The one part of the bulk-move feature that can't be verified through
+    the Django test client alone: checkbox selection swapping in the
+    "Bulk Move…" button, and that button carrying the selection through
+    to the confirmation page.
+    """
+
+    def test_select_and_move_pages(
+        self,
+        browser_page,
+        live_server,
+        browser_user,
+        dir_tree,
+        bulk_move_pages,
+    ):
+        _force_login(browser_page, live_server, browser_user)
+        staff_url = reverse("resolve_path", kwargs={"path": "staff"})
+        browser_page.goto(f"{live_server.url}{staff_url}")
+
+        move_button = browser_page.get_by_role("button", name="Bulk Move…")
+        expect(move_button).to_be_hidden()
+
+        checkboxes = browser_page.locator('input[name="page_ids"]')
+        expect(checkboxes).to_have_count(2)
+        checkboxes.nth(0).check()
+        checkboxes.nth(1).check()
+        expect(move_button).to_be_visible()
+
+        move_button.click()
+
+        # Confirmation page lists both selected pages up front.
+        expect(browser_page.locator("h1")).to_contain_text("Move 2 page")
+        body = browser_page.locator("body")
+        expect(body).to_contain_text("Alpha Page")
+        expect(body).to_contain_text("Beta Page")
+
+        browser_page.locator("#id_directory").select_option(label="/docs")
+        browser_page.get_by_role("button", name="Move 2 Page").click()
+
+        # Redirected back to the (now empty of these pages) staff listing.
+        browser_page.wait_for_url(f"**{staff_url}**")
+        expect(browser_page.locator("body")).not_to_contain_text("Alpha Page")
+
+        for p in bulk_move_pages:
+            p.refresh_from_db()
+            assert p.directory.path == "docs"
+
+
+@pytest.fixture
 def wiki_link_pages(browser_user, dir_tree):
     """A pair of pages whose titles share a prefix, for autocomplete tests.
 


### PR DESCRIPTION
## Fixes
Fixes #144

## Summary
Adds a GitHub-issues-style checkbox system to directory page listings, scoped to **Move** for this round.

The issue proposed four candidate bulk actions (Move, Subscribe/Unsubscribe, Permissions, make History public). All four were prototyped end-to-end (views, confirmation pages, tests), but after iterating on the UI live against a running dev instance, we cut the scope down to just Move — a single "Bulk Move…" button that appears once you check any page — because the other three added a lot of visual/interaction surface (a floating action bar, redundant Subscribe/Unsubscribe and History Public/Private button pairs, a second "Actions" menu competing with the directory's existing one) for comparatively little value. The Subscribe/History/Permissions code was fully removed before this PR rather than left half-wired — happy to bring any of them back as a follow-up if there's demand, following the same pattern established here.

**How it works:**
- Checkboxes appear on each page (gated on `can_edit`, the same threshold as the existing pin-toggle control) plus a tri-state "select all" checkbox.
- Selecting any page swaps the sort-controls row for a "Bulk Move…" button in place — no floating bar, no layout shift between the two states.
- Clicking it is a plain `formmethod="get"` submit carrying the selection to a new confirmation page (`page_bulk_move`), which shows which of the selected pages you actually administer *before* asking for a destination — mirroring the existing single-page Move view's GET-renders-form/POST-submits-form shape, just for N pages.
- `_move_page_to_directory` (the collision-check-and-save logic) is extracted out of the existing `page_move` view so both the single-page and bulk views share it without duplication; `page_move`'s own tests pass unchanged after the extraction.

**Gotchas hit along the way** (left as code comments where they bit):
- Alpine's `$el` inside a component method resolves to whatever element the *calling* directive is bound to, not the `x-data` root — so the per-checkbox `@change` handlers needed the root captured once in `init()` rather than read via `this.$el` elsewhere.
- Django's `{# ... #}` template comment doesn't support multi-line content; a multi-line one I wrote for context rendered as literal visible text on the page (looked like a real layout bug until traced back to that).
- A button label without `whitespace-nowrap` can wrap inside a shrinking flex container, which reads as a mysterious height/reflow bug rather than what it is (text wrap) — matches an existing convention elsewhere in this codebase (`_permission_form.html`) that I should've applied from the start.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No daemon/background-task code was touched — this is entirely web-tier (views, templates, JS, CSS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editors can select multiple pages from a directory listing and move them in one action.
  * Added a confirmation screen showing eligible and skipped pages before moving.
  * Added destination directory selection and clear feedback for conflicts or unauthorized pages.
  * Selection controls include select-all behavior and update sorting controls dynamically.

* **Bug Fixes**
  * Improved move handling with safer redirects, collision reporting, and consistent permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->