### PR TITLE
Bulk-move UI polish: alignment, dropdown pre-select, click safety

### DIFF
--- a/wiki/assets/static-global/js/alpine-components.js
+++ b/wiki/assets/static-global/js/alpine-components.js
@@ -183,6 +183,13 @@ document.addEventListener('alpine:init', () => {
     get noneSelected() {
       return this.count === 0
     },
+    // The select-all checkbox is hidden until something's selected, so
+    // "Pages" lines up with "Directories" above it (which has no
+    // checkbox of its own). Once it appears, indent the heading to make
+    // room for it — same left offset as each page's own checkbox below.
+    get headerPaddingClass() {
+      return this.hasSelection ? 'pl-5' : ''
+    },
   }))
 
   // Search tips toggle

--- a/wiki/directories/templates/directories/detail.html
+++ b/wiki/directories/templates/directories/detail.html
@@ -162,9 +162,9 @@
     natural width and wrap it to two lines, which also causes a shift.
   {% endcomment %}
   <div class="min-h-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
-    <div class="flex items-center gap-2 {% if can_edit %}pl-5{% endif %}">
+    <div class="flex items-center gap-2" {% if can_edit %}:class="headerPaddingClass"{% endif %}>
       {% if can_edit %}
-      <input type="checkbox" x-ref="selectAll" @change="toggleAll" class="accent-primary-600" aria-label="Select all pages">
+      <input type="checkbox" x-ref="selectAll" @change="toggleAll" x-show="hasSelection" x-cloak class="accent-primary-600" aria-label="Select all pages">
       {% endif %}
       <h2 class="text-lg font-semibold font-sans">Pages</h2>
     </div>

--- a/wiki/directories/templates/directories/detail.html
+++ b/wiki/directories/templates/directories/detail.html
@@ -211,14 +211,23 @@
         </svg>
         {% endif %}
       {% endif %}
-      <a href="{{ page.get_absolute_url }}" class="flex-1 min-w-0 no-underline after:absolute after:inset-0">
-        <span class="font-medium text-gray-900 dark:text-gray-100">{{ page.title }}</span>
+      <div class="flex-1 min-w-0">
+        <a href="{{ page.get_absolute_url }}" class="relative z-10 font-medium text-gray-900 dark:text-gray-100 no-underline hover:underline">{{ page.title }}</a>
         <c-visibility-badge visibility="{{ page.visibility }}" />
         <c-domain-access-badges :domains="page.access_domains" />
         <span class="text-sm text-gray-400 dark:text-gray-500 ml-2">
           {{ page.updated_at|timesince }} ago
         </span>
-      </a>
+      </div>
+      {% comment %}
+        Whole-card click target — a separate overlay, not part of the
+        title link above, so it can be turned off independently. While
+        a selection is active it's hidden, leaving only the title text
+        itself clickable; this stops a checkbox-selecting user from
+        accidentally navigating away by clicking the card background
+        between checkboxes.
+      {% endcomment %}
+      <a href="{{ page.get_absolute_url }}" class="absolute inset-0" aria-hidden="true" tabindex="-1" {% if can_edit %}x-show="noneSelected"{% endif %}></a>
       {% if can_edit %}
       <button type="button" @click="toggle" class="relative z-10 text-gray-400 hover:text-primary-500 dark:text-gray-500 dark:hover:text-primary-400 p-1 flex-shrink-0" x-bind:title="title">
         <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">

--- a/wiki/directories/tests.py
+++ b/wiki/directories/tests.py
@@ -117,6 +117,24 @@ class TestBulkSelectionUI:
         content = r.content.decode()
         assert 'name="page_ids"' not in content
 
+    def test_select_all_checkbox_wired_to_appear_on_selection(
+        self, client, user, page_in_directory, sub_directory
+    ):
+        """The select-all checkbox stays hidden until a page is checked
+        (so "Pages" lines up with "Directories" above it, which has no
+        checkbox) — this only checks the reactive wiring is present;
+        TestBulkMoveUI in tests_browser.py verifies the actual show/hide
+        and alignment in a real browser."""
+        client.force_login(user)
+        r = client.get(sub_directory.get_absolute_url())
+        content = r.content.decode()
+        marker = content.index('aria-label="Select all pages"')
+        tag_start = content.rindex("<input", 0, marker)
+        tag_end = content.index(">", marker)
+        checkbox_html = content[tag_start:tag_end]
+        assert 'x-show="hasSelection"' in checkbox_html
+        assert "x-cloak" in checkbox_html
+
     def test_selection_form_is_get_with_no_csrf_token(
         self, client, user, page_in_directory, sub_directory
     ):

--- a/wiki/pages/templates/pages/bulk_move.html
+++ b/wiki/pages/templates/pages/bulk_move.html
@@ -25,12 +25,7 @@
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">Moving:</p>
     <ul class="space-y-1">
       {% for page in eligible_pages %}
