### PR TITLE
Add mobile TOC toggle and persistent desktop TOC gutter

### DIFF
--- a/wiki/assets/static-global/css/toc.css
+++ b/wiki/assets/static-global/css/toc.css
@@ -1,17 +1,17 @@
-#toc-nav ul {
+.toc-nav ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
-#toc-nav ul ul {
+.toc-nav ul ul {
   padding-left: 1rem;
 }
-#toc-nav a.toc-active {
+.toc-nav a.toc-active {
   font-weight: 700;
   color: var(--color-blue-600);
 }
 @media (prefers-color-scheme: dark) {
-  #toc-nav a.toc-active {
+  .toc-nav a.toc-active {
     color: var(--color-blue-400);
   }
 }

--- a/wiki/assets/static-global/js/alpine-components.js
+++ b/wiki/assets/static-global/js/alpine-components.js
@@ -201,6 +201,15 @@ document.addEventListener('alpine:init', () => {
     },
   }))
 
+  // Mobile TOC accordion toggle — page detail, below lg breakpoint
+  Alpine.data('tocToggle', () => ({
+    open: false,
+    toggle() { this.open = !this.open },
+    get buttonLabel() {
+      return this.open ? 'Hide table of contents' : 'On this page'
+    },
+  }))
+
   // Search sort dropdown
   Alpine.data('searchSort', () => ({
     change(event) {

--- a/wiki/pages/templates/pages/detail.html
+++ b/wiki/pages/templates/pages/detail.html
@@ -55,7 +55,7 @@
 <div class="flex gap-8">
   {# Main content #}
   <article class="flex-1 min-w-0">
-    <div class="flex flex-col justify-between gap-3 mb-6">
+    <div class="flex flex-col justify-between gap-3 mb-6" x-data="tocToggle">
       <h1>{{ page.title|inline_code }} <c-visibility-badge visibility="{{ effective_visibility }}" /><c-domain-access-badges :domains="page.access_domains" /></h1>
       <div class="flex items-center gap-2 flex-shrink-0">
         {% if can_edit %}
@@ -113,7 +113,23 @@
             {% endif %}
           </div>
         </div>
+        {% if toc %}
+        {# Mobile TOC toggle — hidden at lg: and up, where the sidebar takes over #}
+        <button @click="toggle" :aria-expanded="open" :aria-label="buttonLabel" type="button"
+                title="On this page" class="btn-outline p-2 lg:hidden">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12M8.25 17.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+          </svg>
+        </button>
+        {% endif %}
       </div>
+      {% if toc %}
+      <nav x-show="open" x-cloak class="toc-nav lg:hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-3 text-sm max-h-64 overflow-y-auto">
+        <div class="space-y-1 text-gray-600 dark:text-gray-400">
+          {{ toc|safe }}
+        </div>
+      </nav>
+      {% endif %}
     </div>
 
     <textarea id="page-markdown-source" class="hidden" aria-hidden="true">{{ page.content }}</textarea>
@@ -182,10 +198,10 @@
     </div>
   </article>
 
-  {# TOC sidebar #}
-  {% if toc %}
+  {# TOC sidebar — always reserves the gutter at lg: and up, even without a TOC, so line-width stays consistent (issue #150) #}
   <aside class="hidden lg:block w-64 flex-shrink-0">
-    <nav id="toc-nav" class="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-sm">
+    {% if toc %}
+    <nav id="toc-nav" class="toc-nav sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-sm">
       <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">
         On this page
       </h3>
@@ -193,10 +209,10 @@
         {{ toc|safe }}
       </div>
     </nav>
+    <link rel="stylesheet" href="{% static 'css/toc.css' %}">
+    <script src="{% static 'js/toc-highlight.js' %}" defer></script>
+    {% endif %}
   </aside>
-  <link rel="stylesheet" href="{% static 'css/toc.css' %}">
-  <script src="{% static 'js/toc-highlight.js' %}" defer></script>
-  {% endif %}
 </div>
 {% endblock %}
 

--- a/wiki/pages/tests.py
+++ b/wiki/pages/tests.py
@@ -331,6 +331,31 @@ class TestPageDetail:
         r = client.get(page.get_absolute_url())
         assert b"<h2" in r.content
 
+    def test_mobile_toc_toggle_present_with_headings(self, client, page):
+        """Issue #150: a page with headings gets the mobile TOC icon button."""
+        r = client.get(page.get_absolute_url())
+        assert b'title="On this page"' in r.content
+        assert b'id="toc-nav"' in r.content
+
+    def test_mobile_toc_toggle_absent_without_headings(
+        self, client, user, private_page
+    ):
+        """Issue #150: no headings means no TOC content, so no icon
+        button and no populated sidebar nav either."""
+        client.force_login(user)
+        r = client.get(private_page.get_absolute_url())
+        assert b'title="On this page"' not in r.content
+        assert b'id="toc-nav"' not in r.content
+
+    def test_toc_gutter_reserved_without_headings(
+        self, client, user, private_page
+    ):
+        """Issue #150: the desktop TOC gutter is reserved even when there's
+        no TOC, so line-width is consistent whether or not a page has one."""
+        client.force_login(user)
+        r = client.get(private_page.get_absolute_url())
+        assert b'class="hidden lg:block w-64 flex-shrink-0"' in r.content
+
 
 class TestPageAbsoluteUrl:
     def test_page_without_directory(self, page):

--- a/wiki/tests_browser.py
+++ b/wiki/tests_browser.py
@@ -1081,3 +1081,36 @@ class TestContentTabs:
             "() => navigator.clipboard.readText()"
         )
         assert "curl -L" in clipboard
+
+
+@pytest.mark.django_db(transaction=True)
+class TestMobileTocToggle:
+    """Issue #150: mobile "On this page" accordion for the TOC."""
+
+    def test_toggle_expands_and_jumps_to_heading(
+        self, browser_page, live_server, page
+    ):
+        browser_page.set_viewport_size({"width": 375, "height": 800})
+        browser_page.goto(f"{live_server.url}{page.get_absolute_url()}")
+
+        # title is a static marker for the button; aria-label/aria-expanded
+        # change with state, so don't use them to locate the element.
+        button = browser_page.locator('button[title="On this page"]')
+        panel = browser_page.locator('[x-data="tocToggle"] nav')
+
+        expect(panel).to_be_hidden()
+        expect(button).to_have_attribute("aria-expanded", "false")
+        expect(button).to_have_attribute("aria-label", "On this page")
+
+        button.click()
+        expect(panel).to_be_visible()
+        expect(button).to_have_attribute("aria-expanded", "true")
+        expect(button).to_have_attribute(
+            "aria-label", "Hide table of contents"
+        )
+
+        link = panel.locator("a").first
+        href = link.get_attribute("href")
+        link.click()
+
+        assert browser_page.url.endswith(href)


### PR DESCRIPTION
## Fixes
Fixes: #150

## Summary
Two fixes to the TOC sidebar in `wiki/pages/templates/pages/detail.html`:

1. **Mobile TOC access.** Below the `lg` breakpoint the TOC sidebar (`<aside class="hidden lg:block ...">`) was hidden entirely with no affordance to see it, so mobile readers had no way to jump to a section on a long page. Added a small icon-only button to the right of the "Actions" menu (in the title row) that expands the same TOC links inline below the title, using a new `tocToggle` Alpine component (`wiki/assets/static-global/js/alpine-components.js`) that mirrors the existing `searchTips` open/toggle/computed-label pattern already used on the search page. The button has no visible text — it carries a static `title` tooltip plus `:aria-expanded`/`:aria-label` bindings (via the same computed getter) so its state is announced to screen readers.

2. **Consistent line-width with or without a TOC.** Previously the `<aside>` gutter only rendered when `toc` was truthy, so a page without any headings had its `<article>` stretch to the full 960px container while a page with headings was narrower by the TOC's 256px + gap. The `<aside class="hidden lg:block w-64 flex-shrink-0">` now always renders at `lg:`+; only the nav content (and its CSS/JS) inside it are gated on `{% if toc %}`. So the right-hand gutter is reserved either way and the content column reads at a consistent width.

`toc.css` selectors moved from the `#toc-nav` ID to a shared `.toc-nav` class, since the TOC markup is now rendered twice (desktop sidebar + mobile panel) and both need the same list styling. `toc-highlight.js`'s scroll-spy still targets `#toc-nav` specifically (desktop-only) — the mobile panel is a transient jump-menu, not something read while scrolling.

**Tests added:**
- `TestPageDetail` (Django test client): mobile icon button present/absent based on whether the page has headings; desktop gutter still renders without a TOC.
- `TestMobileTocToggle` (Playwright): at mobile viewport width, `aria-expanded`/`aria-label` flip on click, the panel becomes visible, and its links jump to the target heading.

1235 non-browser tests + the new/existing TOC-related tests pass, pre-commit clean.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-daemon-deploy`

No daemon/background-task code touched — this is entirely web-tier (a template, JS, CSS, tests). No migrations, no new settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible mobile table of contents for pages with headings.
  * Added accordion controls with accessible labels and expanded/collapsed states.
  * Preserved consistent desktop page spacing, including pages without a table of contents.

* **Style**
  * Improved table-of-contents styling across light and dark themes.

* **Tests**
  * Added coverage for mobile table-of-contents behavior and pages with or without headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->