### PR TITLE
Add AI disclosure section to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,8 @@ This PR...
 <!-- YOUR IMAGE(S) HERE -->
 </details>
 <!-- END DELETE -->
+
+## AI Disclosure
+<!-- Please check the one box that applies. -->
+- [ ] No AI tools were used to create the content of this PR.
+- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.


### PR DESCRIPTION
Adds an AI Disclosure section to the end of the existing PR template: contributors assert either that no AI tools were used, or that they have carefully reviewed all AI-assisted content and take full responsibility for it. The wording matches the disclosure already adopted in courtlistener and free.law. No other sections of the template are changed.

Test plan:

- [ ] GitHub resolves PR templates from the base branch, so this can't be verified on this PR — the next PR opened after merge should render the new section.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an AI Disclosure section to the pull request template.
  * Contributors can now indicate whether AI tools were used when preparing a pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->