-      <li>
-        {{ page.title }}
-        <span class="text-sm text-gray-400 dark:text-gray-500">
-          {% if page.directory %}/{{ page.directory.path }}{% else %}/ (Root){% endif %}
-        </span>
-      </li>
+      <li>{{ page.title }}</li>
       {% endfor %}
     </ul>
   </div>

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -2269,6 +2269,32 @@ class TestBulkPageMove:
         assert b"Not Yours" in r.content
         assert b"Getting Started" in r.content
 
+    def test_get_preselects_source_directory_in_dropdown(
+        self, client, user, page_in_directory, sub_directory
+    ):
+        """The checkboxes that build this selection only ever come from
+        one directory's listing, so the destination dropdown should
+        default to it — instead of repeating it next to every page."""
+        client.force_login(user)
+        r = client.get(
+            reverse("page_bulk_move"),
+            {"page_ids": [page_in_directory.pk]},
+        )
+        assert r.status_code == 200
+        content = r.content.decode()
+        option = re.search(
+            rf'<option value="{sub_directory.pk}"[^>]*>', content
+        )
+        assert option is not None
+        assert "selected" in option.group()
+        # No longer repeated next to the page's title in the "Moving:"
+        # list (the destination dropdown's own option label legitimately
+        # mentions the path elsewhere on the page, so scope the check).
+        moving_list = content[
+            content.index("Moving:") : content.index("</ul>")
+        ]
+        assert sub_directory.path not in moving_list
+
     def test_get_hides_unviewable_pages_entirely(
         self, client, user, other_user, page
     ):

--- a/wiki/pages/views.py
+++ b/wiki/pages/views.py
@@ -1146,8 +1146,14 @@ def page_bulk_move(request):
     # have changed between the GET and the POST.
     eligible, ineligible = _split_by_administer(request.user, pages)
 
+    # The checkboxes that produce this selection only ever exist on one
+    # directory's listing at a time, so every selected page shares the
+    # same source directory — pre-select it in the destination dropdown
+    # instead of repeating it next to every page in the list below.
+    source_directory = pages[0].directory if pages else None
     form = PageMoveForm(
         request.POST if request.method == "POST" else None,
+        initial={"directory": source_directory},
         user=request.user,
     )
 

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -629,6 +629,15 @@ class TestBulkMoveUI:
         browser_page.goto(f"{live_server.url}{staff_url}")
         checkbox = browser_page.locator('input[name="page_ids"]').first
         checkbox.check()
+        # Wait for Alpine's reactive update (hiding the overlay) to
+        # actually land before clicking — checking the box doesn't wait
+        # for its @change handler's DOM update to finish, and on a
+        # slower runner the click can land before x-show flips the
+        # overlay to hidden. The Bulk Move button reacts to the exact
+        # same hasSelection state, so waiting for it doubles as a
+        # barrier for the overlay's update too.
+        move_button = browser_page.get_by_role("button", name="Bulk Move…")
+        expect(move_button).to_be_visible()
 
         browser_page.mouse.click(bg_x, bg_y)
         browser_page.wait_for_timeout(300)

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -610,14 +610,15 @@ class TestBulkMoveUI:
 
         card = browser_page.locator(".card", has_text="Beta Page")
         card_box = card.bounding_box()
-        timestamp = card.locator("span", has_text="ago")
-        ts_box = timestamp.bounding_box()
-        pin_button = card.locator("button")
-        pin_box = pin_button.bounding_box()
-        # Midpoint of the empty gap between the timestamp and the pin
-        # button — genuine card background, not any interactive element.
-        bg_x = (ts_box["x"] + ts_box["width"] + pin_box["x"]) / 2
-        bg_y = card_box["y"] + card_box["height"] / 2
+        # A point inside the card's fixed py-3.5 top padding — no child
+        # element reaches into that strip (they're all vertically
+        # centered), so it's genuine background regardless of how wide
+        # any text inside happens to render. Deriving this from text
+        # bounding boxes instead (e.g. the gap next to the timestamp)
+        # is what broke on CI: slightly different font metrics there
+        # shifted the computed point onto the title link.
+        bg_x = card_box["x"] + card_box["width"] / 2
+        bg_y = card_box["y"] + 5
 
         # With nothing selected, the whole card is a click target.
         browser_page.mouse.click(bg_x, bg_y)

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -638,6 +638,47 @@ class TestBulkMoveUI:
         browser_page.locator("a", has_text="Beta Page").first.click()
         browser_page.wait_for_url(f"**{beta_url}")
 
+    def test_select_all_checkbox_appears_only_after_selection(
+        self,
+        browser_page,
+        live_server,
+        browser_user,
+        dir_tree,
+        bulk_move_pages,
+    ):
+        """The select-all checkbox stays hidden (and "Pages" unindented)
+        until a page is checked, so it lines up with "Directories" above
+        it — which has no checkbox of its own."""
+        Directory.objects.create(
+            path="staff/nested",
+            title="Nested",
+            parent=Directory.objects.get(path="staff"),
+            owner=browser_user,
+            created_by=browser_user,
+        )
+        _force_login(browser_page, live_server, browser_user)
+        staff_url = reverse("resolve_path", kwargs={"path": "staff"})
+        browser_page.goto(f"{live_server.url}{staff_url}")
+
+        select_all = browser_page.locator(
+            "input[aria-label='Select all pages']"
+        )
+        pages_heading = browser_page.locator("h2", has_text="Pages")
+        dirs_heading = browser_page.locator("h2", has_text="Directories")
+
+        expect(select_all).to_be_hidden()
+        assert (
+            pages_heading.bounding_box()["x"]
+            == dirs_heading.bounding_box()["x"]
+        )
+
+        browser_page.locator('input[name="page_ids"]').first.check()
+        expect(select_all).to_be_visible()
+        assert (
+            pages_heading.bounding_box()["x"]
+            > dirs_heading.bounding_box()["x"]
+        )
+
 
 @pytest.fixture
 def wiki_link_pages(browser_user, dir_tree):

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -591,6 +591,53 @@ class TestBulkMoveUI:
             p.refresh_from_db()
             assert p.directory.path == "docs"
 
+    def test_card_background_not_clickable_while_selecting(
+        self,
+        browser_page,
+        live_server,
+        browser_user,
+        dir_tree,
+        bulk_move_pages,
+    ):
+        """A page card's title link stays clickable, but the rest of the
+        card shouldn't be — otherwise a slightly-off click while checking
+        several boxes in a row navigates away by accident."""
+        _force_login(browser_page, live_server, browser_user)
+        staff_url = reverse("resolve_path", kwargs={"path": "staff"})
+        beta_page = bulk_move_pages[1]
+        beta_url = beta_page.get_absolute_url()
+        browser_page.goto(f"{live_server.url}{staff_url}")
+
+        card = browser_page.locator(".card", has_text="Beta Page")
+        card_box = card.bounding_box()
+        timestamp = card.locator("span", has_text="ago")
+        ts_box = timestamp.bounding_box()
+        pin_button = card.locator("button")
+        pin_box = pin_button.bounding_box()
+        # Midpoint of the empty gap between the timestamp and the pin
+        # button — genuine card background, not any interactive element.
+        bg_x = (ts_box["x"] + ts_box["width"] + pin_box["x"]) / 2
+        bg_y = card_box["y"] + card_box["height"] / 2
+
+        # With nothing selected, the whole card is a click target.
+        browser_page.mouse.click(bg_x, bg_y)
+        browser_page.wait_for_url(f"**{beta_url}")
+
+        # Back on the listing, select a page — the background click
+        # target should now be disabled.
+        browser_page.goto(f"{live_server.url}{staff_url}")
+        checkbox = browser_page.locator('input[name="page_ids"]').first
+        checkbox.check()
+
+        browser_page.mouse.click(bg_x, bg_y)
+        browser_page.wait_for_timeout(300)
+        assert browser_page.url == f"{live_server.url}{staff_url}"
+        expect(checkbox).to_be_checked()
+
+        # The title text itself is still clickable.
+        browser_page.locator("a", has_text="Beta Page").first.click()
+        browser_page.wait_for_url(f"**{beta_url}")
+
 
 @pytest.fixture
 def wiki_link_pages(browser_user, dir_tree):


### PR DESCRIPTION
## Fixes
Follow-up to #144 / #146 (already merged) — polish requested after using the shipped feature.

## Summary
Three small UX fixes to the bulk page-move feature added in #146:

1. **Pre-select the source directory on the bulk-move confirmation page.** Every page in a selection comes from the same directory listing, so repeating "currently in /X" next to each item in the "Moving:" list was pure noise. Removed that per-item text and instead pre-select the shared source directory in the destination dropdown — still visible at a glance, just not repeated.

2. **Hide the select-all checkbox until a page is selected.** It used to always sit next to "Pages", indenting that heading relative to "Directories" above it (which has no checkbox) even with nothing selected. Now it only appears once something's checked, keeping the two headings flush the rest of the time — and it's still there to select/clear everything once there's something to act on.

3. **Only the title text is a click target while a selection is active.** Directory listing cards navigate on click anywhere in the card by design — convenient normally, but a liability when checking several boxes in a row, since a slightly-off click navigates away and drops your progress. Split the title into its own tightly-scoped link (always clickable) from a separate full-card overlay link, and hide the overlay whenever a selection is active.

All three came with regression tests (Django-test-client for the markup-level checks, Playwright for the actual show/hide, alignment, and click-target behavior in a real browser) — 1247 passed, pre-commit clean.

**Note for reviewers:** while poking at this in a real browser, I bumped into the same gotcha twice — Django's `{# ... #}` comment tag doesn't support multi-line content and silently renders as visible page text if you write one across multiple lines. Both instances got caught by re-checking the live page rather than by the test suite, since the tests never assert on absence of stray comment text. Something to keep an eye on if anyone else reaches for a multi-line `{# #}` in this codebase.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No daemon/background-task code touched — this is entirely web-tier (a view, two templates, JS, tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk page selection now reveals the select-all checkbox and adjusts heading alignment.
  * Selecting pages disables card-background navigation while preserving title-link access.
  * Bulk move forms now preselect the shared source directory as the destination.

* **Bug Fixes**
  * Simplified bulk-move entries to display page titles without redundant directory details.
  * Improved card layout and selection behavior for directory page lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->